### PR TITLE
Remove deprecated PlaneWaveBasis constructor

### DIFF
--- a/docs/src/guide/input_output.jl
+++ b/docs/src/guide/input_output.jl
@@ -45,7 +45,7 @@ atoms = [ElementPsp(el.symbol, psp=load_psp(el.symbol, functional="pbe")) => pos
 # Finally we run the calculation.
 
 model = model_LDA(lattice, atoms, magnetic_moments=magnetic_moments, temperature=0.01)
-basis = PlaneWaveBasis(model, 10; kgrid=(2, 2, 2))
+basis = PlaneWaveBasis(model; Ecut=10, kgrid=(2, 2, 2))
 ρ0 = guess_density(basis, magnetic_moments)
 scfres = self_consistent_field(basis, tol=1e-4, ρ=ρ0, mixing=KerkerMixing());
 

--- a/examples/arbitrary_floattype.jl
+++ b/examples/arbitrary_floattype.jl
@@ -34,8 +34,7 @@ atoms = [Si => [ones(3)/8, -ones(3)/8]]
 
 ## Cast to Float32, setup model and basis
 model = model_DFT(Array{Float32}(lattice), atoms, [:lda_x, :lda_c_vwn])
-Ecut = 7
-basis = PlaneWaveBasis(model, Ecut, kgrid=[4, 4, 4])
+basis = PlaneWaveBasis(model, Ecut=7, kgrid=[4, 4, 4])
 
 ## Run the SCF
 scfres = self_consistent_field(basis, tol=1e-4);

--- a/examples/cohen_bergstresser.jl
+++ b/examples/cohen_bergstresser.jl
@@ -16,9 +16,8 @@ lattice = Si.lattice_constant / 2 .* [[0 1 1.]; [1 0 1.]; [1 1 0.]]
 atoms = [Si => [ones(3)/8, -ones(3)/8]];
 
 # Next we build the rather simple model and discretise it with moderate `Ecut`:
-Ecut = 10.0
 model = Model(lattice; atoms=atoms, terms=[Kinetic(), AtomicLocal()])
-basis = PlaneWaveBasis(model, Ecut, kgrid=(1, 1, 1));
+basis = PlaneWaveBasis(model, Ecut=10.0, kgrid=(1, 1, 1));
 
 # We diagonalise at the Gamma point to find a Fermi level ...
 ham = Hamiltonian(basis)

--- a/examples/graphene.jl
+++ b/examples/graphene.jl
@@ -5,25 +5,26 @@
 #
 
 using DFTK
+setup_threading()
 
 kgrid = [12, 12, 4]
-Tsmear = 0.0009500431544769484
 Ecut = 15
 
-lattice = [4.659533614391621 -2.3297668071958104 0.0;
-           0.0 4.035274479829987 0.0;
-           0.0 0.0 15.117809010356462]
+lattice = [4.66 -2.33 0.00;
+           0.00  4.04 0.00
+           0.00  0.00 15.12]
 C = ElementPsp(:C, psp=load_psp("hgh/pbe/c-q4"))
-atoms = [C => [[0.0, 0.0, 0.0], [0.33333333333, 0.66666666667, 0.0]]]
+atoms = [C => [[0.0, 0.0, 0.0], [1//3, 2//3, 0.0]]]
 
-model = model_DFT(lattice, atoms, [:gga_x_pbe, :gga_c_pbe];
-                  temperature=Tsmear, smearing=Smearing.Gaussian())
-basis = PlaneWaveBasis(model, Ecut, kgrid=kgrid)
+model = model_PBE(lattice, atoms; temperature=1e-3, smearing=Smearing.Gaussian())
+basis = PlaneWaveBasis(model; Ecut, kgrid)
 
 # Run SCF
-n_bands = 6
-scfres = self_consistent_field(basis; n_bands=n_bands)
+scfres = self_consistent_field(basis)
+
+println("Carbon forces:")
+println(compute_forces(scfres)[1])
 
 # Print obtained energies
 println()
-display(scfres.energies)
+println(scfres.energies)

--- a/examples/gross_pitaevskii_2D.jl
+++ b/examples/gross_pitaevskii_2D.jl
@@ -36,6 +36,6 @@ terms = [Kinetic(),
 ]
 model = Model(lattice; n_electrons=n_electrons,
               terms=terms, spin_polarization=:spinless)  # "spinless electrons"
-basis = PlaneWaveBasis(model, Ecut, kgrid=(1, 1, 1))
+basis = PlaneWaveBasis(model; Ecut, kgrid=(1, 1, 1))
 scfres = direct_minimization(basis, tol=1e-5)  # Reduce tol for production
 heatmap(scfres.ρ[:, :, 1, 1], c=:blues)

--- a/examples/pymatgen.jl
+++ b/examples/pymatgen.jl
@@ -27,7 +27,7 @@ atoms = [Si => [s.frac_coords for s in pystruct.sites]];
 # Setup an LDA model and discretize using
 # a single kpoint and a small `Ecut` of 5 Hartree.
 model = model_LDA(lattice, atoms)
-basis = PlaneWaveBasis(model, 5, kgrid=(1, 1, 1))
+basis = PlaneWaveBasis(model; Ecut=5, kgrid=(1, 1, 1))
 
 # Find the ground state using direct minimisation (always using SCF is boring ...)
 scfres = direct_minimization(basis, tol=1e-5);

--- a/src/PlaneWaveBasis.jl
+++ b/src/PlaneWaveBasis.jl
@@ -333,9 +333,6 @@ function PlaneWaveBasis(model::Model;
                    kgrid, kshift, kwargs...)
 end
 
-PlaneWaveBasis(model::Model, Ecut; kwargs...) = PlaneWaveBasis(model; Ecut, kwargs...)
-@deprecate PlaneWaveBasis(model, Ecut; kwargs...) PlaneWaveBasis(model; Ecut, kwargs...)
-
 """
 Return the list of wave vectors (integer coordinates) for the cubic basis set.
 """

--- a/test/compute_jacobian_eigen.jl
+++ b/test/compute_jacobian_eigen.jl
@@ -75,7 +75,7 @@ if mpi_nprocs() == 1  # Distributed implementation not yet available
 
             Si = ElementPsp(silicon.atnum, psp=load_psp(silicon.psp))
             model = model_atomic(silicon.lattice, [Si => silicon.positions])
-            basis = PlaneWaveBasis(model, Ecut, kgrid=[1,1,1])
+            basis = PlaneWaveBasis(model; Ecut, kgrid=[1,1,1])
 
             scfres = self_consistent_field(basis; tol=tol)
             ψ = select_occupied_orbitals(basis, scfres.ψ)
@@ -95,7 +95,7 @@ if mpi_nprocs() == 1  # Distributed implementation not yet available
 
             Si = ElementPsp(silicon.atnum, psp=load_psp(silicon.psp))
             model = model_LDA(silicon.lattice, [Si => silicon.positions])
-            basis = PlaneWaveBasis(model, Ecut, kgrid=[1,1,1])
+            basis = PlaneWaveBasis(model; Ecut, kgrid=[1,1,1])
 
             scfres = self_consistent_field(basis; tol=tol)
             ψ = select_occupied_orbitals(basis, scfres.ψ)

--- a/test/diag_compare.jl
+++ b/test/diag_compare.jl
@@ -12,7 +12,7 @@ using DFTK
     Ecut = 100
     lattice = Float64[5 0 0; 0 0 0; 0 0 0]
     model = Model(lattice, n_electrons=4, terms=[Kinetic()])
-    basis = PlaneWaveBasis(model, Ecut, kgrid=(1, 1, 1))
+    basis = PlaneWaveBasis(model; Ecut, kgrid=(1, 1, 1))
     ham = Hamiltonian(basis)
     reference = merge(diagonalize_all_kblocks(diag_full, ham, 6), (ham=ham,))
 

--- a/test/external_potential.jl
+++ b/test/external_potential.jl
@@ -15,7 +15,7 @@ if mpi_nprocs() == 1  # Direct minimisation does not yet support MPI
     model = Model(lattice; n_electrons=1, terms=terms, spin_polarization=:spinless)
 
     Ecut = 15
-    basis = PlaneWaveBasis(model, Ecut, kgrid=(1, 1, 1))
+    basis = PlaneWaveBasis(model; Ecut, kgrid=(1, 1, 1))
     scfres_dm = direct_minimization(basis, tol=1e-10)
     scfres_scf = self_consistent_field(basis, tol=1e-10)
     @test abs(scfres_scf.energies.total - scfres_dm.energies.total) < 1e-6

--- a/test/helium_all_electron.jl
+++ b/test/helium_all_electron.jl
@@ -7,7 +7,7 @@ using LinearAlgebra
         lattice = 10 * Matrix{Float64}(I, 3, 3)
         atoms = [ElementCoulomb(:He) => [zeros(3)]]
         model = model_DFT(lattice, atoms, [], n_electrons=2)
-        basis = PlaneWaveBasis(model, Ecut, kgrid=(1, 1, 1))
+        basis = PlaneWaveBasis(model; Ecut, kgrid=(1, 1, 1))
 
         is_converged = DFTK.ScfConvergenceDensity(tol)
         scfres = self_consistent_field(basis, is_converged=is_converged)

--- a/test/interval_arithmetic.jl
+++ b/test/interval_arithmetic.jl
@@ -16,7 +16,7 @@ function discretized_hamiltonian(T, testcase)
     # For interval arithmetic to give useful numbers,
     # the fft_size should be a power of 2
     fft_size = nextpow.(2, compute_fft_size(model.lattice, Ecut))
-    basis = PlaneWaveBasis(model, Ecut, kgrid=(1, 1, 1), fft_size=fft_size)
+    basis = PlaneWaveBasis(model; Ecut, kgrid=(1, 1, 1), fft_size=fft_size)
 
     Hamiltonian(basis; ρ=guess_density(basis))
 end

--- a/test/serialisation.jl
+++ b/test/serialisation.jl
@@ -44,7 +44,7 @@ end
                       magnetic_moments=magnetic_moments, symmetries=false)
 
     kgrid = [1, mpi_nprocs(), 1]   # Ensure at least 1 kpt per process
-    basis  = PlaneWaveBasis(model, 4; kgrid=kgrid)
+    basis  = PlaneWaveBasis(model; Ecut=4, kgrid=kgrid)
 
     # Run SCF and do checkpointing along the way
     mktempdir() do tmpdir


### PR DESCRIPTION
Next release will be breaking anyway (because of #509 and #483), so we might as well do some cleanup.