### PR TITLE
Add NOS function estimating number of Kohn-Sham states for DOS / LDOS

### DIFF
--- a/src/DFTK.jl
+++ b/src/DFTK.jl
@@ -136,6 +136,7 @@ include("postprocess/band_structure.jl")
 
 export DOS
 export LDOS
+export NOS
 include("postprocess/DOS.jl")
 
 export model_free_electron

--- a/src/postprocess/DOS.jl
+++ b/src/postprocess/DOS.jl
@@ -9,10 +9,17 @@
 
 using ForwardDiff
 
-"""
-The number of Kohn-Sham states in temperature window of width T contributing
-to the DOS at temperature T. This value should be larger than one for DOS and LDOS to be
-meaningful at smearing temperature T.
+@doc raw"""
+    NOS(ε, basis, orben; smearing=basis.model.smearing, T=basis.model.temperature)
+
+The number of Kohn-Sham states in a temperature window of width T around the energy ε
+contributing to the DOS at temperature T.
+
+This quantity is not a physical quantity, much rather a dimensionaless approximate measure
+for how well properties near the Fermi surface are sampled with the passed `smearing`
+and temperature `T`. It increases with both `T` and better sampling of the BZ with
+``k``-Points. A value ``\gg 1`` indicates a good sampling of properties near the
+Fermi surface.
 """
 function NOS(ε, basis, orben; smearing=basis.model.smearing, T=basis.model.temperature)
     N = zero(ε)

--- a/src/postprocess/DOS.jl
+++ b/src/postprocess/DOS.jl
@@ -27,11 +27,12 @@ function NOS(ε, basis, orben; smearing=basis.model.smearing, T=basis.model.temp
 
     # Note the differences to the DOS and LDOS functions: We are not counting states
     # per BZ volume (like in DOS), but absolute number of states. Therefore n_symeqk
-    # is used instead of kweigths. The number of states is counted over a temperature
-    # window of width T yielding in analogy to the DOS an integral
-    #     ∫_(T-T/2)^(T+T/2) ( d/dε f_τ(εik - ε') )|_{ε' = ε} dτ
-    # at each k-Point, where f_τ is the smearing function. If we assume the integrand
-    # to vary slowly over the integrated range, this yields the factor T in front.
+    # is used instead of kweigths. We count the states inside a temperature window T
+    # centred about εik. For this the states are weighted by the distribution
+    # -f'((εik - ε)/T).
+    #
+    # To explicitly show the similarity with DOS and the T dependence we employ
+    # -f'((εik - ε)/T) = T * ( d/dε f_τ(εik - ε') )|_{ε' = ε}
     for ik = 1:length(orben)
         n_symeqk = length(basis.ksymops[ik])  # Number of symmetry-equivalent k-Points
         for iband = 1:length(orben[ik])

--- a/src/postprocess/DOS.jl
+++ b/src/postprocess/DOS.jl
@@ -15,7 +15,7 @@ using ForwardDiff
 The number of Kohn-Sham states in a temperature window of width T around the energy ε
 contributing to the DOS at temperature T.
 
-This quantity is not a physical quantity, much rather a dimensionaless approximate measure
+This quantity is not a physical quantity, but rather a dimensionless approximate measure
 for how well properties near the Fermi surface are sampled with the passed `smearing`
 and temperature `T`. It increases with both `T` and better sampling of the BZ with
 ``k``-Points. A value ``\gg 1`` indicates a good sampling of properties near the
@@ -28,9 +28,10 @@ function NOS(ε, basis, orben; smearing=basis.model.smearing, T=basis.model.temp
     # Note the differences to the DOS and LDOS functions: We are not counting states
     # per BZ volume (like in DOS), but absolute number of states. Therefore n_symeqk
     # is used instead of kweigths. The number of states is counted over a temperature
-    # window of width T, where we assume that the number of states remains constant
-    # in the interval [T - T/2, T + T/2] as ( d/dε f_T(εik - ε') )|_{ε' = ε}
-    # with f_T the smearing function. This gives the factor T in front.
+    # window of width T yielding in analogy to the DOS an integral
+    #     ∫_(T-T/2)^(T+T/2) ( d/dε f_τ(εik - ε') )|_{ε' = ε} dτ
+    # at each k-Point, where f_τ is the smearing function. If we assume the integrand
+    # to vary slowly over the integrated range, this yields the factor T in front.
     for ik = 1:length(orben)
         n_symeqk = length(basis.ksymops[ik])  # Number of symmetry-equivalent k-Points
         for iband = 1:length(orben[ik])


### PR DESCRIPTION
@antoine-levitt I differ a little from the definition we discussed via mail:

Instead of being fancy and and summing `-f'((εnk - εF)/T)`, I sum `T * d/dε  f((εnk - ε)/T) |_{ε=εF}`. Only a cosmetic difference, but the `T *` makes the window of width `T` aspect more apparent in my opinion.