### PR TITLE
Replace ForwardDiff by manual forces

### DIFF
--- a/src/terms/ewald.jl
+++ b/src/terms/ewald.jl
@@ -198,6 +198,7 @@ function energy_ewald(lattice, recip_lattice, charges, positions; η=nothing, fo
                 energy_contribution = Zi * Zj * erfc(η * dist) / dist 
                 sum_real += energy_contribution
                 if forces !== nothing
+                    # `dE_ddist` is the derivative of `energy_contribution` w.r.t. `dist`
                     dE_ddist = Zi * Zj * η * (-2exp(-(η * dist)^2) / sqrt(T(π)))
                     dE_ddist -= energy_contribution
                     dE_dti = lattice' * ((dE_ddist / dist^2) * Δr)

--- a/src/terms/ewald.jl
+++ b/src/terms/ewald.jl
@@ -1,5 +1,4 @@
 using SpecialFunctions: erfc
-using ForwardDiff
 
 """
 Ewald term: electrostatic energy per unit cell of the array of point
@@ -187,7 +186,8 @@ function energy_ewald(lattice, recip_lattice, charges, positions; η=nothing, fo
                     continue
                 end
 
-                dist = norm(lattice * (ti - tj - R))
+                v = lattice * (ti - tj - R)
+                dist = norm(v)
 
                 # erfc decays very quickly, so cut off at some point
                 if η * dist > max_erfc_arg
@@ -195,11 +195,15 @@ function energy_ewald(lattice, recip_lattice, charges, positions; η=nothing, fo
                 end
 
                 any_term_contributes = true
-                sum_real += Zi * Zj * erfc(η * dist) / dist
+                energy_contribution = Zi * Zj * erfc(η * dist) / dist 
+                sum_real += energy_contribution
                 if forces !== nothing
-                    # Use ForwardDiff here because I'm lazy. TODO do it properly
-                    forces_real[i] -= ForwardDiff.gradient(r -> (dist=norm(lattice * (r - tj - R)); Zi * Zj * erfc(η * dist) / dist), ti)
-                    forces_real[j] -= ForwardDiff.gradient(r -> (dist=norm(lattice * (ti - r - R)); Zi * Zj * erfc(η * dist) / dist), tj)
+                    # grad = ForwardDiff.gradient(r -> (dist=norm(lattice * (r - tj - R)); Zi * Zj * erfc(η * dist) / dist), ti)
+                    ddist = Zi * Zj * η * (-2exp(-(η*dist)^2) / sqrt(T(π)))
+                    ddist += -energy_contribution
+                    dti = lattice'*((ddist / dist^2) * v)
+                    forces_real[i] += -dti
+                    forces_real[j] += dti
                 end
             end # i,j
         end # R


### PR DESCRIPTION
This fixes the TODO item. The result matches the previous ForwardDiff solution to double precision. On the isolated [test-case](https://github.com/JuliaMolSim/DFTK.jl/blob/f8edc1e563666ee676f25d8b0bd94a7da1ff0ea8/test/ewald.jl#L50) there's also a small speed improvement:
```julia
using Test
using DFTK: energy_ewald, Vec3
using LinearAlgebra
using BenchmarkTools

@testset "Forces" begin
    lattice = [0.0  5.131570667152971 5.131570667152971;
               5.131570667152971 0.0 5.131570667152971;
               5.131570667152971 5.131570667152971  0.0]
    # perturb positions away from equilibrium to get nonzero force
    positions = [ones(3)/8+rand(3)/20, -ones(3)/8]
    charges = [14, 14]

    forces = zeros(Vec3{Float64}, 2)
    γ1 = energy_ewald(lattice, charges, positions, forces=forces)

    # Compare forces to finite differences
    disp = [rand(3)/20, rand(3)/20]
    ε = 1e-8
    γ2 = energy_ewald(lattice, charges, positions .+ ε .* disp)
    @test (γ2-γ1)/ε ≈ -dot(disp, forces) atol=abs(γ1*1e-6)

    @btime energy_ewald($lattice, $charges, $positions, forces=forces) setup=(forces=zeros(Vec3{Float64}, 2))
    # before:             15.108 ms (222822 allocations: 15.95 MiB)
    # after manual forces: 4.433 ms (80129 allocations: 8.21 MiB)
end

```