### PR TITLE
Implement fallback kpoint symmetry search

### DIFF
--- a/src/bzmesh.jl
+++ b/src/bzmesh.jl
@@ -21,6 +21,46 @@ function bzmesh_uniform(kgrid_size)
 end
 
 
+SymOp = Tuple{Mat3{Int}, Vec3{Float64}}
+function find_irreducible_kpoints(kpoints, Stildes, τtildes)
+    n_symops = length(Stildes)
+
+    # Flag which kpoints have already been mapped to another irred.
+    # kpoint or which have been decided to be irreducible.
+    kpoints_mapped = zeros(Bool, length(kpoints))
+    kirreds = empty(kpoints)           # Container for irreducible kpoints
+    ksymops = Vector{Vector{SymOp}}()  # Corresponding symops
+
+    while !all(kpoints_mapped)
+        # Select next not mapped kpoint as irreducible
+        ik = findfirst(isequal(false), kpoints_mapped)
+        push!(kirreds, kpoints[ik])
+        thisk_symops = [(Mat3{Int}(I), Vec3(zeros(3)))]
+        kpoints_mapped[ik] = true
+
+        for jk in findall(.!kpoints_mapped)
+            isym = findfirst(1:n_symops) do isym
+                # If the difference between kred and Stilde' * k == Stilde^{-1} * k
+                # is only integer in fractional reciprocal-space coordinates, then
+                # kred and S' * k are equivalent k-Points
+                all(isinteger, kpoints[jk] - (Stildes[isym]' * kpoints[ik]))
+            end
+
+            if !isnothing(isym)  # Found a reducible kpoint
+                kpoints_mapped[jk] = true
+                S = Stildes[isym]'                  # in fractional reciprocal coordinates
+                τ = -Stildes[isym] \ τtildes[isym]  # in fractional real-space coordinates
+                push!(thisk_symops, (S, τ))
+            end
+        end  # jk
+
+        push!(ksymops, thisk_symops)
+    end
+    kirreds, ksymops
+end
+
+
+
 @doc raw"""
     bzmesh_ir_wedge(kgrid_size, lattice, atoms; tol_symmetry=1e-5)
 
@@ -33,22 +73,7 @@ coordinates. `tol_symmetry` is the tolerance used for searching for symmetry ope
 """
 function bzmesh_ir_wedge(kgrid_size, lattice, atoms; tol_symmetry=1e-5)
     all(isequal.(kgrid_size, 1)) && return bzmesh_uniform(kgrid_size)
-    spglib = import_spglib()
 
-    # Ask spglib for symmetry operations and for irreducible mesh
-    spg_symops = spglib.get_symmetry(spglib_cell(lattice, atoms),
-                                     symprec=tol_symmetry)
-
-    # If spglib does not find symmetries give an error
-    spg_symops !== nothing || error(
-        "spglib failed to get the symmetries. Check your lattice, or use a uniform BZ mesh."
-    )
-
-    Stildes = [St for St in eachslice(spg_symops["rotations"]; dims=1)]
-    τtildes = [rationalize.(τt, tol=tol_symmetry)
-               for τt in eachslice(spg_symops["translations"]; dims=1)]
-    n_symops = length(Stildes)
-    @assert length(τtildes) == n_symops
     # Notice: In the language of the latex document in the docs
     # spglib returns \tilde{S} and \tilde{τ} in integer real-space coordinates, such that
     # (A Stilde A^{-1}) is the actual \tilde{S} from the document as a unitary matrix.
@@ -57,34 +82,13 @@ function bzmesh_ir_wedge(kgrid_size, lattice, atoms; tol_symmetry=1e-5)
     # *fractional* real-space coordinates:
     #      - \tilde{S}^{-1} = S^T (if applied to a vector in frac. coords in reciprocal space)
 
-    # Checks: (A Stilde A^{-1}) is unitary
-    for Stilde in Stildes
-        Scart = lattice * Stilde * inv(lattice)  # Form S in cartesian coords
-        if maximum(abs, Scart'Scart - I) > sqrt(eps(Float64))
-            error("spglib returned non-unitary rotation matrix")
-        end
-    end
+    Stildes, τtildes = spglib_get_symmetry(lattice, atoms; tol_symmetry=tol_symmetry)
+    n_symops = length(Stildes)
 
-    # Check (Stilde, τtilde) maps atoms to equivalent atoms in the lattice
-    for (Stilde, τtilde) in zip(Stildes, τtildes)
-        for (elem, positions) in atoms
-            for coord in positions
-                diffs = [rationalize.(Stilde * coord + τtilde - pos, tol=tol_symmetry)
-                         for pos in positions]
-
-                # If all elements of a difference in diffs is integer, then
-                # Stilde * coord + τtilde and pos are equivalent lattice positions
-                if !any(all(isinteger, d) for d in diffs)
-                    error("Cannot map the atom at position $coord to another atom of the " *
-                          "same element under the symmetry operation (Stilde, τtilde):\n" *
-                          "($Stilde, $τtilde)")
-                end
-            end
-        end
-    end
-
-    mapping, grid = spglib.get_stabilized_reciprocal_mesh(
-        kgrid_size, spg_symops["rotations"], is_shift=[0, 0, 0], is_time_reversal=true
+    # Use determined symmetries to deduce irreducible k-Point mesh
+    spg_rotations = permutedims(cat(Stildes..., dims=3), (3, 1, 2))
+    mapping, grid = import_spglib().get_stabilized_reciprocal_mesh(
+        kgrid_size, spg_rotations, is_shift=[0, 0, 0], is_time_reversal=true
     )
 
     # Convert irreducible k-Points to DFTK conventions
@@ -102,7 +106,6 @@ function bzmesh_ir_wedge(kgrid_size, lattice, atoms; tol_symmetry=1e-5)
     # ksymops will be the list of symmetry operations (for each irreducible k-Point)
     # needed to do the respective mapping irreducible -> reducible to get the respective
     # entry in `k_all_reducible`.
-    SymOp = Tuple{Mat3{Int}, Vec3{Float64}}
     ksymops = Vector{Vector{SymOp}}(undef, length(kirreds))
     for (ik, k) in enumerate(kirreds)
         ksymops[ik] = Vector{SymOp}()
@@ -127,13 +130,14 @@ function bzmesh_ir_wedge(kgrid_size, lattice, atoms; tol_symmetry=1e-5)
     end
 
     if !isempty(kreds_notmapped)
-        @warn("$(length(kreds_notmapped)) reducible kpoints could not be generated from " *
-              "the irreducible kpoints returned by spglib. They are addad as irreducible " *
-              "kpoints as well.")
-        # TODO This could be improved by actually searching for symmetry amongst these as well.
-        #      ... but then we would be reimplementing parts of spglib
-        append!(kirreds, kreds_notmapped)
-        append!(ksymops, [[(Mat3{Int}(I), Vec3(zeros(3)))] for _ in 1:length(kreds_notmapped)])
+        eirreds, esymops = find_irreducible_kpoints(kreds_notmapped, Stildes, τtildes)
+
+        @info("$(length(kreds_notmapped)) reducible kpoints could not be generated from " *
+              "the irreducible kpoints returned by spglib. $(length(eirreds)) of " *
+              "these are added as extra irreducible kpoints.")
+
+        append!(kirreds, eirreds)
+        append!(ksymops, esymops)
     end
 
     # The symmetry operation (S == I and τ == 0) should be present for each k-Point

--- a/src/bzmesh.jl
+++ b/src/bzmesh.jl
@@ -21,8 +21,17 @@ function bzmesh_uniform(kgrid_size)
 end
 
 
-SymOp = Tuple{Mat3{Int}, Vec3{Float64}}
+const SymOp = Tuple{Mat3{Int}, Vec3{Float64}}
+"""
+Implements a primitive search to find an irreducible subset of kpoints
+amongst the provided kpoints.
+"""
 function find_irreducible_kpoints(kpoints, Stildes, τtildes)
+    #
+    # This function is required, because spglib sometimes flags kpoints
+    # as reducible, where we cannot find a symmetry operation to generate
+    # them from the provided irreducible kpoints.
+    #
     n_symops = length(Stildes)
 
     # Flag which kpoints have already been mapped to another irred.

--- a/src/external/spglib.jl
+++ b/src/external/spglib.jl
@@ -39,3 +39,49 @@ function spglib_cell(lattice, atoms)
     #       For future reference: The C interface spglib also uses columns.
     (lattice', spg_positions, spg_numbers)
 end
+
+function spglib_get_symmetry(lattice, atoms; tol_symmetry=1e-5)
+    spglib = import_spglib()
+
+    # Ask spglib for symmetry operations and for irreducible mesh
+    spg_symops = spglib.get_symmetry(spglib_cell(lattice, atoms),
+                                     symprec=tol_symmetry)
+
+    # If spglib does not find symmetries give an error
+    spg_symops !== nothing || error(
+        "spglib failed to get the symmetries. Check your lattice, or use a uniform BZ mesh."
+    )
+
+    Stildes = [St for St in eachslice(spg_symops["rotations"]; dims=1)]
+    τtildes = [rationalize.(τt, tol=tol_symmetry)
+               for τt in eachslice(spg_symops["translations"]; dims=1)]
+    @assert length(τtildes) == length(Stildes)
+
+    # Checks: (A Stilde A^{-1}) is unitary
+    for Stilde in Stildes
+        Scart = lattice * Stilde * inv(lattice)  # Form S in cartesian coords
+        if maximum(abs, Scart'Scart - I) > sqrt(eps(Float64))
+            error("spglib returned non-unitary rotation matrix")
+        end
+    end
+
+    # Check (Stilde, τtilde) maps atoms to equivalent atoms in the lattice
+    for (Stilde, τtilde) in zip(Stildes, τtildes)
+        for (elem, positions) in atoms
+            for coord in positions
+                diffs = [rationalize.(Stilde * coord + τtilde - pos, tol=tol_symmetry)
+                         for pos in positions]
+
+                # If all elements of a difference in diffs is integer, then
+                # Stilde * coord + τtilde and pos are equivalent lattice positions
+                if !any(all(isinteger, d) for d in diffs)
+                    error("Cannot map the atom at position $coord to another atom of the " *
+                          "same element under the symmetry operation (Stilde, τtilde):\n" *
+                          "($Stilde, $τtilde)")
+                end
+            end
+        end
+    end
+
+    Stildes, τtildes
+end

--- a/test/bzmesh.jl
+++ b/test/bzmesh.jl
@@ -60,6 +60,7 @@ end
     test_reduction(silicon, [ 9, 11, 13])
 
     test_reduction(silicon, [ 1,  4,  4], supercell=[2, 1, 1])
+    test_reduction(silicon, [ 1,  16,  16], supercell=[4, 1, 1])
 
     test_reduction(magnesium, [ 2,  3,  2])
     test_reduction(magnesium, [ 3,  3,  3])


### PR DESCRIPTION
A bit of refactoring in bzmesh.jl and a fallback kpoint symmetry search.

Closes #128 