### PR TITLE
Cleanup Chi0Mixing docstrings and timings

### DIFF
--- a/examples/collinear_magnetism.jl
+++ b/examples/collinear_magnetism.jl
@@ -25,7 +25,7 @@ Ecut = 15          # kinetic energy cutoff in Hartree
 model_nospin = model_LDA(lattice, atoms, temperature=0.01)
 basis_nospin = PlaneWaveBasis(model_nospin; kgrid, Ecut)
 
-scfres_nospin = self_consistent_field(basis_nospin, tol=1e-6, mixing=KerkerMixing());
+scfres_nospin = self_consistent_field(basis_nospin, tol=1e-6, mixing=KerkerDosMixing());
 #-
 scfres_nospin.energies
 
@@ -59,7 +59,7 @@ magnetic_moments = [Fe => [4, ]];
 model = model_LDA(lattice, atoms, magnetic_moments=magnetic_moments, temperature=0.01)
 basis = PlaneWaveBasis(model; Ecut, kgrid)
 ρ0 = guess_density(basis, magnetic_moments)
-scfres = self_consistent_field(basis, tol=1e-6; ρ=ρ0, mixing=KerkerMixing());
+scfres = self_consistent_field(basis, tol=1e-6; ρ=ρ0, mixing=KerkerDosMixing());
 #-
 scfres.energies
 

--- a/src/eigen/lobpcg_hyper_impl.jl
+++ b/src/eigen/lobpcg_hyper_impl.jl
@@ -169,7 +169,7 @@ function drop!(X, tol=2eps(real(eltype(X))))
 end
 
 # Find X that is orthogonal, and B-orthogonal to Y, up to a tolerance tol.
-function ortho!(X, Y, BY; tol=2eps(real(eltype(X))))
+@timing "ortho! X vs Y" function ortho!(X, Y, BY; tol=2eps(real(eltype(X))))
     T = real(eltype(X))
     # normalize to try to cheaply improve conditioning
     Threads.@threads for i=1:size(X,2)
@@ -322,8 +322,10 @@ end
         end
         vprintln(niter, "   ", resid_history[:, niter+1])
         if precon !== I
-            precondprep!(precon, X) # update preconditioner if needed; defaults to noop
-            ldiv!(precon, new_R)
+            @timing "preconditioning" begin
+                precondprep!(precon, X) # update preconditioner if needed; defaults to noop
+                ldiv!(precon, new_R)
+            end
         end
 
         ### Compute number of locked vectors

--- a/src/scf/mixing.jl
+++ b/src/scf/mixing.jl
@@ -202,7 +202,7 @@ real space using a GMRES. Either the full kernel (`RPA=false`) or only the Hartr
     RPA::Bool = true       # Use RPA, i.e. only apply the Hartree and not the XC Kernel
     χ0terms   = χ0Model[Applyχ0Model()]  # The terms to use as the model for χ0
     verbose::Bool = false   # Run the GMRES verbosely
-    reltol::Float32 = 0.01  # Relative tolerance for GMRES
+    reltol::Float64 = 0.01  # Relative tolerance for GMRES
 end
 
 @views @timing "χ0Mixing" function mix_density(mixing::χ0Mixing, basis, δF; ρin, kwargs...)

--- a/src/terms/Hamiltonian.jl
+++ b/src/terms/Hamiltonian.jl
@@ -142,7 +142,9 @@ end
             end
         end
 
-        merge!(DFTK.timer, to; tree_point=[t.name for t in DFTK.timer.timer_stack])
+        if tid == 1
+            merge!(DFTK.timer, to; tree_point=[t.name for t in DFTK.timer.timer_stack])
+        end
     end
 
     # Apply the nonlocal operator


### PR DESCRIPTION
In my tests employing LdosMixing for potential-mixing SCF iterations actually works way worse than with density-mixing, which surprises me a bit. My suspicion it's got to do with the fact that we actually apply ε rather than ε^\dagger during the linear solve, such that we cannot benefit from the implict low-pass filtering done by the Hartree kernel. Any thoughts @antoine-levitt ?

**Edit:** I'll split the LdosMixing changes to another PR (#587) to get the the other misc. changes into master.