### PR TITLE
Using pseudo-inverse for one- and two-dimensional cells

### DIFF
--- a/src/postprocess/forces.jl
+++ b/src/postprocess/forces.jl
@@ -28,7 +28,7 @@ which has the same structure as the `atoms` object passed to the underlying [`Mo
 function compute_forces_cart(basis::PlaneWaveBasis, ψ, occ; kwargs...)
     lattice = basis.model.lattice
     forces = compute_forces(basis::PlaneWaveBasis, ψ, occ; kwargs...)
-    [[lattice \ f for f in forces_for_element] for forces_for_element in forces]
+    [[pinv(lattice)*f for f in forces_for_element] for forces_for_element in forces]
 end
 
 function compute_forces(scfres)

--- a/src/postprocess/forces.jl
+++ b/src/postprocess/forces.jl
@@ -28,7 +28,8 @@ which has the same structure as the `atoms` object passed to the underlying [`Mo
 function compute_forces_cart(basis::PlaneWaveBasis, ψ, occ; kwargs...)
     lattice = basis.model.lattice
     forces = compute_forces(basis::PlaneWaveBasis, ψ, occ; kwargs...)
-    [[pinv(lattice)*f for f in forces_for_element] for forces_for_element in forces]
+    pinv_lattice = pinv(lattice)
+    [[pinv_lattice * f for f in forces_for_element] for forces_for_element in forces]
 end
 
 function compute_forces(scfres)

--- a/src/postprocess/forces.jl
+++ b/src/postprocess/forces.jl
@@ -28,8 +28,8 @@ which has the same structure as the `atoms` object passed to the underlying [`Mo
 function compute_forces_cart(basis::PlaneWaveBasis, ψ, occ; kwargs...)
     lattice = basis.model.lattice
     forces = compute_forces(basis::PlaneWaveBasis, ψ, occ; kwargs...)
-    pinv_lattice = pinv(lattice)
-    [[pinv_lattice * f for f in forces_for_element] for forces_for_element in forces]
+    inv_lattice = compute_inverse_lattice(lattice)
+    [[inv_lattice * f for f in forces_for_element] for forces_for_element in forces]
 end
 
 function compute_forces(scfres)

--- a/src/structure.jl
+++ b/src/structure.jl
@@ -1,21 +1,29 @@
 """
-Compute the reciprocal lattice. Takes special care of 1D or 2D cases.
-We use the convention that the reciprocal lattice is the set of G vectors such
-that G ⋅ R ∈ 2π ℤ for all R in the lattice.
+Compute the inverse of the lattice. Takes special care of 1D or 2D cases.
 """
-function compute_recip_lattice(lattice::AbstractMatrix{T}) where {T}
+function compute_inverse_lattice(lattice::AbstractMatrix{T}) where {T}
     # Note: pinv pretty much does the same, but the implied SVD causes trouble
     #       with interval arithmetic and dual numbers, so we go for this version.
     n_dim = count(!iszero, eachcol(lattice))
     @assert 1 ≤ n_dim ≤ 3
     if n_dim == 3
-        2T(π) * inv(lattice')
+        inv(lattice')
     else
-        2T(π) * Mat3{T}([
+        Mat3{T}([
             inv(lattice[1:n_dim, 1:n_dim]')   zeros(T, n_dim, 3 - n_dim);
             zeros(T, 3 - n_dim, 3)
         ])
     end
+end
+
+
+"""
+Compute the reciprocal lattice.
+We use the convention that the reciprocal lattice is the set of G vectors such
+that G ⋅ R ∈ 2π ℤ for all R in the lattice.
+"""
+function compute_recip_lattice(lattice::AbstractMatrix{T}) where {T}
+    2T(π) * compute_inverse_lattice(lattice)
 end
 
 

--- a/src/structure.jl
+++ b/src/structure.jl
@@ -7,10 +7,10 @@ function compute_inverse_lattice(lattice::AbstractMatrix{T}) where {T}
     n_dim = count(!iszero, eachcol(lattice))
     @assert 1 ≤ n_dim ≤ 3
     if n_dim == 3
-        inv(lattice')
+        inv(lattice)
     else
         Mat3{T}([
-            inv(lattice[1:n_dim, 1:n_dim]')   zeros(T, n_dim, 3 - n_dim);
+            inv(lattice[1:n_dim, 1:n_dim])   zeros(T, n_dim, 3 - n_dim);
             zeros(T, 3 - n_dim, 3)
         ])
     end
@@ -23,7 +23,7 @@ We use the convention that the reciprocal lattice is the set of G vectors such
 that G ⋅ R ∈ 2π ℤ for all R in the lattice.
 """
 function compute_recip_lattice(lattice::AbstractMatrix{T}) where {T}
-    2T(π) * compute_inverse_lattice(lattice)
+    2T(π) * compute_inverse_lattice(lattice')
 end
 
 


### PR DESCRIPTION
If the lattice has rank smaller than three, then the routine fails.