### PR TITLE
fix gross_pitaevskii, occupation, and add r_to_G for kpoints

### DIFF
--- a/examples/gross_pitaevskii.jl
+++ b/examples/gross_pitaevskii.jl
@@ -26,7 +26,7 @@ function external_pot(basis::PlaneWaveBasis, energy::Union{Ref, Nothing}, potent
     (potential !== nothing) && (potential .= Vext)
     if energy !== nothing
         dVol = model.unit_cell_volume / N # integration element. In 1D, unit_cell_volume is just the length
-        energy[] = real(sum(real(ρ) .* Vext)) * dVol
+        energy[] = real(sum(ρ.real .* Vext)) * dVol
     end
 
     energy, potential
@@ -41,10 +41,10 @@ function nonlinearity(basis::PlaneWaveBasis, energy::Union{Ref,Nothing}, potenti
 
     if energy !== nothing
         dVol = basis.model.unit_cell_volume / prod(basis.fft_size)
-        energy[] = α * dVol * sum(real(ρ) .^ 2)/2
+        energy[] = α * dVol * sum(real(ρ.real) .^ 2)/2
     end
     if potential !== nothing
-        potential .= α * real(ρ)
+        potential .= α * real(ρ.real)
     end
     energy, potential
 end
@@ -63,7 +63,7 @@ basis = PlaneWaveBasis(model, Ecut, kpoints, ksymops)
 # We solve the self-consistent equation with an SCF algorithm (which
 # is a pretty bad idea; implementing direct minimization is TODO)
 n_bands_scf = model.n_electrons
-ham = Hamiltonian(basis, Density(basis)) # zero initial guess for the density
+ham = Hamiltonian(basis) # zero initial guess for the density
 scfres = self_consistent_field(ham, model.n_electrons, tol=1e-6)
 ham = scfres.ham
 
@@ -78,7 +78,7 @@ end
 
 using PyPlot
 x = a*basis.grids[1]
-ρ = real(scfres.ρ)[:, 1, 1] # converged density
+ρ = real(scfres.ρ.real)[:, 1, 1] # converged density
 ψ_fourier = scfres.Psi[1][:, 1] # first kpoint, all G components, first eigenvector
 ψ = G_to_r(basis, basis.kpoints[1], ψ_fourier)[:, 1, 1] # IFFT back to real space
 @assert sum(abs2.(ψ)) * (x[2]-x[1]) ≈ 1.0

--- a/src/PlaneWaveBasis.jl
+++ b/src/PlaneWaveBasis.jl
@@ -279,6 +279,10 @@ on ``C_ρ^\ast`` and its fourier representation on ``C_ρ``.
 function r_to_G(pw::PlaneWaveBasis, f_real::AbstractArray3or4D)
     r_to_G!(similar(f_real), pw, f_real)
 end
-# Note: There is deliberately no G_to_r version for the kpoints,
-#       because at the moment this requires a copy of the input data f_real,
-#       which is overwritten in r_to_G! for the k-Point version
+# TODO optimize this
+function r_to_G(pw::PlaneWaveBasis, kpt::Kpoint, f_real::AbstractArray{T, 3}) where {T}
+    r_to_G!(similar(f_real, length(kpt.mapping)), pw, kpt, copy(f_real))
+end
+function r_to_G(pw::PlaneWaveBasis, kpt::Kpoint, f_real::AbstractArray{T, 4}) where {T}
+    r_to_G!(similar(f_real, length(kpt.mapping), size(f_real, 4)), pw, kpt, copy(f_real))
+end

--- a/src/occupation.jl
+++ b/src/occupation.jl
@@ -14,8 +14,8 @@ function find_occupation_gap_zero_temperature(basis, energies, Psi)
     @assert basis.model.temperature == 0.0
 
     filled_occ = filled_occupation(basis.model)
-    n_fill = div(n_electrons, 2)
-    @assert 2n_fill == n_electrons
+    n_fill = div(n_electrons, filled_occ)
+    @assert filled_occ * n_fill == n_electrons
     @assert n_bands ≥ n_fill
 
     # We need to fill n_fill states with occupation filled_occ


### PR DESCRIPTION
We should do the `r_to_G` even if it's slow: this is for convenience, not speed