### PR TITLE
Allow to disable taking timings

### DIFF
--- a/src/PlaneWaveBasis.jl
+++ b/src/PlaneWaveBasis.jl
@@ -262,12 +262,12 @@ end
 """
 In-place version of `G_to_r`.
 """
-@timing function G_to_r!(f_real::AbstractArray3, basis::PlaneWaveBasis,
-                         f_fourier::AbstractArray3) where {Tr, Tf}
+@timing_seq function G_to_r!(f_real::AbstractArray3, basis::PlaneWaveBasis,
+                             f_fourier::AbstractArray3) where {Tr, Tf}
     mul!(f_real, basis.opIFFT, f_fourier)
 end
-@timing function G_to_r!(f_real::AbstractArray3, basis::PlaneWaveBasis,
-                         kpt::Kpoint, f_fourier::AbstractVector)
+@timing_seq function G_to_r!(f_real::AbstractArray3, basis::PlaneWaveBasis,
+                             kpt::Kpoint, f_fourier::AbstractVector)
     @assert length(f_fourier) == length(kpt.mapping)
     @assert size(f_real) == basis.fft_size
 
@@ -300,12 +300,12 @@ end
 In-place version of `r_to_G!`.
 NOTE: If `kpt` is given, not only `f_fourier` but also `f_real` is overwritten.
 """
-@timing function r_to_G!(f_fourier::AbstractArray3, basis::PlaneWaveBasis,
-                         f_real::AbstractArray3)
+@timing_seq function r_to_G!(f_fourier::AbstractArray3, basis::PlaneWaveBasis,
+                             f_real::AbstractArray3)
     mul!(f_fourier, basis.opFFT, f_real)
 end
-@timing function r_to_G!(f_fourier::AbstractVector, basis::PlaneWaveBasis,
-                         kpt::Kpoint, f_real::AbstractArray3)
+@timing_seq function r_to_G!(f_fourier::AbstractVector, basis::PlaneWaveBasis,
+                             kpt::Kpoint, f_real::AbstractArray3)
     @assert size(f_real) == basis.fft_size
     @assert length(f_fourier) == length(kpt.mapping)
 

--- a/src/common/timer.jl
+++ b/src/common/timer.jl
@@ -1,4 +1,4 @@
-# Control whether timings are enabled or not, by default yes
+# Control whether timings are enabled or not, by default no
 if parse(Bool, get(ENV, "DFTK_TIMING", "0"))
     timer_enabled() = true
 else

--- a/src/common/timer.jl
+++ b/src/common/timer.jl
@@ -1,5 +1,5 @@
 # Control whether timings are enabled or not, by default yes
-if parse(Bool, get(ENV, "DFTK_TIMING", "1"))
+if parse(Bool, get(ENV, "DFTK_TIMING", "0"))
     timer_enabled() = true
 else
     timer_enabled() = false

--- a/src/common/timer.jl
+++ b/src/common/timer.jl
@@ -1,6 +1,34 @@
+# Control whether timings are enabled or not, by default yes
+if parse(Bool, get(ENV, "DFTK_TIMING", "1"))
+    timer_enabled() = true
+else
+    timer_enabled() = false
+end
+
+"""TimerOutput object used to store DFTK timings."""
 const timer = TimerOutput()
-# creating a new macro to shorten the call :
-# replaces `@timeit to [label] [block]` by `@timer [label] [block]`
+
+"""
+Shortened version of the `@timeit` macro from `TimerOutputs`,
+which writes to the DFTK timer.
+"""
 macro timing(args...)
-    TimerOutputs.timer_expr(__module__, false, timer, args...)
+    if DFTK.timer_enabled()
+        TimerOutputs.timer_expr(__module__, false, :($(DFTK.timer)), args...)
+    else  # Disable taking timings
+        :($(esc(last(args))))
+    end
+end
+
+"""
+Similar to `@timing`, but disabled in parallel runs.
+Should be used to time threaded regions,
+since TimerOutputs is not thread-safe and breaks otherwise.
+"""
+macro timing_seq(args...)
+    if Threads.nthreads() == 1 && DFTK.timer_enabled()
+        TimerOutputs.timer_expr(__module__, false, :($(DFTK.timer)), args...)
+    else  # Disable taking timings
+        :($(esc(last(args))))
+    end
 end

--- a/src/terms/operators.jl
+++ b/src/terms/operators.jl
@@ -52,7 +52,7 @@ struct RealSpaceMultiplication <: RealFourierOperator
     kpoint
     potential::AbstractArray
 end
-@timing "apply real space multiplication" function apply!(Hψ, op::RealSpaceMultiplication, ψ)
+@timing_seq "apply RealSpaceMultiplication" function apply!(Hψ, op::RealSpaceMultiplication, ψ)
     Hψ.real .+= op.potential .* ψ.real
 end
 function Matrix(op::RealSpaceMultiplication)
@@ -86,7 +86,7 @@ struct FourierMultiplication <: RealFourierOperator
     kpoint
     multiplier::AbstractArray
 end
-@timing "apply Fourier space multiplication" function apply!(Hψ, op::FourierMultiplication, ψ)
+@timing_seq "apply FourierMultiplication" function apply!(Hψ, op::FourierMultiplication, ψ)
     Hψ.fourier .+= op.multiplier .* ψ.fourier
 end
 Matrix(op::FourierMultiplication) = Array(Diagonal(op.multiplier))
@@ -103,7 +103,7 @@ struct NonlocalOperator <: RealFourierOperator
     P
     D
 end
-@timing "apply nonlocal operator" function apply!(Hψ, op::NonlocalOperator, ψ)
+@timing_seq "apply NonlocalOperator" function apply!(Hψ, op::NonlocalOperator, ψ)
     Hψ.fourier .+= op.P * (op.D * (op.P' * ψ.fourier))
 end
 Matrix(op::NonlocalOperator) = op.P * op.D * op.P'
@@ -116,7 +116,7 @@ struct MagneticFieldOperator <: RealFourierOperator
     kpoint
     Apot  # Apot[α][i,j,k] is the A field in direction α
 end
-@timing "apply magnetic field operator" function apply!(Hψ, op::MagneticFieldOperator, ψ)
+@timing_seq "apply MagneticFieldOperator" function apply!(Hψ, op::MagneticFieldOperator, ψ)
     # TODO this could probably be better optimized
     for α = 1:3
         all(op.Apot[α] .== 0) && continue


### PR DESCRIPTION
This allows to disable taking timings in DFTK by defining the environment variable `DFTK_TIMING=0`. Also it disables timings is the parallelised regions, since otherwise undefined references and other funs due to race conditions in TimerOutputs are the result.