### PR TITLE
Suppress conditional package load warnings

### DIFF
--- a/.github/workflows/CompatHelper.yaml
+++ b/.github/workflows/CompatHelper.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 1.3
+          version: 1.5
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,10 +22,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {version: '1.4',   os: ubuntu-latest,  payload: serial}
-          - {version: '1.4',   os: macOS-latest,   payload: serial}
-          - {version: '1.4',   os: windows-latest, payload: serial}
-          - {version: '1.4',   os: ubuntu-latest,  payload: mpi   }
+          - {version: '1.5',   os: ubuntu-latest,  payload: serial}
+          - {version: '1.5',   os: macOS-latest,   payload: serial}
+          - {version: '1.5',   os: windows-latest, payload: serial}
+          - {version: '1.5',   os: ubuntu-latest,  payload: mpi   }
           - {version: nightly, os: ubuntu-latest,  payload: serial}
     env:
       PYTHON: ""  # Force using Conda in PyCall
@@ -95,7 +95,7 @@ jobs:
         run: pip install ase pymatgen
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.4'
+          version: '1.5'
       - uses: actions/cache@v1
         env:
           cache-name: cache-artifacts

--- a/Project.toml
+++ b/Project.toml
@@ -65,7 +65,7 @@ StaticArrays = "0.12, 1"
 TimerOutputs = "0.5.6"
 Unitful = "1"
 UnitfulAtomic = "1"
-julia = "1.4"
+julia = "1.5"
 spglib_jll = "1.15"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For getting started with DFTK, see our documentation:
 - [Tutorial](https://juliamolsim.github.io/DFTK.jl/dev/guide/tutorial/)
 - [Examples](https://juliamolsim.github.io/DFTK.jl/dev/#example-index-1)
 
-Note that at least **Julia 1.4** is required.
+Note that at least **Julia 1.5** is required.
 
 ## Support and citation
 DFTK is mostly developed as part of academic research.

--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -3,7 +3,7 @@
 In case you don't have a working Julia installation yet, first
 [download the Julia binaries](https://julialang.org/downloads/)
 and follow the [Julia installation instructions](https://julialang.org/downloads/platform/).
-At least **Julia 1.4** is required for DFTK.
+At least **Julia 1.5** is required for DFTK.
 
 Afterwards you can install DFTK
 [like any other package](https://julialang.github.io/Pkg.jl/v1/getting-started/)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,6 +15,7 @@ Our performance is of the same order of magnitude as much larger production
 codes such as [Abinit](https://www.abinit.org/),
 [Quantum Espresso](http://quantum-espresso.org/) and
 [VASP](https://www.vasp.at/).
+DFTK's source code is [publicly available on github](https://dftk.org).
 
 ## [Package features](@id package-features)
 * Methods and models:

--- a/src/external/etsf_nanoquanta.jl
+++ b/src/external/etsf_nanoquanta.jl
@@ -3,7 +3,6 @@
 
 export EtsfFolder
 
-using NCDatasets
 import JSON
 
 struct EtsfFolder

--- a/src/external/jld2io.jl
+++ b/src/external/jld2io.jl
@@ -1,5 +1,3 @@
-import JLD2
-
 """
 Adds simplistic checkpointing to a DFTK self-consistent field calculation.
 """

--- a/src/external/load_from_python.jl
+++ b/src/external/load_from_python.jl
@@ -6,8 +6,9 @@ function load_lattice(T, pyobj::PyObject)
     ase = pyimport_e("ase")
 
     if !ispynull(mg)
-        mg_supported = (mg.Structure, mg.Lattice)
-        if any(pyisinstance(pyobj, s) for s in mg_supported)
+        Lattice   = pyimport("pymatgen.core.lattice").Lattice
+        Structure = pyimport("pymatgen.core.structure").Structure
+        if any(pyisinstance(pyobj, s) for s in (Lattice, Structure))
             return load_lattice_pymatgen(T, pyobj)
         end
     end
@@ -27,8 +28,10 @@ function load_atoms(T, pyobj::PyObject)
     mg = pyimport_e("pymatgen")
     ase = pyimport_e("ase")
 
-    if !ispynull(mg) && pyisinstance(pyobj, mg.Structure)
-        return load_atoms_pymatgen(T, pyobj)
+    if !ispynull(mg)
+        if pyisinstance(pyobj, pyimport("pymatgen.core.structure").Structure)
+            return load_atoms_pymatgen(T, pyobj)
+        end
     end
     if !ispynull(ase) && pyisinstance(pyobj, ase.Atoms)
         return load_atoms_ase(T, pyobj)

--- a/src/external/pymatgen.jl
+++ b/src/external/pymatgen.jl
@@ -4,15 +4,14 @@
 function pymatgen_lattice(lattice::AbstractArray)
     # Notice: Pymatgen uses rows as lattice vectors, so we unpeel
     # our lattice column by column. The default unit in pymatgen is Ångström
-    mg = pyimport("pymatgen")
+    Lattice = pyimport("pymatgen.core.lattice").Lattice
     bohr_to_A = 1 / austrip(1u"Å")
-    mg.Lattice([Array(bohr_to_A .* lattice[:, i]) for i in 1:3])
+    Lattice([Array(bohr_to_A .* lattice[:, i]) for i in 1:3])
 end
 pymatgen_lattice(model::Model) = pymatgen_lattice(model.lattice)
 
 
 function pymatgen_structure(model_or_lattice, atoms)
-    mg = pyimport("pymatgen")
     pylattice = pymatgen_lattice(model_or_lattice)
 
     n_species = sum(length(pos) for (spec, pos) in atoms)
@@ -28,17 +27,19 @@ function pymatgen_structure(model_or_lattice, atoms)
     end
     @assert ispec == n_species + 1
 
-    mg.Structure(pylattice, pyspecies, pypositions)
+    Structure = pyimport("pymatgen.core.structure").Structure
+    Structure(pylattice, pyspecies, pypositions)
 end
 pymatgen_structure(model::Model) = pymatgen_structure(model, model.atoms)
 
 
 function load_lattice_pymatgen(T, pyobj::PyObject)
-    mg = pyimport("pymatgen")
+    Structure = pyimport("pymatgen.core.structure").Structure
+    Lattice   = pyimport("pymatgen.core.lattice").Lattice
 
-    if pyisinstance(pyobj, mg.Structure)
+    if pyisinstance(pyobj, Structure)
         load_lattice_pymatgen(T, pyobj.lattice)
-    elseif pyisinstance(pyobj, mg.Lattice)
+    elseif pyisinstance(pyobj, Lattice)
         lattice = Matrix{T}(undef, 3, 3)
         for i in 1:3, j in 1:3
             lattice[i, j] = austrip(get(get(pyobj.matrix, j-1), i-1) * u"Å")
@@ -55,7 +56,7 @@ Load a DFTK-compatible atoms representation from a supported pymatgen object.
 All atoms are using a Coulomb model.
 """
 function load_atoms_pymatgen(T, pyobj::PyObject)
-    @assert pyisinstance(pyobj, pyimport("pymatgen").Structure)
+    @assert pyisinstance(pyobj, pyimport("pymatgen.core.structure").Structure)
     map(unique(pyobj.species)) do spec
         coords = [s.frac_coords for s in pyobj.sites if s.specie == spec]
         ElementCoulomb(spec.number) => coords

--- a/src/external/vtkio.jl
+++ b/src/external/vtkio.jl
@@ -1,5 +1,3 @@
-import WriteVTK: vtk_grid, vtk_save
-
 @doc raw"""
     save_scfres(filename, scfres, Val(:vtk))
 
@@ -30,7 +28,7 @@ function save_scfres_master(filename::AbstractString, scfres::NamedTuple, ::Val{
     for (idcs, r) in zip(CartesianIndices(basis.fft_size), r_vectors_cart(basis))
         grid[:, Tuple(idcs)...] = r
     end
-    vtkfile = vtk_grid(filename, grid)
+    vtkfile = WriteVTK.vtk_grid(filename, grid)
 
     # Storing the bloch waves
     if save_ψ
@@ -67,5 +65,5 @@ function save_scfres_master(filename::AbstractString, scfres::NamedTuple, ::Val{
         vtkfile[key] = value
     end
 
-    only(vtk_save(vtkfile))
+    only(WriteVTK.vtk_save(vtkfile))
 end

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -1,5 +1,3 @@
-import Plots
-
 # This is needed to flag that the plots-dependent code has been loaded
 const PLOTS_LOADED = true
 

--- a/test/external_pymatgen.jl
+++ b/test/external_pymatgen.jl
@@ -6,8 +6,8 @@ using UnitfulAtomic
 using PyCall
 
 py"""
-import numpy as np
-import pymatgen as mg
+from pymatgen.core.lattice import Lattice
+from pymatgen.core.structure import Structure
 """
 
 @testset "Lattice DFTK -> pymatgen -> DFTK" begin
@@ -18,7 +18,7 @@ end
 
 @testset "Lattice pymatgen -> DFTK -> pymatgen" begin
     data = randn(9)
-    reference = py"mg.Lattice($data)"
+    reference = py"Lattice($data)"
     output = pymatgen_lattice(load_lattice(reference))
     output = py"$output.matrix.ravel()" .+ 0
     @test data ≈ output atol=1e-14
@@ -41,11 +41,11 @@ end
 
 @testset "Structure pymatgen -> DFTK -> pymatgen" begin
     data = randn(9)
-    reflattice = py"mg.Lattice($data)"
+    reflattice = py"Lattice($data)"
     species = [1, 1, 6, 6, 6, 8]
     positions = [randn(3), randn(3), randn(3), randn(3), randn(3), randn(3)]
 
-    reference = py"mg.Structure($reflattice, $species, $positions)"
+    reference = py"Structure($reflattice, $species, $positions)"
     atoms = load_atoms(reference)
     @test length(atoms) == 3
     @test all(at isa ElementCoulomb for (at, positions) in atoms)


### PR DESCRIPTION
Gets rid of the annoying warnings when Plots, JLD2, WriteVTK or NCDatasets are used with DFTK.

Also fixes tests by moving forward to requiring Julia 1.5 (same as many major packages).

Closes #418.