### PR TITLE
Refactor chi0 models out of HybridMixing

### DIFF
--- a/src/DFTK.jl
+++ b/src/DFTK.jl
@@ -108,7 +108,8 @@ export diag_full
 export diagonalize_all_kblocks
 include("eigen/diag.jl")
 
-export KerkerMixing, KerkerDosMixing, SimpleMixing, DielectricMixing, HybridMixing
+export KerkerMixing, KerkerDosMixing, SimpleMixing, DielectricMixing, HybridMixing, χ0Mixing
+include("scf/chi0models.jl")
 include("scf/mixing.jl")
 export scf_nlsolve_solver
 export scf_damping_solver

--- a/src/scf/chi0models.jl
+++ b/src/scf/chi0models.jl
@@ -25,7 +25,7 @@ function (::LdosModel)(basis; eigenvalues, ψ, εF, kwargs...)
     # Catch cases that will yield no contribution
     iszero(basis.model.temperature) && return nothing
     ldos = [LDOS(εF, basis, eigenvalues, ψ, spins=[σ]) for σ in 1:n_spin]
-    if maximum(maximum(abs, ldos[σ]) for σ in 1:n_spin) < eps(eltype(ldos))
+    if maximum(maximum(abs, ldos[σ]) for σ in 1:n_spin) < eps(eltype(basis))
         return nothing
     end
 
@@ -96,10 +96,10 @@ function (χ0::Applyχ0Model)(basis; ham, eigenvalues, ψ, εF, n_ep_extra, kwar
         # χ0δV[1] is total, χ0δV[2] is spin
         χ0δV = apply_χ0(ham, ψ_cvg, εF, eigenvalues_cvg, δV...; χ0.kwargs_apply_χ0...)
         if basis.model.n_spin_components == 1
-            δρ[1] .+= χ0δV[1].real
+            δρ[:, :, :, 1] .+= χ0δV[1].real
         else
-            δρ[1] .+= (χ0δV[1].real .+ χ0δV[2].real) ./ 2
-            δρ[2] .+= (χ0δV[1].real .- χ0δV[2].real) ./ 2
+            δρ[:, :, :, 1] .+= (χ0δV[1].real .+ χ0δV[2].real) ./ 2
+            δρ[:, :, :, 2] .+= (χ0δV[1].real .- χ0δV[2].real) ./ 2
         end
         δρ
     end

--- a/src/scf/chi0models.jl
+++ b/src/scf/chi0models.jl
@@ -1,0 +1,106 @@
+import Base: @kwdef
+
+# structs defining terms of a composable model for the independent-particle
+# susceptibility χ0. The struct define a call operator, which does some setup
+# and returns an `apply!(δρ, δV)` function to add the χ0 term to a preallocated
+# array `δρ`. `δV[1]` holds the spin-up (or total) potential change, `δV[2]` the
+# spin-down potential as a `RealFourierArray`. `δρ[:, :, :, 1]` is the spin-up
+# or the total density change and `δρ[:, :, :, 2]` the spin-down density change.
+
+abstract type χ0Model end
+
+@doc raw"""
+Represents the LDOS-based ``χ_0`` model
+```math
+χ_0(r, r') = (-D_\text{loc}(r) δ(r, r') + D_\text{loc}(r) D_\text{loc}(r') / D)
+```
+where ``D_\text{loc}`` is the local density of states and ``D`` the density of states.
+For details see Herbst, Levitt 2020 arXiv:2009.01665
+"""
+struct LdosModel <: χ0Model end
+function (::LdosModel)(basis; eigenvalues, ψ, εF, kwargs...)
+    n_spin = basis.model.n_spin_components
+    dVol   = basis.model.unit_cell_volume / prod(basis.fft_size)
+
+    # Catch cases that will yield no contribution
+    iszero(basis.model.temperature) && return nothing
+    ldos = [LDOS(εF, basis, eigenvalues, ψ, spins=[σ]) for σ in 1:n_spin]
+    if maximum(maximum(abs, ldos[σ]) for σ in 1:n_spin) < eps(eltype(ldos))
+        return nothing
+    end
+
+    dos = sum(sum, ldos) * dVol  # Integrate LDOS to form total DOS
+    function apply!(δρ, δV)
+        dotldosδV = sum(dot(ldos[σ], δV[σ].real) for σ = 1:n_spin)
+        for σ in 1:n_spin
+            δρ[:, :, :, σ] .-= (-ldos[σ] .* δV[σ].real
+                                .+ ldos[σ] .* dotldosδV .* dVol ./ dos)
+        end
+        δρ
+    end
+end
+
+@doc raw"""
+A localised dielectric model for ``χ_0``:
+```math
+\sqrt{L(x)} \text{IFFT} \frac{C_0 G^2}{4π (1 - C_0 G^2 / k_{TF}^2)} \text{FFT} \sqrt{L(x)}
+```
+where ``C_0 = 1 - ε_r``, `L(r)` is a real-space localisation function
+and otherwise the same conventions are used as in [`DielectricMixing`](@ref).
+"""
+@kwdef struct DielectricModel <: χ0Model
+    εr::Real  = 10
+    kTF::Real = 0.8
+    localisation::Function = identity
+end
+function (χ0::DielectricModel)(basis; kwargs...)
+    T   = eltype(basis)
+    εr  = T(χ0.εr)
+    kTF = T(χ0.kTF)
+    C0  = 1 - εr
+    n_spin = basis.model.n_spin_components
+    iszero(C0) && return nothing  # Will yield no contribution
+
+    Gsq = [sum(abs2, G) for G in G_vectors_cart(basis)]
+    apply_sqrtL = identity
+    if χ0.localisation != identity
+        sqrtL = sqrt.(χ0.localisation.(r_vectors(basis)))
+        apply_sqrtL = x -> from_real(basis, sqrtL .* x.real)
+    end
+
+    function apply!(δρ, δV)
+        for σ in 1:n_spin
+            loc_δV = apply_sqrtL(δV[σ]).fourier
+            dielectric_loc_δV = @. C0 * kTF^2 * Gsq / 4T(π) / (kTF^2 - C0 * Gsq) * loc_δV
+            δρ[:, :, :, σ] .-= apply_sqrtL(from_fourier(basis, dielectric_loc_δV)).real
+        end
+        δρ
+    end
+end
+
+"""
+Full χ0 application, optionally dropping terms or disabling Sternheimer.
+All keyword arguments passed to [`apply_χ0`](@ref).
+"""
+struct Applyχ0Model <: χ0Model
+    kwargs_apply_χ0
+end
+Applyχ0Model(; kwargs_apply_χ0...) = Applyχ0Model(kwargs_apply_χ0)
+function (χ0::Applyχ0Model)(basis; ham, eigenvalues, ψ, εF, n_ep_extra, kwargs...)
+    # self_consistent_field uses a few extra bands, which are not converged by the eigensolver
+    # For the χ0 application, bands need to be perfectly converged, so we discard them here
+    ψ_cvg = [@view ψk[:, 1:end-n_ep_extra]  for ψk in ψ]
+    eigenvalues_cvg = [εk[1:end-n_ep_extra] for εk in eigenvalues]
+
+    function apply!(δρ, δV)
+        # χ0δV[1] is total, χ0δV[2] is spin
+        χ0δV = apply_χ0(ham, ψ_cvg, εF, eigenvalues_cvg, δV...; χ0.kwargs_apply_χ0...)
+        if basis.model.n_spin_components == 1
+            δρ[1] .+= χ0δV[1].real
+        else
+            δρ[1] .+= (χ0δV[1].real .+ χ0δV[2].real) ./ 2
+            δρ[2] .+= (χ0δV[1].real .- χ0δV[2].real) ./ 2
+        end
+        δρ
+    end
+end

--- a/src/scf/mixing.jl
+++ b/src/scf/mixing.jl
@@ -154,10 +154,7 @@ Important `kwargs` passed on to [`χ0Mixing`](@ref)
 - `verbose`: Run the GMRES in verbose mode.
 """
 function HybridMixing(;εr=1.0, kTF=0.8, localisation=identity, kwargs...)
-    χ0terms = χ0Model[LdosModel()]
-    if εr != 1.0
-        append!(χ0terms, DielectricModel(εr=εr, kTF=kTF, localisation=localisation))
-    end
+    χ0terms = [DielectricModel(εr=εr, kTF=kTF, localisation=localisation), LdosModel()]
     χ0Mixing(; χ0terms=χ0terms, kwargs...)
 end
 

--- a/src/scf/mixing.jl
+++ b/src/scf/mixing.jl
@@ -169,7 +169,7 @@ real space using a GMRES. Either the full kernel (`RPA=false`) or only the Hartr
 @kwdef struct χ0Mixing
     α::Real   = 0.8
     RPA::Bool = true       # Use RPA, i.e. only apply the Hartree and not the XC Kernel
-    χ0terms   = χ0Model[]  # The terms to use as the model for χ0
+    χ0terms   = χ0Model[Applyχ0Model()]  # The terms to use as the model for χ0
     verbose::Bool = false  # Run the GMRES verbosely
 end
 
@@ -180,7 +180,7 @@ end
     @assert basis.model.spin_polarization in (:none, :spinless, :collinear)
 
     # Initialise χ0terms and remove nothings (terms that don't yield a contribution)
-    χ0applies = [χ0(basis, ρin=ρin, ρ_spin_in=ρ_spin_in, kwargs...) for χ0 in mixing.χ0terms]
+    χ0applies = [χ0(basis; ρin=ρin, ρ_spin_in=ρ_spin_in, kwargs...) for χ0 in mixing.χ0terms]
     χ0applies = [apply for apply in χ0applies if !isnothing(apply)]
 
     # If no applies left, do not bother running GMRES and directly do simple mixing

--- a/src/scf/mixing.jl
+++ b/src/scf/mixing.jl
@@ -40,7 +40,7 @@ Notes:
 - Abinit calls ``1/k_{TF}`` the dielectric screening length (parameter *dielng*)
 """
 @kwdef struct KerkerMixing
-    # Default parameters suggested by Kresse, Furthmüller 1996 (α=0.8, kTF=1.5 Ǎ^{-1})
+    # Default parameters suggested by Kresse, Furthmüller 1996 (α=0.8, kTF=1.5Å⁻¹)
     # DOI 10.1103/PhysRevB.54.11169
     α::Real    = 0.8
     kTF::Real  = 0.8  # == sqrt(4π (DOS_α + DOS_β) / Ω)
@@ -146,85 +146,74 @@ where ``C_0 = 1 - ε_r``, ``D_\text{loc}`` is the local density of states,
 the same convention for parameters are used as in [`DielectricMixing`](@ref).
 Additionally there is the real-space localisation function `L(r)`.
 For details see Herbst, Levitt 2020 arXiv:2009.01665
+
+Important `kwargs` passed on to [`χ0Mixing`](@ref)
+- `α`: Damping parameter
+- `RPA`: Is the random-phase approximation used for the kernel (i.e. only Hartree kernel is
+  used and not XC kernel)
+- `verbose`: Run the GMRES in verbose mode.
 """
-@kwdef struct HybridMixing
+function HybridMixing(;εr=1.0, kTF=0.8, localisation=identity, kwargs...)
+    χ0terms = χ0Model[LdosModel()]
+    if εr != 1.0
+        append!(χ0terms, DielectricModel(εr=εr, kTF=kTF, localisation=localisation))
+    end
+    χ0Mixing(; χ0terms=χ0terms, kwargs...)
+end
+
+
+@doc raw"""
+Generic mixing function using a model for the susceptibility composed of the sum of the `χ0terms`.
+For valid `χ0terms` See the subtypes of `χ0Model`. The dielectric model is solved in
+real space using a GMRES. Either the full kernel (`RPA=false`) or only the Hartree kernel
+(`RPA=true`) are employed. `verbose=true` lets the GMRES run in verbose mode
+(useful for debugging).
+"""
+@kwdef struct χ0Mixing
     α::Real   = 0.8
-    εr::Real  = 1.0
-    kTF::Real = 0.8
-    localisation::Function = identity  # `L(r)` with `r` in fractional real-space coordinates
     RPA::Bool = true       # Use RPA, i.e. only apply the Hartree and not the XC Kernel
+    χ0terms   = χ0Model[]  # The terms to use as the model for χ0
     verbose::Bool = false  # Run the GMRES verbosely
 end
 
-@timing "mixing Hybrid" function mix(mixing::HybridMixing, basis, δF_tot::RealFourierArray,
-                                     δF_spin=nothing;
-                                     εF, eigenvalues, ψ, ρin, ρ_spin_in, kwargs...)
-    @assert basis.model.spin_polarization in (:none, :spinless, :collinear)
+@timing "χ0Mixing" function mix(mixing::χ0Mixing, basis, δF_tot::RealFourierArray,
+                                δF_spin=nothing; ρin, ρ_spin_in, kwargs...)
     T = eltype(δF_tot)
-    εr = T(mixing.εr)
-    kTF = T(mixing.kTF)
-    C0 = 1 - εr
-    Gsq = [sum(abs2, G) for G in G_vectors_cart(basis)]
-    dVol = basis.model.unit_cell_volume / prod(basis.fft_size)
     n_spin = basis.model.n_spin_components
+    @assert basis.model.spin_polarization in (:none, :spinless, :collinear)
 
-    apply_sqrtL = identity
-    if mixing.localisation != identity
-        sqrtL = sqrt.(mixing.localisation.(r_vectors(basis)))
-        apply_sqrtL = x -> from_real(basis, sqrtL .* x.real)
-    end
+    # Initialise χ0terms and remove nothings (terms that don't yield a contribution)
+    χ0applies = [χ0(basis, ρin=ρin, ρ_spin_in=ρ_spin_in, kwargs...) for χ0 in mixing.χ0terms]
+    χ0applies = [apply for apply in χ0applies if !isnothing(apply)]
 
-    # Compute the LDOS if required
-    ldos = nothing
-    if basis.model.temperature > 0
-        ldos = [LDOS(εF, basis, eigenvalues, ψ, spins=[σ]) for σ in 1:n_spin]
-        if maximum(maximum(abs, ldos_σ) for ldos_σ in ldos) < eps(T)
-            ldos = nothing
-        end
-        dos = sum(sum, ldos) * dVol  # Integrate LDOS to form total DOS
-    end
+    # If no applies left, do not bother running GMRES and directly do simple mixing
+    isempty(χ0applies) && return mix(SimpleMixing(α=mixing.α), basis, δF_tot, δF_spin)
 
-    # Solve J δρ = δF with J = (1 - χ0 vc) and χ_0 given as in the docstring of the class
+    # Solve J δρ = δF with J = (1 - χ0 vc) and χ_0 given as the sum of the χ0terms
     devec(x) = reshape(x, size(δF_tot)..., n_spin)
     function Jop(x)
         δF = devec(x)  # [:, :, :, 1] is spin-up (or total), [:, :, :, 2] is spin-down
+
+        # Apply Kernel (just vc for RPA and (vc + K_{xc}) if not RPA)
+        @views if n_spin == 1
+            x_tot  = from_real(basis, δF[:, :, :, 1])
+            x_spin = nothing
+        else
+            x_tot  = from_real(basis, δF[:, :, :, 1] .+ δF[:, :, :, 2])
+            x_spin = from_real(basis, δF[:, :, :, 1] .- δF[:, :, :, 2])
+        end
+        δV = apply_kernel(basis, x_tot, x_spin; ρ=ρin, ρspin=ρ_spin_in, RPA=mixing.RPA)
+
+        # set DC of δV to zero (δV[1] is spin-up or total, δV[2] is spin-down)
+        δV_DC = mean(mean(δV[σ].real) for σ in 1:n_spin)
+        δV[1].real .-= δV_DC
+        n_spin == 2 && (δV[2].real .-= δV_DC)
+
         JδF = copy(δF)
-
-        if !iszero(C0) || ldos !== nothing
-            # Apply Kernel (just vc for RPA and (vc + K_{xc}) if not RPA)
-            @views if n_spin == 1
-                x_tot  = from_real(basis, δF[:, :, :, 1])
-                x_spin = nothing
-            else
-                x_tot  = from_real(basis, δF[:, :, :, 1] .+ δF[:, :, :, 2])
-                x_spin = from_real(basis, δF[:, :, :, 1] .- δF[:, :, :, 2])
-            end
-            δV = apply_kernel(basis, x_tot, x_spin; ρ=ρin, ρspin=ρ_spin_in, RPA=mixing.RPA)
-
-            # set DC of δV to zero (δV[1] is spin-up or total, δV[2] is spin-down)
-            δV_DC = mean(mean(δV[σ].real) for σ in 1:n_spin)
-            δV[1].real .-= δV_DC
-            n_spin == 2 && (δV[2].real .-= δV_DC)
+        for apply_term! in χ0applies
+            apply_term!(JδF, δV)
         end
-
-        if !iszero(C0)  # Apply Dielectric term of χ0
-            for σ in 1:n_spin
-                loc_δV = apply_sqrtL(δV[σ]).fourier
-                dielectric_loc_δV = @. C0 * kTF^2 * Gsq / 4T(π) / (kTF^2 - C0 * Gsq) * loc_δV
-                JδF[:, :, :, σ] .-= apply_sqrtL(from_fourier(basis, dielectric_loc_δV)).real
-            end
-        end
-
-        if ldos !== nothing  # Apply LDOS term of χ0
-            dotldosδV = sum(dot(ldos[σ], δV[σ].real) for σ = 1:n_spin)
-            for σ in 1:n_spin
-                JδF[:, :, :, σ] .-= (-ldos[σ] .* δV[σ].real
-                                     .+ ldos[σ] .* dotldosδV .* dVol ./ dos)
-            end
-        end
-
-        # Zero DC component in total density response and return
-        vec(JδF .-= mean(JδF))
+        vec(JδF .-= mean(JδF))  # Zero DC component in total density response
     end
 
     if n_spin == 1

--- a/src/scf/self_consistent_field.jl
+++ b/src/scf/self_consistent_field.jl
@@ -116,7 +116,7 @@ Solve the Kohn-Sham equations with a SCF algorithm, starting at ρ.
         # Update info with results gathered so far
         info = (ham=ham, basis=basis, converged=converged, stage=:iterate,
                 ρin=ρin, ρ_spin_in=ρ_spin_in, ρout=ρout, ρ_spin_out=ρ_spin_out,
-                n_iter=n_iter, nextstate...)
+                n_iter=n_iter, n_ep_extra=n_ep_extra, nextstate...)
 
         # Compute the energy of the new state
         if compute_consistent_energies
@@ -161,7 +161,8 @@ Solve the Kohn-Sham equations with a SCF algorithm, starting at ρ.
     # Callback is run one last time with final state to allow callback to clean up
     info = (ham=ham, basis=basis, energies=energies, converged=converged,
             ρ=ρout, ρspin=ρ_spin_out, eigenvalues=eigenvalues, occupation=occupation, εF=εF,
-            n_iter=n_iter, ψ=ψ, diagonalization=info.diagonalization, stage=:finalize)
+            n_iter=n_iter, n_ep_extra=n_ep_extra, ψ=ψ, diagonalization=info.diagonalization,
+            stage=:finalize)
     callback(info)
     info
 end

--- a/test/scf_compare.jl
+++ b/test/scf_compare.jl
@@ -1,5 +1,6 @@
 using Test
 using DFTK
+import DFTK: Applyχ0Model
 
 include("testcases.jl")
 
@@ -94,7 +95,7 @@ end
     ρ_ref     = scfres.ρ.fourier
 
     for mixing in (KerkerMixing(), KerkerDosMixing(α=1.0), DielectricMixing(εr=10),
-                   HybridMixing(εr=10))
+                   HybridMixing(εr=10), χ0Mixing(χ0terms=[Applyχ0Model()], RPA=false),)
         @testset "Testing $mixing" begin
             scfres = self_consistent_field(basis; ρ=ρ0, ρspin=ρspin0, mixing=mixing, tol=tol)
             @test maximum(abs.(scfres.ρ.fourier     - ρ_ref    )) < sqrt(tol)


### PR DESCRIPTION
A bit of refactoring to make it easier to play with different χ0 models inside HybridMixing. Also implements "exact" χ0 for mixing. Happy to discuss alternatives.