### PR TITLE
Rework occupations

### DIFF
--- a/src/DFTK.jl
+++ b/src/DFTK.jl
@@ -66,6 +66,7 @@ include("terms/term_nonlocal.jl")
 include("terms/term_xc.jl")
 
 export find_fermi_level
+export find_occupation
 include("occupation.jl")
 
 export compute_density

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -19,7 +19,7 @@ struct Model{T <: Real}
     n_electrons::Int
     spin_polarisation::Symbol  # :none, :collinear, :full, :spinless
     temperature::T
-    smearing
+    smearing::Union{Nothing, Function} # see smearing_functions.jl for some choices
 
     # Potential definitions and builders
     build_external  # External potential, e.g. local pseudopotential term

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -20,7 +20,6 @@ struct Model{T <: Real}
     spin_polarisation::Symbol  # :none, :collinear, :full, :spinless
     temperature::T
     smearing
-    assume_band_gap::Bool  # DFTK may assume a band gap at the Fermi level to be present
 
     # Potential definitions and builders
     build_external  # External potential, e.g. local pseudopotential term
@@ -38,7 +37,7 @@ Occupation obtained as `f(ε) = smearing((ε-εF) / T)`
 """
 function Model(lattice::AbstractMatrix{T}, n_electrons; external=nothing,
                nonlocal=nothing, hartree=nothing, xc=nothing, temperature=0.0,
-               smearing=nothing, spin_polarisation=:none, assume_band_gap=nothing) where {T <: Real}
+               smearing=nothing, spin_polarisation=:none) where {T <: Real}
     lattice = SMatrix{3, 3, T, 9}(lattice)
 
     # Special handling of 1D and 2D systems, and sanity checks
@@ -67,12 +66,9 @@ function Model(lattice::AbstractMatrix{T}, n_electrons; external=nothing,
         smearing = smearing_fermi_dirac
     end
 
-    # Assume a band gap (insulator, semiconductor) if no smearing given
-    assume_band_gap === nothing && (assume_band_gap = smearing === nothing)
-
     build_nothing(args...; kwargs...) = (nothing, nothing)
     Model{T}(lattice, recip_lattice, unit_cell_volume, recip_cell_volume, d, n_electrons,
-             spin_polarisation, T(temperature), smearing, assume_band_gap,
+             spin_polarisation, T(temperature), smearing,
              something(external, build_nothing), something(nonlocal, build_nothing),
              something(hartree, build_nothing), something(xc, build_nothing))
 end

--- a/src/occupation.jl
+++ b/src/occupation.jl
@@ -6,18 +6,17 @@ import Roots
 Find the Fermi level, given a `basis`, SCF band `energies` and corresponding Bloch
 one-particle wave function `Psi`.
 """
-function find_fermi_level(basis, energies, Psi)
-    εF, _ = find_occupation(basis, energies, Psi)
+function find_fermi_level(basis, energies)
+    εF, _ = find_occupation(basis, energies)
     εF
 end
 
 """
 Find the Fermi level and occupation for the given parameters.
 """
-function find_occupation(basis, energies, Psi)
+function find_occupation(basis::PlaneWaveBasis{T}, energies) where {T}
     @assert basis.model.spin_polarisation in (:none, :spinless)
     model = basis.model
-    n_bands = size(Psi[1], 2)
     n_electrons = model.n_electrons
     temperature = model.temperature
     smearing = model.smearing
@@ -28,7 +27,15 @@ function find_occupation(basis, energies, Psi)
 
     filled_occ = filled_occupation(model)
 
-    @assert filled_occ*n_bands ≥ n_electrons
+    # assume that we can get the required number of electrons by filling every state
+    @assert filled_occ*sum(basis.kweights .* length.(energies)) ≥ n_electrons - sqrt(eps(T))
+
+    # early exit when all bands have to be filled; avoids numerical problems
+    if temperature == 0 && filled_occ*sum(basis.kweights .* length.(energies)) ≈ n_electrons
+        occ = [fill(filled_occ, length(e)) for e in energies]
+        εF = nextfloat(maximum(maximum.(energies)))
+        return εF, occ
+    end
 
     # Find εF so that
     # n_i = filled_occ * f((εi-εF)/T)
@@ -39,7 +46,9 @@ function find_occupation(basis, energies, Psi)
     # Get rough bounds to bracket εF
     min_ε = minimum(minimum.(energies)) - 1
     max_ε = maximum(maximum.(energies)) + 1
-    @assert compute_n_elec(min_ε) < n_electrons < compute_n_elec(max_ε)
+    if temperature != 0
+        @assert compute_n_elec(min_ε) < n_electrons < compute_n_elec(max_ε)
+    end
 
     # Just use bisection here; note that with MP smearing there might
     # be multiple possible Fermi levels. This could be sped up with more
@@ -47,11 +56,20 @@ function find_occupation(basis, energies, Psi)
     # taken with convergence criteria and the like
     εF = Roots.find_zero(εF -> compute_n_elec(εF) - n_electrons, (min_ε, max_ε),
                          Roots.Bisection())
-    @assert compute_n_elec(εF) ≈ n_electrons
+
+    if !isapprox(compute_n_elec(εF), n_electrons)
+        if temperature == 0
+            error("Unable to find non-fractional occupations that have the" *
+                  "correct number of electrons. You should add a temperature.")
+        else
+            error("This should not happen, debug me!")
+        end
+    end
     minocc = maximum(minimum.(compute_occupation(εF)))
     if minocc > .01
         @warn "One kpoint has a high minimum occupation $minocc. You should probably increase the number of bands."
     end
+
     εF, compute_occupation(εF)
 end
 
@@ -60,9 +78,10 @@ Find Fermi level and occupation for the given parameters, assuming a band gap
 and zero temperature. This function is for DEBUG purposes only, and the
 finite-temperature version with 0 temperature should be preferred.
 """
-function find_occupation_bandgap(basis, energies, Psi)
+function find_occupation_bandgap(basis, energies)
     @assert basis.model.spin_polarisation in (:none, :spinless)
-    n_bands = size(Psi[1], 2)
+    n_bands = length(energies[1])
+    @assert all(e -> length(e) == n_bands, energies)
     n_electrons = basis.model.n_electrons
     T = eltype(basis.kpoints[1].coordinate)
     @assert basis.model.temperature == 0

--- a/src/occupation.jl
+++ b/src/occupation.jl
@@ -3,52 +3,18 @@
 import Roots
 
 """
-Find Fermi level and occupation for the given parameters, assuming a band gap
-and zero temperature.
+Find the Fermi level, given a `basis`, SCF band `energies` and corresponding Bloch
+one-particle wave function `Psi`.
 """
-function find_occupation_gap_zero_temperature(basis, energies, Psi)
-    @assert basis.model.spin_polarisation in (:none, :spinless)
-    n_bands = size(Psi[1], 2)
-    n_electrons = basis.model.n_electrons
-    T = eltype(basis.kpoints[1].coordinate)
-    @assert basis.model.temperature == 0.0
-
-    filled_occ = filled_occupation(basis.model)
-    n_fill = div(n_electrons, filled_occ)
-    @assert filled_occ * n_fill == n_electrons
-    @assert n_bands ≥ n_fill
-
-    # We need to fill n_fill states with occupation filled_occ
-    # Find HOMO and LUMO
-    HOMO = -Inf # highest occupied energy state
-    LUMO = Inf  # lowest unoccupied energy state
-    occupation = similar(basis.kpoints, Vector{T})
-    for ik in 1:length(occupation)
-        occupation[ik] = zeros(T, n_bands)
-        occupation[ik][1:n_fill] .= filled_occ
-        HOMO = max(HOMO, energies[ik][n_fill])
-        if n_fill < n_bands
-            LUMO = min(LUMO, energies[ik][n_fill + 1])
-        end
-    end
-    @assert sum(basis.kweights .* sum.(occupation)) ≈ n_electrons
-
-    # Put Fermi level slightly above HOMO energy, to ensure that HOMO < εF
-    εF = nextfloat(HOMO)
-    if εF > LUMO
-        @warn("`find_occupation_gap_zero_temperature` assumes an insulator, but the " *
-              "system seems metallic. Try specifying a temperature and a smearing function.",
-              HOMO, LUMO, maxlog=5)
-    end
-
-    εF, occupation
+function find_fermi_level(basis, energies, Psi)
+    εF, _ = find_occupation(basis, energies, Psi)
+    εF
 end
 
 """
-Find the Fermi level and occupation for the given parameters, assuming no band gap
-(i.e. a metal).
+Find the Fermi level and occupation for the given parameters.
 """
-function find_occupation_fermi_metal(basis, energies, Psi)
+function find_occupation(basis, energies, Psi)
     @assert basis.model.spin_polarisation in (:none, :spinless)
     model = basis.model
     n_bands = size(Psi[1], 2)
@@ -56,14 +22,13 @@ function find_occupation_fermi_metal(basis, energies, Psi)
     temperature = model.temperature
     smearing = model.smearing
 
+    # Avoid numerical issues by imposing a step function for zero temp
+    temperature == 0 && (smearing(x) = x ≤ 0 ? 1 : 0)
     @assert smearing !== nothing
 
     filled_occ = filled_occupation(model)
 
     @assert filled_occ*n_bands ≥ n_electrons
-
-    # Avoid numerical issues by imposing a step function for zero temp
-    temperature == 0 && (smearing(x) = x ≤ 0 ? 1 : 0)
 
     # Find εF so that
     # n_i = filled_occ * f((εi-εF)/T)
@@ -90,31 +55,46 @@ function find_occupation_fermi_metal(basis, energies, Psi)
     εF, compute_occupation(εF)
 end
 
+"""
+Find Fermi level and occupation for the given parameters, assuming a band gap
+and zero temperature. This function is for DEBUG purposes only, and the
+finite-temperature version with 0 temperature should be preferred.
+"""
+function find_occupation_bandgap(basis, energies, Psi)
+    @assert basis.model.spin_polarisation in (:none, :spinless)
+    n_bands = size(Psi[1], 2)
+    n_electrons = basis.model.n_electrons
+    T = eltype(basis.kpoints[1].coordinate)
+    @assert basis.model.temperature == 0
 
-"""
-Find the Fermi level and occupation numbers, given a `basis`, SCF band `energies`
-and corresponding Bloch one-particle wave function `Psi`. If `basis.model.assume_band_gap`
-this function assumes a band gap at the Fermi level.
-Returns `(fermi_level, occupation)`
-"""
-function find_occupation(basis, energies, Psi)
-    occ = nothing
-    if basis.model.assume_band_gap && basis.model.temperature == 0.0
-        εF, occ = find_occupation_gap_zero_temperature(basis, energies, Psi)
-    elseif basis.model.assume_band_gap && basis.model.temperature > 0.0
-        error("`model.assume_band_gap` and `model.temperature > 0.0` not implemented.")
-    else
-        εF, occ = find_occupation_fermi_metal(basis, energies, Psi)
+    filled_occ = filled_occupation(basis.model)
+    n_fill = div(n_electrons, filled_occ)
+    @assert filled_occ * n_fill == n_electrons
+    @assert n_bands ≥ n_fill
+
+    # We need to fill n_fill states with occupation filled_occ
+    # Find HOMO and LUMO
+    HOMO = -Inf # highest occupied energy state
+    LUMO = Inf  # lowest unoccupied energy state
+    occupation = similar(basis.kpoints, Vector{T})
+    for ik in 1:length(occupation)
+        occupation[ik] = zeros(T, n_bands)
+        occupation[ik][1:n_fill] .= filled_occ
+        HOMO = max(HOMO, energies[ik][n_fill])
+        if n_fill < n_bands
+            LUMO = min(LUMO, energies[ik][n_fill + 1])
+        end
     end
-    εF, occ
+    @assert sum(basis.kweights .* sum.(occupation)) ≈ n_electrons
+
+    # Put Fermi level slightly above HOMO energy, to ensure that HOMO < εF
+    εF = nextfloat(HOMO)
+    if εF > LUMO
+        @warn("`find_occupation_zero_temperature` assumes an insulator, but the " *
+              "system seems metallic. Try specifying a temperature and a smearing function.",
+              HOMO, LUMO, maxlog=5)
+    end
+
+    εF, occupation
 end
 
-"""
-Find the Fermi level, given a `basis`, SCF band `energies` and corresponding Bloch
-one-particle wave function `Psi`. If `basis.model.assume_band_gap` this function
-assumes a band gap at the Fermi level.
-"""
-function find_fermi_level(basis, energies, Psi)
-    εF, _ = find_occupation(basis, energies, Psi)
-    εF
-end

--- a/src/occupation.jl
+++ b/src/occupation.jl
@@ -7,8 +7,7 @@ Find the Fermi level, given a `basis`, SCF band `energies` and corresponding Blo
 one-particle wave function `Psi`.
 """
 function find_fermi_level(basis, energies)
-    εF, _ = find_occupation(basis, energies)
-    εF
+    find_occupation(basis, energies)[1]
 end
 
 """
@@ -34,7 +33,7 @@ function find_occupation(basis::PlaneWaveBasis{T}, energies) where {T}
     if temperature == 0 && filled_occ*sum(basis.kweights .* length.(energies)) ≈ n_electrons
         occ = [fill(filled_occ, length(e)) for e in energies]
         εF = nextfloat(maximum(maximum.(energies)))
-        return εF, occ
+        return occ, εF
     end
 
     # Find εF so that
@@ -70,7 +69,7 @@ function find_occupation(basis::PlaneWaveBasis{T}, energies) where {T}
         @warn "One kpoint has a high minimum occupation $minocc. You should probably increase the number of bands."
     end
 
-    εF, compute_occupation(εF)
+    compute_occupation(εF), εF
 end
 
 """
@@ -114,6 +113,6 @@ function find_occupation_bandgap(basis, energies)
               HOMO, LUMO, maxlog=5)
     end
 
-    εF, occupation
+    occupation, εF
 end
 

--- a/src/occupation.jl
+++ b/src/occupation.jl
@@ -31,9 +31,9 @@ function find_occupation(basis::PlaneWaveBasis{T}, energies) where {T}
 
     # early exit when all bands have to be filled; avoids numerical problems
     if temperature == 0 && filled_occ*sum(basis.kweights .* length.(energies)) ≈ n_electrons
-        occ = [fill(filled_occ, length(e)) for e in energies]
+        occupation = [fill(filled_occ, length(e)) for e in energies]
         εF = nextfloat(maximum(maximum.(energies)))
-        return occ, εF
+        return (occupation=occupation, εF=εF)
     end
 
     # Find εF so that
@@ -69,7 +69,7 @@ function find_occupation(basis::PlaneWaveBasis{T}, energies) where {T}
         @warn "One kpoint has a high minimum occupation $minocc. You should probably increase the number of bands."
     end
 
-    compute_occupation(εF), εF
+    (occupation=compute_occupation(εF), εF=εF)
 end
 
 """
@@ -113,6 +113,5 @@ function find_occupation_bandgap(basis, energies)
               HOMO, LUMO, maxlog=5)
     end
 
-    occupation, εF
+    (occupation=occupation, εF=εF)
 end
-

--- a/src/scf/direct_minimization.jl
+++ b/src/scf/direct_minimization.jl
@@ -69,7 +69,7 @@ function direct_minimization(basis::PlaneWaveBasis{T}, Psi0;
                              optim_solver=Optim.LBFGS, kwargs...) where T
     model = basis.model
     @assert model.spin_polarisation in (:none, :spinless)
-    @assert model.assume_band_gap # temperature is not yet supported
+    @assert model.temperature == 0 # temperature is not yet supported
     filled_occ = filled_occupation(model)
     n_bands = div(model.n_electrons, filled_occ)
     ortho(Psik) = Matrix(qr(Psik).Q)

--- a/src/scf/self_consistent_field.jl
+++ b/src/scf/self_consistent_field.jl
@@ -14,7 +14,7 @@ function next_density(ham::Hamiltonian, n_bands; Psi=nothing,
     eigres.converged || (@warn "Eigensolver not converged" iterations=eigres.iterations)
 
     # Update density from new Psi
-    εF, occupation = find_occupation(ham.basis, eigres.λ, eigres.X)
+    εF, occupation = find_occupation(ham.basis, eigres.λ)
     ρnew = compute_density(ham.basis, eigres.X, occupation)
 
     (Psi=eigres.X, orben=eigres.λ, occupation=occupation, εF=εF, ρ=ρnew)

--- a/src/scf/self_consistent_field.jl
+++ b/src/scf/self_consistent_field.jl
@@ -14,7 +14,7 @@ function next_density(ham::Hamiltonian, n_bands; Psi=nothing,
     eigres.converged || (@warn "Eigensolver not converged" iterations=eigres.iterations)
 
     # Update density from new Psi
-    εF, occupation = find_occupation(ham.basis, eigres.λ)
+    occupation, εF = find_occupation(ham.basis, eigres.λ)
     ρnew = compute_density(ham.basis, eigres.X, occupation)
 
     (Psi=eigres.X, orben=eigres.λ, occupation=occupation, εF=εF, ρ=ρnew)

--- a/src/standard_models.jl
+++ b/src/standard_models.jl
@@ -40,5 +40,5 @@ function model_reduced_hf(lattice::AbstractMatrix, composition...; kwargs...)
     Model(lattice, n_electrons;
           external=term_external(composition...),
           nonlocal=term_nonlocal(composition...),
-          hartree=term_hartree())
+          hartree=term_hartree(), kwargs...)
 end

--- a/test/compute_density.jl
+++ b/test/compute_density.jl
@@ -23,7 +23,7 @@ include("testcases.jl")
         res = diagonalise_all_kblocks(lobpcg_hyper, ham, n_bands; tol=tol)
 
         @assert testcase.n_electrons <= 8
-        _, occ = DFTK.find_occupation(basis, res.λ)
+        occ, εF= DFTK.find_occupation(basis, res.λ)
         ρnew = compute_density(basis, res.X, occ)
 
         basis, res.X, res.λ, ρnew.fourier

--- a/test/compute_density.jl
+++ b/test/compute_density.jl
@@ -23,7 +23,7 @@ include("testcases.jl")
         res = diagonalise_all_kblocks(lobpcg_hyper, ham, n_bands; tol=tol)
 
         @assert testcase.n_electrons <= 8
-        _, occ = DFTK.find_occupation(basis, res.λ, res.X)
+        _, occ = DFTK.find_occupation(basis, res.λ)
         ρnew = compute_density(basis, res.X, occ)
 
         basis, res.X, res.λ, ρnew.fourier

--- a/test/occupation.jl
+++ b/test/occupation.jl
@@ -22,12 +22,11 @@ include("testcases.jl")
     end
     εHOMO = maximum(energies[ik][n_occ] for ik in 1:n_k)
     εLUMO = minimum(energies[ik][n_occ + 1] for ik in 1:n_k)
-    Psi = [fill(NaN, 1, n_bands) for i in 1:n_k]
 
     # Occupation for zero temperature
     model = Model(silicon.lattice, silicon.n_electrons; temperature=0.0, smearing=nothing)
     basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size=fft_size)
-    εF0, occupation0 = find_occupation_bandgap(basis, energies, Psi)
+    εF0, occupation0 = find_occupation_bandgap(basis, energies)
     @test εHOMO < εF0 < εLUMO
     @test sum(basis.kweights .* sum.(occupation0)) ≈ model.n_electrons
 
@@ -36,7 +35,7 @@ include("testcases.jl")
     for T in Ts, fun in smearing_functions
         model = Model(silicon.lattice, silicon.n_electrons; temperature=T, smearing=fun)
         basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size=fft_size)
-        _, occs = find_occupation(basis, energies, Psi)
+        _, occs = find_occupation(basis, energies)
         @test sum(basis.kweights .* sum.(occs)) ≈ model.n_electrons
     end
 
@@ -45,7 +44,7 @@ include("testcases.jl")
     for T in Ts, fun in smearing_functions
         model = Model(silicon.lattice, silicon.n_electrons; temperature=T, smearing=fun)
         basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size=fft_size)
-        _, occupation = find_occupation(basis, energies, Psi)
+        _, occupation = find_occupation(basis, energies)
 
         for ik in 1:n_k
             @test all(isapprox.(occupation[ik], occupation0[ik], atol=1e-2))
@@ -80,7 +79,6 @@ end
     n_bands = length(energies[1])
     n_k = length(kcoords)
     @assert n_k == length(energies)
-    Psi = [fill(NaN, 1, n_bands) for i in 1:n_k]
 
     parameters = (
         (smearing_fermi_dirac,         0.01, 0.17251898225370),
@@ -95,7 +93,7 @@ end
         model = Model(silicon.lattice, testcase.n_electrons;
                       temperature=Tsmear, smearing=smearing)
         basis = PlaneWaveBasis(model, Ecut, kcoords, ksymops; fft_size=fft_size)
-        εF, occupation = find_occupation(basis, energies, Psi)
+        εF, occupation = find_occupation(basis, energies)
 
         @test sum(basis.kweights .* sum.(occupation)) ≈ model.n_electrons
         @test εF ≈ εF_ref

--- a/test/occupation.jl
+++ b/test/occupation.jl
@@ -26,7 +26,7 @@ include("testcases.jl")
     # Occupation for zero temperature
     model = Model(silicon.lattice, silicon.n_electrons; temperature=0.0, smearing=nothing)
     basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size=fft_size)
-    εF0, occupation0 = find_occupation_bandgap(basis, energies)
+    occupation0, εF0 = find_occupation_bandgap(basis, energies)
     @test εHOMO < εF0 < εLUMO
     @test sum(basis.kweights .* sum.(occupation0)) ≈ model.n_electrons
 
@@ -35,7 +35,7 @@ include("testcases.jl")
     for T in Ts, fun in smearing_functions
         model = Model(silicon.lattice, silicon.n_electrons; temperature=T, smearing=fun)
         basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size=fft_size)
-        _, occs = find_occupation(basis, energies)
+        occs, _ = find_occupation(basis, energies)
         @test sum(basis.kweights .* sum.(occs)) ≈ model.n_electrons
     end
 
@@ -44,7 +44,7 @@ include("testcases.jl")
     for T in Ts, fun in smearing_functions
         model = Model(silicon.lattice, silicon.n_electrons; temperature=T, smearing=fun)
         basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size=fft_size)
-        _, occupation = find_occupation(basis, energies)
+        occupation, _= find_occupation(basis, energies)
 
         for ik in 1:n_k
             @test all(isapprox.(occupation[ik], occupation0[ik], atol=1e-2))
@@ -93,7 +93,7 @@ end
         model = Model(silicon.lattice, testcase.n_electrons;
                       temperature=Tsmear, smearing=smearing)
         basis = PlaneWaveBasis(model, Ecut, kcoords, ksymops; fft_size=fft_size)
-        εF, occupation = find_occupation(basis, energies)
+        occupation, εF = find_occupation(basis, energies)
 
         @test sum(basis.kweights .* sum.(occupation)) ≈ model.n_electrons
         @test εF ≈ εF_ref

--- a/test/occupation.jl
+++ b/test/occupation.jl
@@ -1,6 +1,6 @@
 using Test
 using DFTK: smearing_functions, find_fermi_level, Model, PlaneWaveBasis
-using DFTK: find_occupation_gap_zero_temperature, find_occupation_fermi_metal
+using DFTK: find_occupation, find_occupation_bandgap
 using DFTK: smearing_fermi_dirac, load_psp, Species, bzmesh_ir_wedge
 using DFTK: smearing_methfessel_paxton_1
 
@@ -27,7 +27,7 @@ include("testcases.jl")
     # Occupation for zero temperature
     model = Model(silicon.lattice, silicon.n_electrons; temperature=0.0, smearing=nothing)
     basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size=fft_size)
-    εF0, occupation0 = find_occupation_gap_zero_temperature(basis, energies, Psi)
+    εF0, occupation0 = find_occupation_bandgap(basis, energies, Psi)
     @test εHOMO < εF0 < εLUMO
     @test sum(basis.kweights .* sum.(occupation0)) ≈ model.n_electrons
 
@@ -36,7 +36,7 @@ include("testcases.jl")
     for T in Ts, fun in smearing_functions
         model = Model(silicon.lattice, silicon.n_electrons; temperature=T, smearing=fun)
         basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size=fft_size)
-        _, occs = find_occupation_fermi_metal(basis, energies, Psi)
+        _, occs = find_occupation(basis, energies, Psi)
         @test sum(basis.kweights .* sum.(occs)) ≈ model.n_electrons
     end
 
@@ -45,7 +45,7 @@ include("testcases.jl")
     for T in Ts, fun in smearing_functions
         model = Model(silicon.lattice, silicon.n_electrons; temperature=T, smearing=fun)
         basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size=fft_size)
-        _, occupation = find_occupation_fermi_metal(basis, energies, Psi)
+        _, occupation = find_occupation(basis, energies, Psi)
 
         for ik in 1:n_k
             @test all(isapprox.(occupation[ik], occupation0[ik], atol=1e-2))
@@ -95,7 +95,7 @@ end
         model = Model(silicon.lattice, testcase.n_electrons;
                       temperature=Tsmear, smearing=smearing)
         basis = PlaneWaveBasis(model, Ecut, kcoords, ksymops; fft_size=fft_size)
-        εF, occupation = find_occupation_fermi_metal(basis, energies, Psi)
+        εF, occupation = find_occupation(basis, energies, Psi)
 
         @test sum(basis.kweights .* sum.(occupation)) ≈ model.n_electrons
         @test εF ≈ εF_ref

--- a/test/scf_compare.jl
+++ b/test/scf_compare.jl
@@ -10,7 +10,7 @@ include("testcases.jl")
     tol = 1e-6
 
     Si = Species(silicon.atnum, psp=load_psp(silicon.psp))
-    model = model_reduced_hf(silicon.lattice, Si => silicon.positions)
+    model = model_dft(silicon.lattice, :lda_xc_teter93, Si => silicon.positions)
     basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size=fft_size)
 
     # Run nlsolve without guess

--- a/test/silicon_runners.jl
+++ b/test/silicon_runners.jl
@@ -3,7 +3,7 @@ using DFTK
 
 include("testcases.jl")
 
-# Silicon RHF is a metal, so we add a bit of temperature to it
+# Silicon redHF (without xc) is a metal, so we add a bit of temperature to it
 
 # TODO There is a lot of code duplication in this file ... once we have the ABINIT reference
 #      stuff in place, this should be refactored.

--- a/test/silicon_runners.jl
+++ b/test/silicon_runners.jl
@@ -3,6 +3,8 @@ using DFTK
 
 include("testcases.jl")
 
+# Silicon RHF is a metal, so we add a bit of temperature to it
+
 # TODO There is a lot of code duplication in this file ... once we have the ABINIT reference
 #      stuff in place, this should be refactored.
 
@@ -28,7 +30,7 @@ function run_silicon_redHF(T; Ecut=5, test_tol=1e-6, n_ignored=0, grid_size=15, 
 
     fft_size = grid_size * ones(3)
     Si = Species(silicon.atnum, psp=load_psp(silicon.psp))
-    model = model_reduced_hf(Array{T}(silicon.lattice), Si => silicon.positions)
+    model = model_reduced_hf(Array{T}(silicon.lattice), Si => silicon.positions, temperature=.1)
     basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size=fft_size)
     ham = Hamiltonian(basis, guess_density(basis, Si => silicon.positions))
 


### PR DESCRIPTION
Fix https://github.com/JuliaMolSim/DFTK.jl/issues/94

There are a couple workarounds we could do that probably would work for doing fractional occupations at 0K (eg if there's only one energy level at the fermi level, fill it partially to fit the correct number of electrons) but that is very tricky, and figuring out the proper fractional occupations at 0K is a much more involved job than just looking at the band energies. So I prefer keeping it explicit that it doesn't work and erroring.