### PR TITLE
High-level PlaneWaveBasis constructor interface

### DIFF
--- a/examples/graphene.jl
+++ b/examples/graphene.jl
@@ -19,7 +19,7 @@ composition = [C => [[0.0, 0.0, 0.0], [0.33333333333, 0.66666666667, 0.0]]]
 
 model = model_dft(lattice, [:gga_x_pbe, :gga_c_pbe], composition...;
                   temperature=Tsmear, smearing=DFTK.Smearing.Gaussian())
-basis = PlaneWaveBasis(model, Ecut, kgrid)
+basis = PlaneWaveBasis(model, Ecut, kgrid=kgrid)
 
 # Run SCF
 n_bands = 6

--- a/examples/graphene.jl
+++ b/examples/graphene.jl
@@ -19,8 +19,7 @@ composition = [C => [[0.0, 0.0, 0.0], [0.33333333333, 0.66666666667, 0.0]]]
 
 model = model_dft(lattice, [:gga_x_pbe, :gga_c_pbe], composition...;
                   temperature=Tsmear, smearing=DFTK.Smearing.Gaussian())
-kcoords, ksymops = bzmesh_ir_wedge(kgrid, lattice, composition...)
-basis = PlaneWaveBasis(model, Ecut, kcoords, ksymops)
+basis = PlaneWaveBasis(model, Ecut, kgrid)
 
 # Run SCF
 n_bands = 6

--- a/examples/gross_pitaevskii.jl
+++ b/examples/gross_pitaevskii.jl
@@ -6,7 +6,6 @@ using DFTK
 using Printf
 using LinearAlgebra
 
-kgrid = [1, 1, 1] # No kpoints
 Ecut = 4000
 
 a = 10
@@ -57,7 +56,7 @@ model = Model(lattice; n_electrons=n_electrons,
               xc=nonlinearity,
               spin_polarisation=:spinless # "spinless fermions"
               )
-basis = PlaneWaveBasis(model, Ecut, kgrid)
+basis = PlaneWaveBasis(model, Ecut, kgrid=[1, 1, 1])
 
 # We solve the self-consistent equation with an SCF algorithm (which
 # is a pretty bad idea; implementing direct minimization is TODO)

--- a/examples/gross_pitaevskii.jl
+++ b/examples/gross_pitaevskii.jl
@@ -57,9 +57,7 @@ model = Model(lattice; n_electrons=n_electrons,
               xc=nonlinearity,
               spin_polarisation=:spinless # "spinless fermions"
               )
-
-kpoints, ksymops = bzmesh_uniform(kgrid) # create dummy BZ mesh
-basis = PlaneWaveBasis(model, Ecut, kpoints, ksymops)
+basis = PlaneWaveBasis(model, Ecut, kgrid)
 
 # We solve the self-consistent equation with an SCF algorithm (which
 # is a pretty bad idea; implementing direct minimization is TODO)

--- a/examples/magnesium_pbe.jl
+++ b/examples/magnesium_pbe.jl
@@ -32,7 +32,7 @@ atoms = [Mg => [s.frac_coords for s in pystruct.sites]]
 model = model_dft(lattice, [:gga_x_pbe, :gga_c_pbe], atoms;
                   temperature=Tsmear,
                   smearing=DFTK.Smearing.MethfesselPaxton1())
-basis = PlaneWaveBasis(model, Ecut, kgrid)
+basis = PlaneWaveBasis(model, Ecut, kgrid=kgrid)
 
 # Run SCF
 ham = Hamiltonian(basis, guess_density(basis, atoms))

--- a/examples/magnesium_pbe.jl
+++ b/examples/magnesium_pbe.jl
@@ -32,8 +32,7 @@ atoms = [Mg => [s.frac_coords for s in pystruct.sites]]
 model = model_dft(lattice, [:gga_x_pbe, :gga_c_pbe], atoms;
                   temperature=Tsmear,
                   smearing=DFTK.Smearing.MethfesselPaxton1())
-kcoords, ksymops = bzmesh_ir_wedge(kgrid, lattice, atoms)
-basis = PlaneWaveBasis(model, Ecut, kcoords, ksymops)
+basis = PlaneWaveBasis(model, Ecut, kgrid)
 
 # Run SCF
 ham = Hamiltonian(basis, guess_density(basis, atoms))

--- a/examples/silicon.jl
+++ b/examples/silicon.jl
@@ -39,8 +39,7 @@ elseif calculation_model == :free
 else
     error("Unknown calculation_model $(calculation_model)")
 end
-kcoords, ksymops = bzmesh_ir_wedge(kgrid, lattice, atoms)
-basis = PlaneWaveBasis(model, Ecut, kcoords, ksymops)
+basis = PlaneWaveBasis(model, Ecut, kgrid)
 
 # Run SCF. Note Silicon is a semiconductor, so we use an insulator
 # occupation scheme. This will cause warnings in some models, because

--- a/examples/silicon.jl
+++ b/examples/silicon.jl
@@ -39,7 +39,7 @@ elseif calculation_model == :free
 else
     error("Unknown calculation_model $(calculation_model)")
 end
-basis = PlaneWaveBasis(model, Ecut, kgrid)
+basis = PlaneWaveBasis(model, Ecut, kgrid=kgrid)
 
 # Run SCF. Note Silicon is a semiconductor, so we use an insulator
 # occupation scheme. This will cause warnings in some models, because

--- a/examples/silicon_lda_arbitrary_floattype.jl
+++ b/examples/silicon_lda_arbitrary_floattype.jl
@@ -16,8 +16,7 @@ atoms = [Si => [ones(3)/8, -ones(3)/8]]
 
 # Setup LDA model and discretisation
 model = model_dft(Array{T}(lattice), [:lda_x, :lda_c_vwn], atoms)
-kpoints, ksymops = bzmesh_ir_wedge(kgrid, lattice, atoms)
-basis = PlaneWaveBasis(model, Ecut, kpoints, ksymops)
+basis = PlaneWaveBasis(model, Ecut, kgrid)
 
 # Run SCF, note Silicon metal is an insulator, so no need for all bands here
 ham = Hamiltonian(basis, guess_density(basis, atoms))

--- a/examples/silicon_lda_arbitrary_floattype.jl
+++ b/examples/silicon_lda_arbitrary_floattype.jl
@@ -16,7 +16,7 @@ atoms = [Si => [ones(3)/8, -ones(3)/8]]
 
 # Setup LDA model and discretisation
 model = model_dft(Array{T}(lattice), [:lda_x, :lda_c_vwn], atoms)
-basis = PlaneWaveBasis(model, Ecut, kgrid)
+basis = PlaneWaveBasis(model, Ecut, kgrid=kgrid)
 
 # Run SCF, note Silicon metal is an insulator, so no need for all bands here
 ham = Hamiltonian(basis, guess_density(basis, atoms))

--- a/src/PlaneWaveBasis.jl
+++ b/src/PlaneWaveBasis.jl
@@ -128,8 +128,13 @@ function PlaneWaveBasis(model::Model{T}, Ecut::Number,
         kweights, ksymops, fft_size, grids, opFFT, ipFFT, opIFFT, ipIFFT
     )
 end
-function PlaneWaveBasis(model::Model, Ecut::Number, kgrid_size::AbstractVector;
+function PlaneWaveBasis(model::Model, Ecut::Number;
+                        kspacing=2π * 0.04 / units.Ǎ, kgrid=nothing,
                         enable_bzmesh_symmetry=true, kwargs...)
+    if kgrid === nothing
+        kgrid = kgrid_size_from_minimal_spacing(model.lattice, spacing=kspacing)
+    end
+
     if enable_bzmesh_symmetry
         kcoords, ksymops = bzmesh_ir_wedge(kgrid_size, model.lattice, model.atoms)
     else

--- a/src/PlaneWaveBasis.jl
+++ b/src/PlaneWaveBasis.jl
@@ -131,9 +131,9 @@ end
 function PlaneWaveBasis(model::Model, Ecut::Number;
                         kgrid=[1, 1, 1], enable_bzmesh_symmetry=true, kwargs...)
     if enable_bzmesh_symmetry
-        kcoords, ksymops = bzmesh_ir_wedge(kgrid_size, model.lattice, model.atoms)
+        kcoords, ksymops = bzmesh_ir_wedge(kgrid, model.lattice, model.atoms)
     else
-        kcoords, ksymops = bzmesh_uniform(kgrid_size)
+        kcoords, ksymops = bzmesh_uniform(kgrid)
     end
     PlaneWaveBasis(model, Ecut, kcoords, ksymops; kwargs...)
 end

--- a/src/PlaneWaveBasis.jl
+++ b/src/PlaneWaveBasis.jl
@@ -129,12 +129,7 @@ function PlaneWaveBasis(model::Model{T}, Ecut::Number,
     )
 end
 function PlaneWaveBasis(model::Model, Ecut::Number;
-                        kspacing=2π * 0.04 / units.Ǎ, kgrid=nothing,
-                        enable_bzmesh_symmetry=true, kwargs...)
-    if kgrid === nothing
-        kgrid = kgrid_size_from_minimal_spacing(model.lattice, spacing=kspacing)
-    end
-
+                        kgrid=[1, 1, 1], enable_bzmesh_symmetry=true, kwargs...)
     if enable_bzmesh_symmetry
         kcoords, ksymops = bzmesh_ir_wedge(kgrid_size, model.lattice, model.atoms)
     else

--- a/src/bzmesh.jl
+++ b/src/bzmesh.jl
@@ -33,7 +33,7 @@ representing a mapping from `Element` objects to a list of positions in fraction
 coordinates. `tol_symmetry` is the tolerance used for searching for symmetry operations.
 """
 function bzmesh_ir_wedge(kgrid_size, lattice, atoms; tol_symmetry=1e-5)
-    all(isequal.(kgrid_size, (1, 1, 1))) && return bzmesh_uniform(kgrid_size)
+    all(isequal.(kgrid_size, 1)) && return bzmesh_uniform(kgrid_size)
     spglib = pyimport("spglib")
 
     # Ask spglib for symmetry operations and for irreducible mesh

--- a/src/bzmesh.jl
+++ b/src/bzmesh.jl
@@ -33,6 +33,7 @@ representing a mapping from `Element` objects to a list of positions in fraction
 coordinates. `tol_symmetry` is the tolerance used for searching for symmetry operations.
 """
 function bzmesh_ir_wedge(kgrid_size, lattice, atoms; tol_symmetry=1e-5)
+    all(isequal.(kgrid_size, (1, 1, 1))) && return bzmesh_uniform(kgrid_size)
     spglib = pyimport("spglib")
 
     # Ask spglib for symmetry operations and for irreducible mesh

--- a/test/forces.jl
+++ b/test/forces.jl
@@ -11,7 +11,6 @@ include("testcases.jl")
         Si = Element(silicon.atnum, psp=load_psp(silicon.psp))
         atoms = [Si => pos]
         model = model_dft(silicon.lattice, :lda_xc_teter93, atoms)
-        kcoords, ksymops = bzmesh_ir_wedge(kgrid, lattice, atoms)
         basis = PlaneWaveBasis(model, Ecut, kgrid=[2, 1, 2])
 
         n_bands_scf = Int(model.n_electrons / 2)

--- a/test/forces.jl
+++ b/test/forces.jl
@@ -4,7 +4,6 @@ include("testcases.jl")
 
 @testset "Forces" begin
     function energy(pos)
-        kgrid = [2, 1, 2]        # k-Point grid
         Ecut = 5                # kinetic energy cutoff in Hartree
 
         # Setup silicon lattice
@@ -13,7 +12,7 @@ include("testcases.jl")
         atoms = [Si => pos]
         model = model_dft(silicon.lattice, :lda_xc_teter93, atoms)
         kcoords, ksymops = bzmesh_ir_wedge(kgrid, lattice, atoms)
-        basis = PlaneWaveBasis(model, Ecut, kcoords, ksymops)
+        basis = PlaneWaveBasis(model, Ecut, kgrid=[2, 1, 2])
 
         n_bands_scf = Int(model.n_electrons / 2)
         ham = Hamiltonian(basis, guess_density(basis))

--- a/test/variational.jl
+++ b/test/variational.jl
@@ -20,7 +20,7 @@ function get_scf_energies(testcase, supersampling, functionals)
         model = model_reduced_hf(testcase.lattice, [spec => testcase.positions])
     end
 
-    ksymops = nothing
+    ksymops = [[(Mat3{Int}(I), Vec3(zeros(3)))] for _ in 1:length(kcoords)]
     basis = PlaneWaveBasis(model, Ecut, kcoords, ksymops; fft_size=fft_size)
     ham = Hamiltonian(basis, guess_density(basis, [spec => testcase.positions]))
     scfres = self_consistent_field(ham, n_bands, tol=scf_tol)


### PR DESCRIPTION
Adds a high-level interfaces to PlaneWaveBasis where `kgrid` can be directly passed.