### PR TITLE
Remove remaining from_fourier

### DIFF
--- a/src/guess_density.jl
+++ b/src/guess_density.jl
@@ -78,7 +78,7 @@ and are placed at `position` (in fractional coordinates).
 """
 function gaussian_superposition(basis::PlaneWaveBasis{T}, gaussians) where {T}
     ρ = zeros(complex(T), basis.fft_size)
-    isempty(gaussians) && return from_fourier(basis, ρ)
+    isempty(gaussians) && return G_to_r(basis, ρ)
 
     # Fill ρ with the (unnormalized) Fourier transform, i.e. ∫ e^{-iGx} f(x) dx,
     # where f(x) is a weighted gaussian

--- a/test/external_potential.jl
+++ b/test/external_potential.jl
@@ -1,0 +1,32 @@
+using DFTK
+using Test
+
+@testset "Externel potential from Fourier coefficients" begin
+    function pot(G)
+        if G == 0
+            return 0.0
+        else
+            1. / (abs(G))
+        end
+    end
+
+    a = 10
+    lattice = a .* [[1 0 0.]; [0 0 0]; [0 0 0]];
+
+    C = 1.0
+    α = 2;
+
+    n_electrons = 1
+    terms = [Kinetic(),
+             ExternalFromFourier(G -> pot(G[1])),
+             PowerNonlinearity(C, α),
+    ]
+    model = Model(lattice; n_electrons=n_electrons, terms=terms,
+                  spin_polarization=:spinless);  # use "spinless electrons"
+
+    Ecut = 15
+    basis = PlaneWaveBasis(model, Ecut, kgrid=(1, 1, 1))
+    scfres_dm = direct_minimization(basis, tol=1e-10)
+    scfres_scf = self_consistent_field(basis, tol=1e-10)
+    @test norm(scfres_scf.energies.total - scfres_dm.energies.total) < 1e-6
+end

--- a/test/external_potential.jl
+++ b/test/external_potential.jl
@@ -2,25 +2,20 @@ using DFTK
 using Test
 
 @testset "Externel potential from Fourier coefficients" begin
+    lattice = [[10 0 0.]; [0 0 0]; [0 0 0]]
+
     pot(G) = G == 0 ? zero(G) : 1 / abs(G)
-
-    a = 10
-    lattice = a * [[1 0 0.]; [0 0 0]; [0 0 0]]
-
     C = 1
     α = 2
-
-    n_electrons = 1
     terms = [Kinetic(),
              ExternalFromFourier(G -> pot(G[1])),
              PowerNonlinearity(C, α),
     ]
-    model = Model(lattice; n_electrons=n_electrons, terms=terms,
-                  spin_polarization=:spinless)  # use "spinless electrons"
+    model = Model(lattice; n_electrons=1, terms=terms, spin_polarization=:spinless)
 
     Ecut = 15
     basis = PlaneWaveBasis(model, Ecut, kgrid=(1, 1, 1))
     scfres_dm = direct_minimization(basis, tol=1e-10)
     scfres_scf = self_consistent_field(basis, tol=1e-10)
-    @test norm(scfres_scf.energies.total - scfres_dm.energies.total) < 1e-6
+    @test abs(scfres_scf.energies.total - scfres_dm.energies.total) < 1e-6
 end

--- a/test/external_potential.jl
+++ b/test/external_potential.jl
@@ -1,6 +1,7 @@
 using DFTK
 using Test
 
+if mpi_nprocs() == 1  # Direct minimisation does not yet support MPI
 @testset "Externel potential from Fourier coefficients" begin
     lattice = [[10 0 0.]; [0 0 0]; [0 0 0]]
 
@@ -18,4 +19,5 @@ using Test
     scfres_dm = direct_minimization(basis, tol=1e-10)
     scfres_scf = self_consistent_field(basis, tol=1e-10)
     @test abs(scfres_scf.energies.total - scfres_dm.energies.total) < 1e-6
+end
 end

--- a/test/external_potential.jl
+++ b/test/external_potential.jl
@@ -2,19 +2,13 @@ using DFTK
 using Test
 
 @testset "Externel potential from Fourier coefficients" begin
-    function pot(G)
-        if G == 0
-            return 0.0
-        else
-            1. / (abs(G))
-        end
-    end
+    pot(G) = G == 0 ? zero(G) : 1 / abs(G)
 
     a = 10
-    lattice = a .* [[1 0 0.]; [0 0 0]; [0 0 0]];
+    lattice = a * [[1 0 0.]; [0 0 0]; [0 0 0]]
 
-    C = 1.0
-    α = 2;
+    C = 1
+    α = 2
 
     n_electrons = 1
     terms = [Kinetic(),
@@ -22,7 +16,7 @@ using Test
              PowerNonlinearity(C, α),
     ]
     model = Model(lattice; n_electrons=n_electrons, terms=terms,
-                  spin_polarization=:spinless);  # use "spinless electrons"
+                  spin_polarization=:spinless)  # use "spinless electrons"
 
     Ecut = 15
     basis = PlaneWaveBasis(model, Ecut, kgrid=(1, 1, 1))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,6 +51,7 @@ Random.seed!(0)
         include("scf_compare.jl")
         include("iron_lda.jl")
         include("oxygen_pbe.jl")
+        include("external_potential.jl")
     end
 
     if "all" in TAGS


### PR DESCRIPTION
There was a remaining "from_fourier" in guess_density.jl. I removed it and created a test case inspired from what lead me to this bug.