### PR TITLE
Small tweak with miniter

### DIFF
--- a/src/postprocess/chi0.jl
+++ b/src/postprocess/chi0.jl
@@ -108,7 +108,7 @@ function sternheimer_solver(basis, kpoint, Hk, ψk, ψnk, εnk, rhs, cgtol)
     # don't commute enough, and an oversolving of the linear
     # system can lead to spurious solutions
     rhs = Q(rhs)
-    δψnk = cg(J, rhs, Pl=FunctionPreconditioner(f_ldiv!), tol=cgtol / norm(rhs), verbose=true)
+    δψnk = cg(J, rhs, Pl=FunctionPreconditioner(f_ldiv!), tol=cgtol / norm(rhs), verbose=false)
     δψnk
 end
 

--- a/src/scf/self_consistent_field.jl
+++ b/src/scf/self_consistent_field.jl
@@ -72,7 +72,7 @@ Determine the tolerance used for the next diagonalization. This function takes
 ensuring additionally that the returned value is between `diagtol_min` and `diagtol_max`
 and never increases.
 """
-function ScfDiagtol(;ratio_ρdiff=0.2, diagtol_min=nothing, diagtol_max=0.1)
+function ScfDiagtol(;ratio_ρdiff=0.2, diagtol_min=nothing, diagtol_max=0.03)
     function determine_diagtol(info)
         isnothing(diagtol_min) && (diagtol_min = 100eps(real(eltype(info.ρin))))
         info.n_iter == 1 && return diagtol_max

--- a/src/terms/xc.jl
+++ b/src/terms/xc.jl
@@ -78,6 +78,7 @@ function apply_kernel(term::TermXc, dρ; ρ::RealFourierArray, kwargs...)
     basis = term.basis
     T = eltype(basis)
     @assert all(xc.family in (:lda, :gga) for xc in term.functionals)
+    isempty(term.functionals) && return false  # Strong zero
 
     # Take derivatives of the density and the perturbation if needed.
     max_ρ_derivs = maximum(max_required_derivative, term.functionals)

--- a/test/forces.jl
+++ b/test/forces.jl
@@ -56,7 +56,7 @@ end
     ε = 1e-6
     pos2 = [pos1[1] + ε * disp, pos1[2]]
 
-    for (tol, smearing) in [(0.001, Smearing.FermiDirac), (5e-5, Smearing.Gaussian)]
+    for (tol, smearing) in [(0.003, Smearing.FermiDirac), (5e-5, Smearing.Gaussian)]
         E1, F1 = silicon_energy_forces(pos1; smearing=smearing())
         E2, _ = silicon_energy_forces(pos2; smearing=smearing())
 


### PR DESCRIPTION
I've noticed in the calculations I currently do that often in the second SCF step only 1 LOBPCG per k-Point is performed, but in the third step many more (about 10 to 20) due to our adaptive tolerance selection kicking in. I think in order to easy making progress it makes sense to enforce a few more iterations for the first two steps. I've selected `2` because that's the typical average which is done in the first step anyway so this will not increase the number of applies a lot.