### PR TITLE
Simplify loading logic for ForwardDiff workarounds

### DIFF
--- a/src/DFTK.jl
+++ b/src/DFTK.jl
@@ -172,24 +172,22 @@ include("postprocess/chi0.jl")
 export compute_current
 include("postprocess/current.jl")
 
+# ForwardDiff workarounds
+include("workarounds/dummy_inplace_fft.jl")
+include("workarounds/forwarddiff_rules.jl")
+
 function __init__()
     # Use "@require" to only include fft_generic.jl once IntervalArithmetic or
     # DoubleFloats has been loaded (via a "using" or an "import").
     # See https://github.com/JuliaPackaging/Requires.jl for details.
     #
-    # The global variables GENERIC_FFT_LOADED and DUMMY_INPLACE_LOADED
-    # make sure that things are only included once.
-    @require ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210" begin
-        !isdefined(DFTK, :DUMMY_INPLACE_LOADED) && include("workarounds/dummy_inplace_fft.jl")
-        include("workarounds/forwarddiff_rules.jl")
-    end
+    # The global variable GENERIC_FFT_LOADED makes sure that things are
+    # only included once.
     @require IntervalArithmetic="d1acc4aa-44c8-5952-acd4-ba5d80a2a253" begin
         include("workarounds/intervals.jl")
-        !isdefined(DFTK, :DUMMY_INPLACE_LOADED) && include("workarounds/dummy_inplace_fft.jl")
         !isdefined(DFTK, :GENERIC_FFT_LOADED) && include("workarounds/fft_generic.jl")
     end
     @require DoubleFloats="497a8b3b-efae-58df-a0af-a86822472b78" begin
-        !isdefined(DFTK, :DUMMY_INPLACE_LOADED) && include("workarounds/dummy_inplace_fft.jl")
         !isdefined(DFTK, :GENERIC_FFT_LOADED) && include("workarounds/fft_generic.jl")
     end
     @require Plots="91a5bcdd-55d7-5caf-9e0b-520d859cae80" include("plotting.jl")

--- a/src/workarounds/dummy_inplace_fft.jl
+++ b/src/workarounds/dummy_inplace_fft.jl
@@ -1,6 +1,3 @@
-# This is needed to flag that the dummy_inplace_fft.jl file has already been loaded
-const DUMMY_INPLACE_LOADED = true
-
 # A dummy wrapper around an out-of-place FFT plan to make it appear in-place
 # This is needed for some generic FFT implementations, which do not have in-place plans
 struct DummyInplace{opFFT}


### PR DESCRIPTION
@niklasschmitz I just realised that we hard depend on ForwardDiff (for other reasons) and thus that we *always* load the fallbacks anyway, so we might as well get rid of this involved logic.