### PR TITLE
Remove coordinate_cart field from Kpoint

### DIFF
--- a/src/PlaneWaveBasis.jl
+++ b/src/PlaneWaveBasis.jl
@@ -19,7 +19,6 @@ struct Kpoint{T <: Real}
     spin::Int                     # Spin component can be 1 or 2 as index into what is
                                   # returned by the `spin_components` function
     coordinate::Vec3{T}           # Fractional coordinate of k-point
-    coordinate_cart::Vec3{T}      # Cartesian coordinate of k-point
     mapping::Vector{Int}          # Index of G_vectors[i] on the FFT grid:
                                   # G_vectors(basis)[kpt.mapping[i]] == G_vectors(basis, kpt)[i]
     mapping_inv::Dict{Int, Int}   # Inverse of `mapping`:

--- a/src/PlaneWaveBasis.jl
+++ b/src/PlaneWaveBasis.jl
@@ -131,7 +131,7 @@ Base.eltype(::PlaneWaveBasis{T}) where {T} = T
         mapping_inv = Dict(ifull => iball for (iball, ifull) in enumerate(mapping))
         for iσ = 1:model.n_spin_components
             push!(kpoints_per_spin[iσ],
-                  Kpoint(iσ, k, model.recip_lattice * k, mapping, mapping_inv, Gvecs_k))
+                  Kpoint(iσ, k, mapping, mapping_inv, Gvecs_k))
         end
     end
 

--- a/src/postprocess/band_structure.jl
+++ b/src/postprocess/band_structure.jl
@@ -139,7 +139,8 @@ function prepare_band_data(band_data; datakeys=[:λ, :λerror],
     n_bands  = nothing
 
     # Convert coordinates to Cartesian
-    kcoords_cart = [basis.kpoints[ik].coordinate_cart for ik in krange_spin(basis, 1)]
+    kcoords_cart = [basis.model.recip_lattice * basis.kpoints[ik].coordinate
+                    for ik in krange_spin(basis, 1)]
     klabels_cart = Dict(lal => basis.model.recip_lattice * vec for (lal, vec) in klabels)
 
     # Split data into branches


### PR DESCRIPTION
This PR removes the `coordinate_cart` field from `Kpoint`, which is only used in band structure. For our AD work this will mean that we can conveniently mark `build_kpoints` as non-differentiable altogether.