### PR TITLE
Fix threading

### DIFF
--- a/src/densities.jl
+++ b/src/densities.jl
@@ -22,15 +22,29 @@ grid `basis`, where the individual k-points are occupied according to `occupatio
 """
 @views @timing function compute_density(basis::PlaneWaveBasis, ψ, occupation)
     T = promote_type(eltype(basis), real(eltype(ψ[1])))
-    ρ = similar(ψ[1], T, (basis.fft_size..., basis.model.n_spin_components))
-    ρ .= 0
-    ψnk_real = zeros(complex(T), basis.fft_size)
-    for (ik, kpt) in enumerate(basis.kpoints)
-        for n = 1:size(ψ[ik], 2)
+
+    # we split the total iteration range (ik, n) in chunks, and parallelize over them
+    ik_n = [(ik, n) for ik = 1:length(basis.kpoints) for n = 1:size(ψ[ik], 2)]
+    chunk_length = cld(length(ik_n), Threads.nthreads())
+
+    # chunk-local variables
+    ρ_chunklocal = [zeros(T, basis.fft_size..., basis.model.n_spin_components)
+                    for _ = 1:Threads.nthreads()]
+    ψnk_real_chunklocal = [zeros(complex(T), basis.fft_size) for _ = 1:Threads.nthreads()]
+
+    @sync for (ichunk, chunk) in enumerate(Iterators.partition(1:total_iters, chunk_length))
+        Threads.@spawn for it in chunk  # spawn a task per chunk
+            ik, n = ik_n[it]
+            ψnk_real = ψnk_real_chunklocal[ichunk]
+            ρ_loc = ρ_chunklocal[ichunk]
+
+            kpt = basis.kpoints[ik]
             G_to_r!(ψnk_real, basis, kpt, ψ[ik][:, n])
-            ρ[:, :, :, kpt.spin] .+= occupation[ik][n] .* basis.kweights[ik] .* abs2.(ψnk_real)
+            ρ_loc[:, :, :, kpt.spin] .+= occupation[ik][n] .* basis.kweights[ik] .* abs2.(ψnk_real)
         end
     end
+
+    ρ = sum(ρ_chunklocal)
     mpi_sum!(ρ, basis.comm_kpts)
     ρ = symmetrize_ρ(basis, ρ)
 

--- a/src/densities.jl
+++ b/src/densities.jl
@@ -32,9 +32,8 @@ grid `basis`, where the individual k-points are occupied according to `occupatio
                     for _ = 1:Threads.nthreads()]
     ψnk_real_chunklocal = [zeros(complex(T), basis.fft_size) for _ = 1:Threads.nthreads()]
 
-    @sync for (ichunk, chunk) in enumerate(Iterators.partition(1:total_iters, chunk_length))
-        Threads.@spawn for it in chunk  # spawn a task per chunk
-            ik, n = ik_n[it]
+    @sync for (ichunk, chunk) in enumerate(Iterators.partition(1:length(ik_n), chunk_length))
+        Threads.@spawn for (ik, n) in chunk  # spawn a task per chunk
             ψnk_real = ψnk_real_chunklocal[ichunk]
             ρ_loc = ρ_chunklocal[ichunk]
 

--- a/src/densities.jl
+++ b/src/densities.jl
@@ -32,7 +32,7 @@ grid `basis`, where the individual k-points are occupied according to `occupatio
                     for _ = 1:Threads.nthreads()]
     ψnk_real_chunklocal = [zeros(complex(T), basis.fft_size) for _ = 1:Threads.nthreads()]
 
-    @sync for (ichunk, chunk) in enumerate(Iterators.partition(1:length(ik_n), chunk_length))
+    @sync for (ichunk, chunk) in enumerate(Iterators.partition(ik_n, chunk_length))
         Threads.@spawn for (ik, n) in chunk  # spawn a task per chunk
             ψnk_real = ψnk_real_chunklocal[ichunk]
             ρ_loc = ρ_chunklocal[ichunk]

--- a/src/terms/Hamiltonian.jl
+++ b/src/terms/Hamiltonian.jl
@@ -127,9 +127,8 @@ end
     @sync for (ichunk, chunk) in enumerate(Iterators.partition(1:n_bands, chunk_length))
         Threads.@spawn for iband in chunk # spawn a task per chunk
             to = TimerOutput()  # Thread-local timer output
-            tid = Threads.threadid()
             ψ_real = H.scratch.ψ_reals[ichunk]
-            
+
             @timeit to "local+kinetic" begin
                 G_to_r!(ψ_real, H.basis, H.kpoint, ψ[:, iband]; normalize=false)
                 ψ_real .*= potential
@@ -146,7 +145,7 @@ end
                 end
             end
 
-            if tid == 1
+            if Threads.threadid() == 1
                 merge!(DFTK.timer, to; tree_point=[t.name for t in DFTK.timer.timer_stack])
             end
        end


### PR DESCRIPTION
This applies to https://github.com/JuliaMolSim/DFTK.jl/pull/589
This fixes the threading for 1.8 by using spawn manually. It's a bit pedestrian, but not as bad as I'd feared. I do it manually because I'm not 100% sure what floops is doing, I want to ensure control over allocations and floops seems to be in flux right now, but eventually we should probably use it.
All in all this should hopefully give us a nice speedup by improving load balancing for the apply_hamiltonian and actually doing nested threading for compute_density.
@mfherbst I don't understand the timeroutput code, we should discuss it