### PR TITLE
Band structure for non-standard lattice, cleanup

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -48,7 +48,7 @@ spglib_jll = "ac4a9f1e-bdb2-5204-990c-47c8b2f70d4e"
 [compat]
 AbstractFFTs = "1"
 AtomsBase = "0.2.2"
-Brillouin = "0.5"
+Brillouin = "0.5.4"
 ChainRulesCore = "1.15"
 Conda = "1"
 DftFunctionals = "0.2"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
+Brillouin = "23470ee3-d0df-4052-8b1a-8cbd6363e7f0"
 DFTK = "acf6eb54-70d9-11e9-0013-234b7a5f5337"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/examples/graphene.jl
+++ b/examples/graphene.jl
@@ -35,4 +35,4 @@ scfres = self_consistent_field(basis)
 ## Construct 2D path through Brillouin zone
 sgnum = 13  # Graphene space group number
 kpath = irrfbz_path(model; dim=2, sgnum)
-plot_bandstructure(scfres; kpath, kline_density=20)
+plot_bandstructure(scfres, kpath; kline_density=20)

--- a/examples/graphene.jl
+++ b/examples/graphene.jl
@@ -8,7 +8,6 @@ using DFTK
 using Unitful
 using UnitfulAtomic
 using LinearAlgebra
-import Brillouin
 
 ## Define the convergence parameters (these should be increased in production)
 L = 20  # height of the simulation box
@@ -35,6 +34,5 @@ scfres = self_consistent_field(basis)
 
 ## Construct 2D path through Brillouin zone
 sgnum = 13  # Graphene space group number
-lattice_2d = [lattice[1:2, 1], lattice[1:2, 2]]
-kpath = Brillouin.irrfbz_path(sgnum, lattice_2d, length(lattice_2d))
+kpath = irrfbz_path(model; dim=2, sgnum)
 plot_bandstructure(scfres; kpath, kline_density=20)

--- a/examples/publications/2022_cazalis.jl
+++ b/examples/publications/2022_cazalis.jl
@@ -59,30 +59,9 @@ basis = PlaneWaveBasis(model; Ecut, kgrid)
 ## Run SCF
 scfres = self_consistent_field(basis, tol=1e-10)
 
-## Choose the points of the band diagram, in reduced coordinates (in the (b1,b2) basis)
-Γ  = [0, 0, 0]
-K  = [ 1, 1, 0]/3
-Kp = [-1, 2, 0]/3
-M  = (K + Kp)/2
-kpath_coords = [Γ, K, M, Γ]
-kpath_names  = ["Γ", "K", "M", "Γ"]
-
-## Build the path
-kline_density = 20
-function build_path(k1, k2)
-    target_Δk = 1/kline_density  # the actual Δk is |k2-k1|/npt
-    npt = ceil(Int, norm(model.recip_lattice * (k2-k1)) / target_Δk)
-    [k1 + t * (k2-k1) for t in range(0, 1, length=npt)]
-end
-kcoords = []
-for i = 1:length(kpath_coords)-1
-    append!(kcoords, build_path(kpath_coords[i], kpath_coords[i+1]))
-end
-klabels = Dict(kpath_names[i] => kpath_coords[i] for i=1:length(kpath_coords))
-
-## Plot the bands
-band_data = compute_bands(basis, kcoords; n_bands=5, scfres.ρ)
-p = DFTK.plot_band_data(band_data; klabels, markersize=nothing)
+## Plot bands
+sgnum = 13  # Graphene space group number
+p = plot_bandstructure(scfres; kpath=high_symmetry_kpath(model; sgnum), n_bands=5)
 Plots.hline!(p, [scfres.εF], label="", color="black")
-Plots.ylims!(p, -Inf,Inf)
+Plots.ylims!(p, (-Inf, Inf))
 p

--- a/examples/publications/2022_cazalis.jl
+++ b/examples/publications/2022_cazalis.jl
@@ -61,7 +61,7 @@ scfres = self_consistent_field(basis, tol=1e-10)
 
 ## Plot bands
 sgnum = 13  # Graphene space group number
-p = plot_bandstructure(scfres; kpath=irrfbz_path(model; sgnum), n_bands=5)
+p = plot_bandstructure(scfres, irrfbz_path(model; sgnum); n_bands=5)
 Plots.hline!(p, [scfres.εF], label="", color="black")
 Plots.ylims!(p, (-Inf, Inf))
 p

--- a/examples/publications/2022_cazalis.jl
+++ b/examples/publications/2022_cazalis.jl
@@ -61,7 +61,7 @@ scfres = self_consistent_field(basis, tol=1e-10)
 
 ## Plot bands
 sgnum = 13  # Graphene space group number
-p = plot_bandstructure(scfres; kpath=high_symmetry_kpath(model; sgnum), n_bands=5)
+p = plot_bandstructure(scfres; kpath=irrfbz_path(model; sgnum), n_bands=5)
 Plots.hline!(p, [scfres.εF], label="", color="black")
 Plots.ylims!(p, (-Inf, Inf))
 p

--- a/src/DFTK.jl
+++ b/src/DFTK.jl
@@ -177,8 +177,8 @@ include("external/pymatgen.jl")
 include("external/stubs.jl")  # Function stubs for conditionally defined methods
 
 export compute_bands
-export high_symmetry_kpath
 export plot_bandstructure
+export irrfbz_path
 include("postprocess/band_structure.jl")
 
 export compute_forces

--- a/src/common/zeros_like.jl
+++ b/src/common/zeros_like.jl
@@ -7,3 +7,4 @@ function zeros_like(X::AbstractArray, T::Type=eltype(X), dims::Integer...=size(X
 end
 zeros_like(X::AbstractArray, dims::Integer...) = zeros_like(X, eltype(X), dims...)
 zeros_like(X::Array, T::Type=eltype(X), dims::Integer...=size(X)...) = zeros(T, dims...)
+zeros_like(X::StaticArray, T::Type=eltype(X), dims::Integer...=size(X)...) = @SArray zeros(T, dims...)

--- a/src/external/spglib.jl
+++ b/src/external/spglib.jl
@@ -56,6 +56,9 @@ function spglib_cell(lattice, atom_groups, positions, magnetic_moments)
     spg = spglib_atoms(atom_groups, positions, magnetic_moments)
     (; cell=Spglib.Cell(lattice, spg.positions, spg.numbers, spg.spins), spg.collinear)
 end
+function spglib_cell(model::Model, magnetic_moments)
+    spglib_cell(model.lattice, model.atom_groups, model.positions, magnetic_moments)
+end
 
 
 @timing function spglib_get_symmetry(lattice::AbstractMatrix{<:AbstractFloat}, atom_groups,
@@ -180,6 +183,6 @@ end
 function spglib_spacegroup_number(model, magnetic_moments=[]; tol_symmetry=SYMMETRY_TOLERANCE)
     # Get spacegroup number according to International Tables for Crystallography (ITA)
     # TODO Time-reversal symmetry disabled? (not yet available in DFTK)
-    cell, _ = spglib_cell(model.lattice, model.atom_groups, model.positions, magnetic_moments)
+    cell, _ = spglib_cell(model, magnetic_moments)
     Spglib.get_spacegroup_number(cell, tol_symmetry)
 end

--- a/src/external/wannier90.jl
+++ b/src/external/wannier90.jl
@@ -42,16 +42,16 @@ function write_w90_win(fileprefix::String, basis::PlaneWaveBasis;
         println(fp, "!"^20 * " k_points\n")
 
         if bands_plot
-            kpathdata = high_symmetry_kpath(basis.model)
-            length(kpathdata.kpath) > 1 || @warn(
+            kpath  = irrfbz_path(basis.model)
+            length(kpath.paths) > 1 || @warn(
                 "Only first kpath branch considered in write_w90_win")
-            path = kpathdata.kpath[1]
+            path = kpath.paths[1]
 
             println(fp, "begin kpoint_path")
             for i in 1:length(path)-1
                 A, B = path[i:i+1]  # write segment A -> B
-                @printf(fp, "%s %10.6f %10.6f %10.6f  ", A, round.(kpathdata.klabels[A], digits=5)...)
-                @printf(fp, "%s %10.6f %10.6f %10.6f\n", B, round.(kpathdata.klabels[B], digits=5)...)
+                @printf(fp, "%s %10.6f %10.6f %10.6f  ", A, round.(kpath.points[A], digits=5)...)
+                @printf(fp, "%s %10.6f %10.6f %10.6f\n", B, round.(kpath.points[B], digits=5)...)
             end
             println(fp, "end kpoint_path")
             println(fp, "bands_plot = true\n")

--- a/src/postprocess/band_structure.jl
+++ b/src/postprocess/band_structure.jl
@@ -100,7 +100,7 @@ end
     merge((; basis=bs_basis), select_eigenpairs_all_kblocks(eigres, 1:n_bands))
 end
 function compute_bands(basis::PlaneWaveBasis, kpath::KPathInterpolant; kwargs...)
-    compute_bands(basis, kpath_get_kcoords(kpath))
+    compute_bands(basis, kpath_get_kcoords(kpath); kwargs...)
 end
 
 

--- a/test/compute_bands.jl
+++ b/test/compute_bands.jl
@@ -169,9 +169,9 @@ end
             push!(ref_kdist, ref_kdist[end])
         end
     end
-    @test ret.kdistances ≈ ref_kdist tol=1e-14
+    @test ret.kdistances ≈ ref_kdist atol=1e-14
     @test ret.ticks.labels == ["Γ", "X", "U | K", "Γ", "L", "W", "X"]
-    @test ret.ticks.distances ≈ ref_kdist[[1, 2, 3, 5, 6, 7, 8]] tol=1e-14
+    @test ret.ticks.distances ≈ ref_kdist[[1, 2, 3, 5, 6, 7, 8]] atol=1e-14
     @test ret.kbranches == [1:3, 4:8]
 end
 

--- a/test/compute_bands.jl
+++ b/test/compute_bands.jl
@@ -23,7 +23,6 @@ if mpi_nprocs() == 1  # not easy to distribute
         [0.423076923077, 0.000000000000, 0.423076923077],
         [0.461538461538, 0.000000000000, 0.461538461538],
         [0.500000000000, 0.000000000000, 0.500000000000],
-        [0.500000000000, 0.000000000000, 0.500000000000],
         [0.531250000000, 0.062500000000, 0.531250000000],
         [0.562500000000, 0.125000000000, 0.562500000000],
         [0.593750000000, 0.187500000000, 0.593750000000],
@@ -43,7 +42,6 @@ if mpi_nprocs() == 1  # not easy to distribute
         [0.053571428571, 0.053571428571, 0.107142857143],
         [0.026785714286, 0.026785714286, 0.053571428571],
         [0.000000000000, 0.000000000000, 0.000000000000],
-        [0.000000000000, 0.000000000000, 0.000000000000],
         [0.041666666667, 0.041666666667, 0.041666666667],
         [0.083333333333, 0.083333333333, 0.083333333333],
         [0.125000000000, 0.125000000000, 0.125000000000],
@@ -56,7 +54,6 @@ if mpi_nprocs() == 1  # not easy to distribute
         [0.416666666667, 0.416666666667, 0.416666666667],
         [0.458333333333, 0.458333333333, 0.458333333333],
         [0.500000000000, 0.500000000000, 0.500000000000],
-        [0.500000000000, 0.500000000000, 0.500000000000],
         [0.500000000000, 0.472222222222, 0.527777777778],
         [0.500000000000, 0.444444444444, 0.555555555556],
         [0.500000000000, 0.416666666667, 0.583333333333],
@@ -65,7 +62,6 @@ if mpi_nprocs() == 1  # not easy to distribute
         [0.500000000000, 0.333333333333, 0.666666666667],
         [0.500000000000, 0.305555555556, 0.694444444444],
         [0.500000000000, 0.277777777778, 0.722222222222],
-        [0.500000000000, 0.250000000000, 0.750000000000],
         [0.500000000000, 0.250000000000, 0.750000000000],
         [0.500000000000, 0.208333333333, 0.708333333333],
         [0.500000000000, 0.166666666667, 0.666666666667],
@@ -76,16 +72,16 @@ if mpi_nprocs() == 1  # not easy to distribute
     ]
 
     ref_klabels = Dict(
-        "U"=>[0.625, 0.25, 0.625],
-        "W"=>[0.5, 0.25, 0.75],
-        "X"=>[0.5, 0.0, 0.5],
-        "Γ"=>[0.0, 0.0, 0.0],
-        "L"=>[0.5, 0.5, 0.5],
-        "K"=>[0.375, 0.375, 0.75]
+        :U=>[0.625, 0.25, 0.625],
+        :W=>[0.5, 0.25, 0.75],
+        :X=>[0.5, 0.0, 0.5],
+        :Γ=>[0.0, 0.0, 0.0],
+        :L=>[0.5, 0.5, 0.5],
+        :K=>[0.375, 0.375, 0.75]
     )
 
     model = model_LDA(testcase.lattice, testcase.atoms, testcase.positions)
-    kcoords, klabels, kpath = high_symmetry_kpath(model; kline_density=22.7)
+    kcoords, klabels, kpath, kbranches = high_symmetry_kpath(model; kline_density=22.7)
 
     @test length(ref_kcoords) == length(kcoords)
     for ik in 1:length(ref_kcoords)
@@ -99,18 +95,21 @@ if mpi_nprocs() == 1  # not easy to distribute
 
     @test kpath[1] == ["Γ", "X", "U"]
     @test kpath[2] == ["K", "Γ", "L", "W", "X"]
+
+    @test kbranches == [1:18, 19:60]
 end
 
 @testset "High-symmetry kpath construction for 1D system" begin
     lattice = diagm([8.0, 0, 0])
     model = Model(lattice; n_electrons=1, terms=[Kinetic()])
-    kcoords, klabels, kpath = high_symmetry_kpath(model; kline_density=20)
+    kcoords, klabels, kpath, kbranches = high_symmetry_kpath(model; kline_density=20)
 
     @test length(kcoords) == 17
     @test kcoords[1]  ≈ [-1/2, 0, 0]
     @test kcoords[9]  ≈ [   0, 0, 0]
     @test kcoords[17] ≈ [ 1/2, 0, 0]
     @test length(kpath) == 1
+    @test kbranches == [1:17]
 end
 
 @testset "Compute bands for silicon" begin
@@ -141,70 +140,51 @@ end
 
     # k coordinates simulating two band branches, Γ => X => W and U => X
     kcoords = [
-        [0.000, 0.000, 0.000],
+        [0.000, 0.000, 0.000], # Γ
         [0.250, 0.000, 0.250],
-        [0.500, 0.000, 0.500],
-        #
-        [0.500, 0.000, 0.500],
+        [0.500, 0.000, 0.500], # X
         [0.500, 0.125, 0.625],
-        [0.500, 0.250, 0.750],
+        [0.500, 0.250, 0.750], # W
         #
-        [0.625, 0.250, 0.625],
+        [0.625, 0.250, 0.625], # U
         [0.575, 0.150, 0.575],
-        [0.500, 0.000, 0.500],
+        [0.500, 0.000, 0.500], # X
     ]
     kweights = ones(9) ./ 9
     basis = PlaneWaveBasis(model, 5, kcoords, kweights)
     klabels = Dict("Γ" => [0, 0, 0], "X" => [0.5, 0.0, 0.5],
                    "W" => [0.5, 0.25, 0.75], "U" => [0.625, 0.25, 0.625])
+    kbranches = [1:5, 6:8]
 
     # Setup some dummy data
     λ = [10ik .+ collect(1:4) for ik = 1:length(kcoords)]  # Simulate 4 computed bands
     λerror = [λ[ik]./100 for ik = 1:length(kcoords)]       # ... and 4 errors
 
-    ret = DFTK.prepare_band_data((basis=basis, λ=λ, λerror=λerror), klabels=klabels)
+    ret = DFTK.prepare_band_data((basis=basis, λ=λ, λerror=λerror), klabels=klabels, kbranches=kbranches)
 
     @test ret.n_spin   == 1
-    @test ret.n_kcoord == 9
+    @test ret.n_kcoord == 8
     @test ret.n_bands  == 4
 
-    @test ret.branches[1].kindices == [1, 2, 3]
-    @test ret.branches[2].kindices == [4, 5, 6]
-    @test ret.branches[3].kindices == [7, 8, 9]
-
-    @test ret.branches[1].klabels == ("Γ", "X")
-    @test ret.branches[2].klabels == ("X", "W")
-    @test ret.branches[3].klabels == ("U", "X")
-
     for iband in 1:4
-        @test ret.branches[1].λ[:, iband, 1] == [10ik .+ iband for ik in 1:3]
-        @test ret.branches[2].λ[:, iband, 1] == [10ik .+ iband for ik in 4:6]
-        @test ret.branches[3].λ[:, iband, 1] == [10ik .+ iband for ik in 7:9]
-
-        for ibr in 1:3
-            @test ret.branches[ibr].λerror[:, iband, 1] == ret.branches[ibr].λ[:, iband, 1] ./ 100
-        end
+        @test ret.λ[:, iband, 1] == [10ik .+ iband for ik in 1:8]
+        @test ret.λerror[:, iband, 1] == ret.λ[:, iband, 1] ./ 100
     end
 
     B = model.recip_lattice
-    ref_kdist = zeros(3, 3)  # row idx is k-point, col idx is branch,
-    ikpt = 1
-    for ibr in 1:3
-        ibr != 1 && (ref_kdist[1, ibr] = ref_kdist[end, ibr-1])
-        ikpt += 1
-        for ik in 2:3
-            ref_kdist[ik, ibr] = (
-                ref_kdist[ik-1, ibr] + norm(B * (kcoords[ikpt-1] - kcoords[ikpt]))
-            )
-            ikpt += 1
+    ref_kdist = [0.0]
+    for ik in 2:8
+        if ik != 6
+            push!(ref_kdist, ref_kdist[end] + norm(B * (kcoords[ik-1] - kcoords[ik])))
+        else
+            # At ik = 6, the branch changes so kdistance does not increase.
+            push!(ref_kdist, ref_kdist[end])
         end
     end
-    for ibr in 1:3
-        @test ret.branches[ibr].kdistances == ref_kdist[:, ibr]
-    end
-
+    @test ret.kdistances == ref_kdist
     @test ret.ticks.labels == ["Γ", "X", "W | U", "X"]
-    @test ret.ticks.distances == [0.0, ref_kdist[end, 1], ref_kdist[end, 2], ref_kdist[end, 3]]
+    @test ret.ticks.distances == ref_kdist[[1, 3, 5, 8]]
+    @test ret.kbranches == kbranches
 end
 
 @testset "is_metal" begin
@@ -217,4 +197,30 @@ end
     @test !DFTK.is_metal((λ=λ, basis=basis), 2.5)
     @test DFTK.is_metal((λ=λ, basis=basis), 3.2)
 end
+
+@testset "High-symmetry kpath for nonstandard lattice" begin
+    testcase = silicon
+    spec = ElementPsp(testcase.atnum, psp=load_psp(testcase.psp))
+    lattice_standard = [0 1 1; 1 0 1; 1 1 0] .* 5.13
+    model_standard = model_LDA(lattice_standard, [spec => [ones(3)/8, -ones(3)/8]])
+
+    # Non-standard lattice parameters that describe the same system as model_standard.
+    lattice_nonstandard = copy(lattice_standard)
+    lattice_nonstandard[:, 3] .+= lattice_nonstandard[:, 1] .* 3
+    model_nonstandard = model_LDA(lattice_nonstandard,
+                                  [spec => [[-2, 1, 1]/8, -[-2, 1, 1]/8]])
+
+    data_standard = high_symmetry_kpath(model_standard)
+    data_nonstandard = high_symmetry_kpath(model_nonstandard)
+
+    # Check the k points are the same in Cartesian coordinates.
+    for (k_standard, k_nonstandard) in zip(data_standard.kcoords, data_nonstandard.kcoords)
+        @test(  model_standard.recip_lattice    * k_standard
+              ≈ model_nonstandard.recip_lattice * k_nonstandard)
+    end
+    @test Set(keys(data_standard.klabels)) == Set(keys(data_nonstandard.klabels))
+    @test data_standard.kpath == data_nonstandard.kpath
+    @test data_standard.kbranches == data_nonstandard.kbranches
 end
+end
+

--- a/test/compute_bands.jl
+++ b/test/compute_bands.jl
@@ -169,9 +169,9 @@ end
             push!(ref_kdist, ref_kdist[end])
         end
     end
-    @test ret.kdistances == ref_kdist
+    @test ret.kdistances ≈ ref_kdist tol=1e-14
     @test ret.ticks.labels == ["Γ", "X", "U | K", "Γ", "L", "W", "X"]
-    @test ret.ticks.distances == ref_kdist[[1, 2, 3, 5, 6, 7, 8]]
+    @test ret.ticks.distances ≈ ref_kdist[[1, 2, 3, 5, 6, 7, 8]] tol=1e-14
     @test ret.kbranches == [1:3, 4:8]
 end
 


### PR DESCRIPTION
As I mentioned in #533, I make some improvements to the high-symmetry k-path and band plotting routines.

### Changes
* Use the new `Brillouin.irrfbz_path(cell::Spglib.Cell)` function (https://github.com/thchr/Brillouin.jl/pull/15) that gives a k-path for non-standard unit cell, added tests.
* Drop kpoint duplication (which was needed for interfacing with pymatgen) in high_symmetry_kpath
* Simplify band structure plotting. The concept of branches is removed.

### Things to be discussed
* [x] `Brillouin.irrfbz_path(cell::Spglib.Cell)` does not work for undistorted supercells. Currently, `high_symmetry_kpath` raises an error in such as case. Is there a better option?
  * Brillouin was updated to give k path for supercells, too.

### Example: band structure of silicons with a non-standard lattice parameters
```julia
using DFTK
using Plots

Ecut = 7
kgrid = [3, 3, 3]
psp = ElementPsp(14, psp=load_psp("hgh/lda/si-q4"))

# Non-standard lattice parameters that describe the same system as model_standard.
lattice = [0 1 1; 1 0 1; 1 1 0] .* 5.13
model = model_LDA(lattice, [psp => [ones(3)/8, -ones(3)/8]])
basis = PlaneWaveBasis(model; Ecut, kgrid)
scfres = self_consistent_field(basis, tol=1e-12);
plot_bandstructure(scfres; kline_density=20)


lattice = [0 1 1; 1 0 1+3; 1 1 0+3] .* 5.13
model = model_LDA(lattice, [psp => [[-2,1,1]./8, -[-2,1,1]./8]], temperature=0.01)
basis = PlaneWaveBasis(model; Ecut, kgrid)
scfres = self_consistent_field(basis, tol=1e-12);
plot_bandstructure(scfres; kline_density=20)
```
Standard:
![image](https://user-images.githubusercontent.com/32537613/148490275-6d519f36-ba3c-48e7-8c3b-01708b24d6ff.png)

Non-standard, old code:
![image](https://user-images.githubusercontent.com/32537613/148490284-ec54103b-d060-4e90-9c8e-fe711c0c09c4.png)

Non-standard, new code:
![image](https://user-images.githubusercontent.com/32537613/148490289-7d5cf42a-f155-4598-a3ab-59498d690a14.png)