### PR TITLE
Support for multiple partials in ForwardDiff SCF

### DIFF
--- a/src/workarounds/forwarddiff_rules.jl
+++ b/src/workarounds/forwarddiff_rules.jl
@@ -199,9 +199,7 @@ function self_consistent_field(basis_dual::PlaneWaveBasis{T};
                     DT(imag(ψi), imag.(δψi)))
         end
     end
-    ρ_out = map(scfres.ρ, δρ...) do ρi, δρi...
-       DT(ρi, δρi)
-    end
+    ρ_out = map((ρi, δρi...) -> DT(ρi, δρi), scfres.ρ, δρ...)
 
     merge(scfres, (; ham=ham_dual, basis=basis_dual, energies=energies_dual, ψ=ψ_out,
                      occupation=occupation_dual, ρ=ρ_out, eigenvalues=eigenvalues_dual,

--- a/src/workarounds/forwarddiff_rules.jl
+++ b/src/workarounds/forwarddiff_rules.jl
@@ -195,10 +195,8 @@ function self_consistent_field(basis_dual::PlaneWaveBasis{T};
     DT = ForwardDiff.Dual{ForwardDiff.tagtype(T)}
     ψ_out = map(ψ, δψ...) do ψk, δψk...
         map(ψk, δψk...) do ψi, δψi...
-            Complex(
-                DT(real(ψi), real.(δψi)),
-                DT(imag(ψi), imag.(δψi)),
-            )
+            Complex(DT(real(ψi), real.(δψi)),
+                    DT(imag(ψi), imag.(δψi)))
         end
     end
     ρ_out = map(scfres.ρ, δρ...) do ρi, δρi...

--- a/src/workarounds/forwarddiff_rules.jl
+++ b/src/workarounds/forwarddiff_rules.jl
@@ -181,15 +181,15 @@ function self_consistent_field(basis_dual::PlaneWaveBasis{T};
     ## Implicit differentiation
     hamψ_dual = ham_dual * ψ_dual
     δresults = ntuple(ForwardDiff.npartials(T)) do α
-        δHψα = [ForwardDiff.partials.(δHψk, α) for δHψk in hamψ_dual]
-        δψα, responseα = solve_ΩplusK(basis, ψ, -δHψα, occupation;
-                                      tol_cg=scfres.norm_Δρ, verbose=response.verbose)
-        δρα = compute_δρ(basis, ψ, δψα, occupation)
-        δψα, δρα, responseα
+        δHψ_α = [ForwardDiff.partials.(δHψk, α) for δHψk in hamψ_dual]
+        δψ_α, response_α = solve_ΩplusK(basis, ψ, -δHψ_α, occupation;
+                                        tol_cg=scfres.norm_Δρ, verbose=response.verbose)
+        δρ_α = compute_δρ(basis, ψ, δψ_α, occupation)
+        δψ_α, δρ_α, response_α
     end
-    δψ = [δψα for (δψα, δρα, responseα) in δresults]
-    δρ = [δρα for (δψα, δρα, responseα) in δresults]
-    response = [responseα for (δψα, δρα, responseα) in δresults]
+    δψ       = [δψ_α       for (δψ_α, δρ_α, response_α) in δresults]
+    δρ       = [δρ_α       for (δψ_α, δρ_α, response_α) in δresults]
+    response = [response_α for (δψ_α, δρ_α, response_α) in δresults]
 
     ## Convert, combine and return
     DT = ForwardDiff.Dual{ForwardDiff.tagtype(T)}

--- a/src/workarounds/forwarddiff_rules.jl
+++ b/src/workarounds/forwarddiff_rules.jl
@@ -53,7 +53,7 @@ for P in [:Plan, :ScaledPlan]  # need ScaledPlan to avoid ambiguities
         Base.:*(p::AbstractFFTs.$P, x::AbstractArray{<:Complex{<:ForwardDiff.Dual}}) =
             _apply_plan(p, x)
 
-        LinearAlgebra.mul!(Y::AbstractArray, p::AbstractFFTs.$P, X::AbstractArray{<:ForwardDiff.Dual}) = 
+        LinearAlgebra.mul!(Y::AbstractArray, p::AbstractFFTs.$P, X::AbstractArray{<:ForwardDiff.Dual}) =
             (Y .= _apply_plan(p, X))
 
         LinearAlgebra.mul!(Y::AbstractArray, p::AbstractFFTs.$P, X::AbstractArray{<:Complex{<:ForwardDiff.Dual}}) =
@@ -184,8 +184,8 @@ function self_consistent_field(basis_dual::PlaneWaveBasis{T};
     δresults = ntuple(N) do j
         δHψj = [ForwardDiff.partials.(δHψₖ, j) for δHψₖ in hamψ_dual]
         δψj, responsej = solve_ΩplusK(basis, ψ, -δHψj, occupation;
-                                    tol_cg=scfres.norm_Δρ, verbose=response.verbose)
-        δρj  = compute_δρ(basis, ψ, δψj, occupation)
+                                      tol_cg=scfres.norm_Δρ, verbose=response.verbose)
+        δρj = compute_δρ(basis, ψ, δψj, occupation)
         δψj, δρj, responsej
     end
     δψ = [δψj for (δψj, δρj, responsej) in δresults]
@@ -203,9 +203,9 @@ function self_consistent_field(basis_dual::PlaneWaveBasis{T};
         end
     end
     ρ_out = map(scfres.ρ, δρ...) do ρi, δρi...
-       DT(ρi, δρi) 
+       DT(ρi, δρi)
     end
-    
+
     merge(scfres, (; ham=ham_dual, basis=basis_dual, energies=energies_dual, ψ=ψ_out,
                      occupation=occupation_dual, ρ=ρ_out, eigenvalues=eigenvalues_dual,
                      εF=εF_dual, response))

--- a/test/forwarddiff.jl
+++ b/test/forwarddiff.jl
@@ -4,9 +4,10 @@ using Test
 include("testcases.jl")
 
 @testset "Force derivatives using finite differences" begin
-    function compute_force(ε::T) where T
+    function compute_force(ε1, ε2)
+        T = promote_type(typeof(ε1), typeof(ε2))
         Si  = ElementPsp(silicon.atnum, psp=load_psp(silicon.psp))
-        pos = [[1.01, 1.02, 1.03] / 8, -ones(3) / 8 + ε * [1., 0, 0]]
+        pos = [[1.01, 1.02, 1.03] / 8, -ones(3) / 8 + ε1 * [1., 0, 0] + ε2 * [0, 1., 0]]
         atoms = [Si => pos]
         # TODO symmetries = true gives issues for now ... debug after refactoring done.
         model = model_DFT(Matrix{T}(silicon.lattice), atoms, [:lda_x, :lda_c_pw], symmetries=false)
@@ -17,9 +18,25 @@ include("testcases.jl")
         compute_forces_cart(scfres)[1]
     end
 
-    derivative_fd = let ε = 1e-5
-        (compute_force(ε) - compute_force(0.0)) / ε
+    F = compute_force(0.0)
+    derivative_ε1_fd = let ε1 = 1e-5
+        (compute_force(ε1, 0.0) - F) / ε1
     end
-    derivative = ForwardDiff.derivative(compute_force, 0.0)
-    @test maximum(maximum, derivative - derivative_fd) < 1e-4
+    derivative_ε1 = ForwardDiff.derivative(ε1 -> compute_force(ε1, 0.0), 0.0)
+    @test norm(derivative_ε1 - derivative_ε1_fd) < 1e-4
+
+    derivative_ε2_fd = let ε2 = 1e-5
+        (compute_force(0.0, ε2) - F) / ε2
+    end
+    derivative_ε2 = ForwardDiff.derivative(ε2 -> compute_force(0.0, ε2), 0.0)
+    @test norm(derivative_ε2 - derivative_ε2_fd) < 1e-4
+
+    @testset "Multiple partials" begin
+        grad = ForwardDiff.gradient(v -> compute_force(v...)[1][1], [0.0, 0.0])
+        @test abs(grad[1] - derivative_ε1[1][1]) < 1e-4
+        @test abs(grad[2] - derivative_ε2[1][1]) < 1e-4
+
+        # TODO
+        # jac = ForwardDiff.jacobian(v -> compute_force(v...), [0.0, 0.0])
+    end
 end

--- a/test/forwarddiff.jl
+++ b/test/forwarddiff.jl
@@ -18,7 +18,7 @@ include("testcases.jl")
         compute_forces_cart(scfres)[1]
     end
 
-    F = compute_force(0.0)
+    F = compute_force(0.0, 0.0)
     derivative_ε1_fd = let ε1 = 1e-5
         (compute_force(ε1, 0.0) - F) / ε1
     end


### PR DESCRIPTION
This PR adds support for multiple partials in the ForwardDiff version of `self_consistent_field`, enabling usage of `ForwardDiff.gradient` for vector parameters. For the implicit differentiation, each tangent direction is solved with `solve_ΩplusK` independently.