### PR TITLE
Fix spglib wrapper bug (wrong transpose)

### DIFF
--- a/docs/src/advanced/conventions.md
+++ b/docs/src/advanced/conventions.md
@@ -67,8 +67,9 @@ auconvert(Å, 1.2)  # 1.2 Bohr in Ångström
 
 ## [Lattices and lattice vectors](@id conventions-lattice)
 Both the real-space lattice (i.e. `model.lattice`) and reciprocal-space lattice
-(`model.recip_lattice`) contain the lattice vectors in columns. If 1D or 2D
-problems are to be treated these arrays are still ``3 \times 3`` matrices,
+(`model.recip_lattice`) contain the lattice vectors in columns.
+For example, `model.lattice[:, 1]` is the first real-space lattice vector.
+If 1D or 2D problems are to be treated these arrays are still ``3 \times 3`` matrices,
 but contain two or one zero-columns, respectively.
 The real-space lattice vectors are sometimes referred to by ``A`` and the
 reciprocal-space lattice vectors by ``B = 2\pi A^{-T}``.

--- a/src/external/spglib.jl
+++ b/src/external/spglib.jl
@@ -185,9 +185,9 @@ function get_spglib_lattice(model; to_primitive=false)
     #      Essentially this does not influence the standardisation,
     #      but it only influences the kpath.
     spg_positions, spg_numbers, _ = spglib_atoms(model.atoms)
-    structure = Spglib.Cell(transpose(model.lattice), spg_positions, spg_numbers)
+    structure = Spglib.Cell(model.lattice, spg_positions, spg_numbers)
     spglib_lattice = Spglib.standardize_cell(structure, to_primitive=to_primitive).lattice
-    Matrix(copy(spglib_lattice'))
+    Matrix(spglib_lattice)
 end
 
 
@@ -196,7 +196,7 @@ function spglib_spacegroup_number(model)
     # TODO Time-reversal symmetry disabled? (not yet available in DFTK)
     # TODO Are magnetic moments passed?
     spg_positions, spg_numbers, _ = spglib_atoms(model.atoms)
-    structure = Spglib.Cell(transpose(model.lattice), spg_positions, spg_numbers)
+    structure = Spglib.Cell(model.lattice, spg_positions, spg_numbers)
     spacegroup_number = Spglib.get_spacegroup_number(structure)
     spacegroup_number
 end

--- a/src/external/spglib.jl
+++ b/src/external/spglib.jl
@@ -1,6 +1,8 @@
 # Routines for interaction with spglib
 # Note: spglib/C uses the row-major convention, thus we need to perform transposes
 #       between julia and spglib (https://spglib.github.io/spglib/variable.html)
+#       In contrast, Spglib.jl follows the spglib/python convention, which is the one used
+#       in DFTK. So, when calling Spglib functions, we do not perform transposes.
 import Spglib
 const SPGLIB = spglib_jll.libsymspg
 
@@ -186,8 +188,7 @@ function get_spglib_lattice(model; to_primitive=false)
     #      but it only influences the kpath.
     spg_positions, spg_numbers, _ = spglib_atoms(model.atoms)
     structure = Spglib.Cell(model.lattice, spg_positions, spg_numbers)
-    spglib_lattice = Spglib.standardize_cell(structure, to_primitive=to_primitive).lattice
-    Matrix(spglib_lattice)
+    Matrix(Spglib.standardize_cell(structure, to_primitive=to_primitive).lattice)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,7 @@ Random.seed!(0)
         include("elements.jl")
         include("bzmesh.jl")
         include("bzmesh_symmetry.jl")
+        include("spglib.jl")
         include("external_pymatgen.jl")
         include("external_ase.jl")
     end

--- a/test/spglib.jl
+++ b/test/spglib.jl
@@ -1,0 +1,72 @@
+using DFTK
+using LinearAlgebra
+using Test
+
+@testset "spglib" begin
+    a = 10.3
+    Si = ElementPsp(:Si, psp=load_psp("hgh/lda/Si-q4"))
+    Ge = ElementPsp(:Ge, psp=load_psp("hgh/lda/Ge-q4"))
+
+    # silicon
+    lattice = a / 2 * [[0 1 1.]; [1 0 1.]; [1 1 0.]]
+    atoms = [Si => [ones(3)/8, -ones(3)/8]]
+    model = model_LDA(lattice, atoms)
+    @test DFTK.spglib_spacegroup_number(model) == 227
+    @test DFTK.get_spglib_lattice(model) ≈ a * I(3)
+
+    # silicon with Cartesian x coordinates flipped
+    lattice = a / 2 * [[0 -1 -1.]; [1 0 1.]; [1 1 0.]]
+    atoms = [Si => [ones(3)/8, -ones(3)/8]]
+    model = model_LDA(lattice, atoms)
+    @test DFTK.spglib_spacegroup_number(model) == 227
+    @test DFTK.get_spglib_lattice(model) ≈ a * I(3)
+
+    # silicon with different lattice vectors
+    lattice = a / 2 * [[0 1 1.]; [-1 0 1.]; [-1 1 0.]]
+    atoms = [Si => [[-1, 1, 1]/8, -[-1, 1, 1]/8]]
+    model = model_LDA(lattice, atoms)
+    @test DFTK.spglib_spacegroup_number(model) == 227
+    @test DFTK.get_spglib_lattice(model) ≈ a * I(3)
+
+    # Zincblende structure
+    lattice = a / 2 * [[0 1 1.]; [1 0 1.]; [1 1 0.]]
+    atoms = [Si => [ones(3)/8], Ge => [-ones(3)/8]]
+    model = model_LDA(lattice, atoms)
+    @test DFTK.spglib_spacegroup_number(model) == 216
+    @test DFTK.get_spglib_lattice(model) ≈ a * I(3)
+
+    # Zincblende structure with Cartesian x coordinates flipped
+    lattice = a / 2 * [[0 -1 -1.]; [1 0 1.]; [1 1 0.]]
+    atoms = [Si => [ones(3)/8], Ge => [-ones(3)/8]]
+    model = model_LDA(lattice, atoms)
+    @test DFTK.spglib_spacegroup_number(model) == 216
+    @test DFTK.get_spglib_lattice(model) ≈ a * I(3)
+
+    # Zincblende structure with different lattice vectors
+    lattice = a / 2 * [[0 1 1.]; [-1 0 1.]; [-1 1 0.]]
+    atoms = [Si => [[-1, 1, 1]/8], Ge => [-[-1, 1, 1]/8]]
+    model = model_LDA(lattice, atoms)
+    @test DFTK.spglib_spacegroup_number(model) == 216
+    @test DFTK.get_spglib_lattice(model) ≈ a * I(3)
+
+    # Hexagonal close packed lattice
+    lattice = a * [[1. -1/2 0.]; [0. sqrt(3)/2 0.]; [0. 0. sqrt(8/3)]]
+    atoms = [Si => [[0, 0, 0], [1/3, 2/3, 1/2]]]
+    model = model_LDA(lattice, atoms)
+    @test DFTK.spglib_spacegroup_number(model) == 194
+    @test DFTK.get_spglib_lattice(model) ≈ lattice
+
+    # Hexagonal close packed lattice with x coordinates flipped
+    lattice = a * [[-1. 1/2 0.]; [0. sqrt(3)/2 0.]; [0. 0. sqrt(8/3)]]
+    atoms = [Si => [[0, 0, 0], [1/3, 2/3, 1/2]]]
+    model = model_LDA(lattice, atoms)
+    @test DFTK.spglib_spacegroup_number(model) == 194
+    @test !(DFTK.get_spglib_lattice(model) ≈ lattice)
+
+    # Hexagonal close packed lattice with different lattice vectors
+    lattice = a * [[-1. -1/2 0.]; [0. sqrt(3)/2 0.]; [0. 0. sqrt(8/3)]]
+    atoms = [Si => [[0, 0, 0], [-1/3, 2/3, 1/2]]]
+    model = model_LDA(lattice, atoms)
+    @test DFTK.spglib_spacegroup_number(model) == 194
+    @test DFTK.get_spglib_lattice(model) ≈ a * [[1. -1/2 0.]; [0. sqrt(3)/2 0.]; [0. 0. sqrt(8/3)]]
+end


### PR DESCRIPTION
Closes #539

It seems that this bug (wrong transpose) was added in #496 when moving from spglib_jll to Spglib.jl.

The tests are a bit verbose but I did not have a good idea to organize them.