### PR TITLE
Doc typos

### DIFF
--- a/docs/src/advanced/conventions.md
+++ b/docs/src/advanced/conventions.md
@@ -110,5 +110,5 @@ This means for instance that wavefunctions in the real space grid are
 normalized as ``\frac{|\Omega|}{N} \sum_{r} |\psi(r)|^{2} = 1`` where
 ``N`` is the number of grid points
 and in reciprocal space its coefficients are ``\ell^{2}``-normalized,
-see the [`PlaneWaveBasis` and plane-wave discretisations](@ref) for an example
+see the discussion in section [`PlaneWaveBasis` and plane-wave discretisations](@ref)
 where this is demonstrated.

--- a/docs/src/advanced/conventions.md
+++ b/docs/src/advanced/conventions.md
@@ -36,7 +36,7 @@ to simplify typing them.
 - ``j_l`` are the **Bessel functions**. In particular, ``j_{0}(x) = \frac{\sin x}{x}``.
 
 ## Units
-In DFTK atomic units are used thoughout, most importantly
+In DFTK, atomic units are used throughout, most importantly
 lengths are in Bohr and energies in Hartree.
 See [wikipedia](https://en.wikipedia.org/wiki/Hartree_atomic_units)
 for a list of conversion factors. Useful conversion factors
@@ -52,9 +52,9 @@ import DFTK.units: eV, Å
 !!! warning "Differing unit conventions"
     Different electronic-structure codes use different unit conventions.
     For example for lattice vectors the common length units
-    are bohr (used by DFTK) and Ångström (used e.g. by ASE, 1Å ≈ 1.80 bohr).
+    are Bohr (used by DFTK) and Ångström (used e.g. by ASE, 1Å ≈ 1.80 Bohr).
     When setting up a calculation for DFTK
-    one needs to ensure to convert to bohr and atomic units.
+    one needs to ensure to convert to Bohr and atomic units.
     For some Python libraries (currently ASE, pymatgen and abipy)
     DFTK directly ships conversion tools in form of the [`load_lattice`](@ref)
     and [`load_atoms`](@ref) functions,
@@ -110,4 +110,5 @@ This means for instance that wavefunctions in the real space grid are
 normalized as ``\frac{|\Omega|}{N} \sum_{r} |\psi(r)|^{2} = 1`` where
 ``N`` is the number of grid points
 and in reciprocal space its coefficients are ``\ell^{2}``-normalized,
-see the [Tutorial](@ref) for an example where this is demonstrated.
+see the [`PlaneWaveBasis` and plane-wave discretisations](@ref) for an example
+where this is demonstrated.

--- a/docs/src/guide/tutorial.jl
+++ b/docs/src/guide/tutorial.jl
@@ -56,7 +56,7 @@ scfres.energies
 # number of eigenvalues that are computed and 8 the number of kpoints.
 hcat(scfres.eigenvalues...)
 # Use `scfres.occupation` to see the number of electrons on each energy level.
-scfres.occupation
+hcat(scfres.occupation...)
 # And density:
 rvecs = collect(r_vectors(basis))[:, 1, 1]  # slice along the x axis
 x = [r[1] for r in rvecs]                   # only keep the x coordinate

--- a/docs/src/guide/tutorial.jl
+++ b/docs/src/guide/tutorial.jl
@@ -52,8 +52,11 @@ scfres = self_consistent_field(basis, tol=1e-8);
 # That's it! Now you can get various quantities from the result of the SCF.
 # For instance, the energies:
 scfres.energies
-# Eigenvalues:
+# Eigenvalues: here `scfres.eigenvalues` returns a 7x8 Array where 7 is the
+# number of eigenvalues that are computed and 8 the number of kpoints.
 hcat(scfres.eigenvalues...)
+# Use `scfres.occupation` to see the number of electron on each energy level.
+scfres.occupation
 # And density:
 rvecs = collect(r_vectors(basis))[:, 1, 1]  # slice along the x axis
 x = [r[1] for r in rvecs]                   # only keep the x coordinate

--- a/docs/src/guide/tutorial.jl
+++ b/docs/src/guide/tutorial.jl
@@ -55,7 +55,7 @@ scfres.energies
 # Eigenvalues: here `scfres.eigenvalues` returns a 7x8 Array where 7 is the
 # number of eigenvalues that are computed and 8 the number of kpoints.
 hcat(scfres.eigenvalues...)
-# Use `scfres.occupation` to see the number of electron on each energy level.
+# Use `scfres.occupation` to see the number of electrons on each energy level.
 scfres.occupation
 # And density:
 rvecs = collect(r_vectors(basis))[:, 1, 1]  # slice along the x axis

--- a/examples/ase.jl
+++ b/examples/ase.jl
@@ -63,7 +63,7 @@ atoms = [ElementPsp(el.symbol, psp=load_psp(el.symbol, functional="pbe")) => pos
          for (el, position) in atoms]
 lattice = load_lattice(surface);
 
-# We model this surface with (quite large a) temperature of 0.01 Hartree``
+# We model this surface with (quite large a) temperature of 0.01 Hartree
 # to ease convergence. Try lowering the SCF convergence tolerance (`tol`
 # or the `temperature` to see the full challenge of this system.
 model = model_DFT(lattice, atoms, [:gga_x_pbe, :gga_c_pbe],


### PR DESCRIPTION
2 typos plus 2 questions where I might be mistaking but we never know : 
- in https://juliamolsim.github.io/DFTK.jl/dev/advanced/conventions/#Units-1 do you use bohr or Bohr ?
- I think the link at the bottom of https://juliamolsim.github.io/DFTK.jl/dev/advanced/conventions/#Normalization-conventions-1 sends to the tutorial page whereas the normalization of the wave functions is in https://juliamolsim.github.io/DFTK.jl/dev/advanced/data_structures/#PlaneWaveBasis-and-plane-wave-discretisations-1