### PR TITLE
Fix symmetrization of stresses

### DIFF
--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -245,8 +245,9 @@ end
 function symmetrize_stresses(lattice, symmetries, stresses)
     stresses_symmetrized = zero(stresses)
     for symop in symmetries
-        S_reduced = inv(lattice) * symop.S * lattice
-        stresses_symmetrized += S_reduced' * stresses * S_reduced
+        W = symop.S'
+        Wcart = lattice * W * inv(lattice)
+        stresses_symmetrized += Wcart * stresses * Wcart'
     end
     stresses_symmetrized /= length(symmetries)
     stresses_symmetrized

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -243,12 +243,14 @@ Symmetrize a density by applying all the basis (by default) symmetries and formi
 end
 # symmetrize the stress tensor, which is a rank-2 contravariant tensor in reduced coordinates
 function symmetrize_stresses(lattice, symmetries, stresses)
-    stresses_symmetrized = zero(stresses)
+    # FIXME: stresses is in Cartesian coordinates, not reduced coordinates.
+    stresses_symmetrized_reduced = zero(stresses)
+    stresses_reduced = inv(lattice) * stresses * lattice
     for symop in symmetries
         W = symop.S'
-        Wcart = lattice * W * inv(lattice)
-        stresses_symmetrized += Wcart * stresses * Wcart'
+        stresses_symmetrized_reduced += W * stresses_reduced * inv(W)
     end
+    stresses_symmetrized = lattice * stresses_symmetrized_reduced * inv(lattice)
     stresses_symmetrized /= length(symmetries)
     stresses_symmetrized
 end

--- a/test/stresses.jl
+++ b/test/stresses.jl
@@ -13,7 +13,7 @@ include("testcases.jl")
         Si = ElementPsp(silicon.atnum, psp=load_psp(silicon.psp))
         atoms = [Si => silicon.positions]
         model = model_PBE(lattice, atoms; symmetries)
-        kgrid = [3, 3, 1]
+        kgrid = [3, 3, 3]
         Ecut = 7
         PlaneWaveBasis(model; Ecut, kgrid)
     end
@@ -34,7 +34,7 @@ include("testcases.jl")
 
 
     a = 10.0  # slightly compressed
-    lattice = a / 2 * [[0 1 1.];
+    lattice = a / 2 * [[0 1 1.1];
                        [1 0 1.];
                        [1 1 0.]]
     is_converged = DFTK.ScfConvergenceDensity(1e-13)


### PR DESCRIPTION
As @antoine-levitt spotted in https://github.com/JuliaMolSim/DFTK.jl/pull/511#issuecomment-1040462597, there were several issues in my implementation of `symmetrize_stresses`.
> 1) since both the stress tensor and the symmetry operation are in reduced coordinates, why does the lattice even appear?
> 2) why do you use S (which is in reciprocal space) rather than W (which is in real space)? Did you copy the formula from somewhere or did you derive it yourself?

The problems are:
* The implementation was wrong in that a transpose is incorrectly applied to `lattice`.
* Test did not fail because lattice was symmetric. I updated the test to use non-symmetric lattice. Test fails with the old implementation but passes with the new one.
*  `S_reduced` in the previous version was actually `W_cart` (Regarding point 2, I was using W indeed, but incorrectly referred it to S.)

One thing that still needs to be discussed is the definition of stress tensor and point 1 ("why does the lattice even appear").
In https://github.com/JuliaMolSim/DFTK.jl/blob/70fc3c86a6eebcd6622cde9a540bb28b5c74ea07/src/postprocess/stresses.jl#L33, the lattice is transformed as `L=(I+M) * L`, so `M` acts on the columns of `L` which are Cartesian axis. In this case, the first lattice vector transform as `L'[i, 1] = L[i, 1] + sum_j M[i, j] * L[j, 1]`.
But the formula I found in the literature (Appendix G of Richard Martin's book) is that the lattice vector transform as `L'[i, 1] = L[i, 1] + sum_b M_Martin[a, b] * L[i, b]`, i.e. `L'_Martin = L * (I + M_Martin^T)`.
So the relation between `M` and `M_Martin` is `M = L * M_Martin^T * L^{-1}`. I think this is the reason why `lattice` appears in the symmetrization routine.