### PR TITLE
Overhaul pack/unpack routines to not assume that psi are fully occupied

### DIFF
--- a/src/PlaneWaveBasis.jl
+++ b/src/PlaneWaveBasis.jl
@@ -596,16 +596,15 @@ function pack_ψ(ψ)
     vcat([vec(ψk) for ψk in ψ]...)
 end
 
-function unpack_ψ(x, ψ_for_shape) where T
-    n_bands = size(ψ_for_shape[1], 2)
-    lengths = length.(ψ_for_shape)
+function unpack_ψ(x, sizes_ψ)
+    n_bands = sizes_ψ[1][2]
+    lengths = prod.(sizes_ψ)
     ends = cumsum(lengths)
     # We unsafe_wrap the resulting array to avoid a complicated type for ψ.
     # The resulting array is valid as long as the original x is still in live memory.
-    map(1:length(ψ_for_shape)) do ik
-        unsafe_wrap(Array{eltype(ψ_for_shape[ik])},
+    map(1:length(sizes_ψ)) do ik
+        unsafe_wrap(Array{complex(eltype(x))},
                     pointer(@views x[ends[ik]-lengths[ik]+1:ends[ik]]),
-                    size(ψ_for_shape[ik]))
-
+                    sizes_ψ[ik])
     end
 end

--- a/src/PlaneWaveBasis.jl
+++ b/src/PlaneWaveBasis.jl
@@ -591,25 +591,21 @@ end
 reinterpret_real(x) = reinterpret(real(eltype(x)), x)
 reinterpret_complex(x) = reinterpret(Complex{eltype(x)}, x)
 
-function pack_ψ(basis::PlaneWaveBasis, ψ)
+function pack_ψ(ψ)
     # TODO as an optimization, do that lazily? See LazyArrays
     vcat([vec(ψk) for ψk in ψ]...)
 end
 
-function unpack_ψ(basis::PlaneWaveBasis{T}, x) where T
-    model = basis.model
-    filled_occ = filled_occupation(model)
-    n_spin = model.n_spin_components
-    n_bands = div(model.n_electrons, n_spin * filled_occ)
-
-    lengths = length.(G_vectors.(basis.kpoints)) .* n_bands
+function unpack_ψ(x, ψ_for_shape) where T
+    n_bands = size(ψ_for_shape[1], 2)
+    lengths = length.(ψ_for_shape)
     ends = cumsum(lengths)
     # We unsafe_wrap the resulting array to avoid a complicated type for ψ.
     # The resulting array is valid as long as the original x is still in live memory.
-    map(1:length(basis.kpoints)) do ik
-        unsafe_wrap(Array{Complex{T}},
+    map(1:length(ψ_for_shape)) do ik
+        unsafe_wrap(Array{eltype(ψ_for_shape[ik])},
                     pointer(@views x[ends[ik]-lengths[ik]+1:ends[ik]]),
-                    (length(G_vectors(basis.kpoints[ik])), n_bands))
+                    size(ψ_for_shape[ik]))
 
     end
 end

--- a/src/scf/direct_minimization.jl
+++ b/src/scf/direct_minimization.jl
@@ -90,7 +90,7 @@ function direct_minimization(basis::PlaneWaveBasis{T}, ψ0;
     # we need to copy the reinterpret array here to not raise errors in Optim.jl
     # TODO raise this issue in Optim.jl
     pack(ψ) = copy(reinterpret_real(pack_ψ(ψ)))
-    unpack(x) = unpack_ψ(reinterpret_complex(x), ψ0)
+    unpack(x) = unpack_ψ(reinterpret_complex(x), size.(ψ0))
 
     # this will get updated along the iterations
     H = nothing

--- a/src/scf/direct_minimization.jl
+++ b/src/scf/direct_minimization.jl
@@ -89,8 +89,8 @@ function direct_minimization(basis::PlaneWaveBasis{T}, ψ0;
 
     # we need to copy the reinterpret array here to not raise errors in Optim.jl
     # TODO raise this issue in Optim.jl
-    pack(ψ) = copy(reinterpret_real(pack_ψ(basis, ψ)))
-    unpack(x) = unpack_ψ(basis, reinterpret_complex(x))
+    pack(ψ) = copy(reinterpret_real(pack_ψ(ψ)))
+    unpack(x) = unpack_ψ(reinterpret_complex(x), ψ0)
 
     # this will get updated along the iterations
     H = nothing

--- a/src/scf/newton.jl
+++ b/src/scf/newton.jl
@@ -117,13 +117,16 @@ Return δψ where (Ω+K) δψ = rhs
 function solve_ΩplusK(basis::PlaneWaveBasis{T}, ψ, rhs, occupation;
                      tol_cg=1e-10, verbose=false) where T
     @assert mpi_nprocs() == 1  # Distributed implementation not yet available
+    filled_occ = filled_occupation(basis.model)
+    # for now, all orbitals have to be fully occupied -> need to strip them beforehand
+    @assert all(all(occ_k .== filled_occ) for occ_k in occupation)
 
     # compute quantites at the point which define the tangent space
     ρ = compute_density(basis, ψ, occupation)
     _, H = energy_hamiltonian(basis, ψ, occupation; ρ=ρ)
 
-    pack(ψ) = reinterpret_real(pack_ψ(basis, ψ))
-    unpack(x) = unpack_ψ(basis, reinterpret_complex(x))
+    pack(ψ) = reinterpret_real(pack_ψ(ψ))
+    unpack(x) = unpack_ψ(reinterpret_complex(x), ψ)
 
     # project rhs on the tangent space before starting
     proj_tangent!(rhs, ψ)

--- a/src/scf/newton.jl
+++ b/src/scf/newton.jl
@@ -126,7 +126,7 @@ function solve_ΩplusK(basis::PlaneWaveBasis{T}, ψ, rhs, occupation;
     _, H = energy_hamiltonian(basis, ψ, occupation; ρ=ρ)
 
     pack(ψ) = reinterpret_real(pack_ψ(ψ))
-    unpack(x) = unpack_ψ(reinterpret_complex(x), ψ)
+    unpack(x) = unpack_ψ(reinterpret_complex(x), size.(ψ))
 
     # project rhs on the tangent space before starting
     proj_tangent!(rhs, ψ)

--- a/test/compute_jacobian_eigen.jl
+++ b/test/compute_jacobian_eigen.jl
@@ -20,8 +20,8 @@ if mpi_nprocs() == 1  # Distributed implementation not yet available
 
         occupation = [filled_occ * ones(T, n_bands) for kpt = basis.kpoints]
 
-        pack(ψ) = reinterpret_real(pack_ψ(basis, ψ))
-        unpack(x) = unpack_ψ(basis, reinterpret_complex(x))
+        pack(ψ) = reinterpret_real(pack_ψ(ψ))
+        unpack(x) = unpack_ψ(reinterpret_complex(x), size.(ψ))
 
         # compute quantites at the point which define the tangent space
         ρ = compute_density(basis, ψ, occupation)


### PR DESCRIPTION
Will need this for finite temperature, and came up as a confusing error with @niklasschmitz 