### PR TITLE
Convert lattice first thing to Float64 for spglib

### DIFF
--- a/src/external/spglib.jl
+++ b/src/external/spglib.jl
@@ -42,6 +42,7 @@ end
 
 function spglib_get_symmetry(lattice, atoms; tol_symmetry=1e-5)
     spglib = import_spglib()
+    lattice = Matrix{Float64}(lattice)  # spglib operates in double precision
 
     # Ask spglib for symmetry operations and for irreducible mesh
     spg_symops = spglib.get_symmetry(spglib_cell(lattice, atoms),


### PR DESCRIPTION
Fixes #138 by always converting the lattice to Float64 in the spglib routine. This is fine since spglib uses Float64 internally for all computations anyway.