### PR TITLE
Make atoms and positions positional arguments of the Model

### DIFF
--- a/docs/src/guide/periodic_problems.jl
+++ b/docs/src/guide/periodic_problems.jl
@@ -217,8 +217,8 @@ lattice[1, 1] = 20.;
 
 # Step 2: Select a model. In this case we choose a free-electron model,
 # which is the same as saying that there is only a Kinetic term
-# (and no potential) in the model. The `n_electrons` argument is dummy here.
-model = Model(lattice; n_electrons=1, terms=[Kinetic()])
+# (and no potential) in the model.
+model = Model(lattice; terms=[Kinetic()])
 
 # Step 3: Define a plane-wave basis using this model and a cutoff ``E_\text{cut}``
 # of 300 Hartree. The ``k``-point grid is given as a regular grid in the BZ
@@ -316,7 +316,7 @@ atoms     = [nucleus, nucleus]
 positions = [[0.2, 0, 0], [0.8, 0, 0]]
 
 ## Assemble the model, discretize and build the Hamiltonian
-model = Model(lattice; atoms, positions, terms=[Kinetic(), AtomicLocal()])
+model = Model(lattice, atoms, positions; terms=[Kinetic(), AtomicLocal()])
 basis = PlaneWaveBasis(model; Ecut=300, kgrid=(1, 1, 1));
 ham   = Hamiltonian(basis)
 
@@ -337,7 +337,7 @@ plot(x, potential, label="", xlabel="x", ylabel="V(x)")
 using Unitful
 using UnitfulAtomic
 
-plot_bandstructure(basis; n_bands=6, kline_density=100)
+plot_bandstructure(basis; n_bands=6, kline_density=500)
 
 # The bands are noticeably different.
 #  - The bands no longer overlap, meaning that the spectrum of $H$ is no longer continuous

--- a/docs/src/guide/periodic_problems.jl
+++ b/docs/src/guide/periodic_problems.jl
@@ -217,8 +217,8 @@ lattice[1, 1] = 20.;
 
 # Step 2: Select a model. In this case we choose a free-electron model,
 # which is the same as saying that there is only a Kinetic term
-# (and no potential) in the model. The `n_electrons` is dummy here.
-model = Model(lattice; n_electrons=0, terms=[Kinetic()])
+# (and no potential) in the model. The `n_electrons` argument is dummy here.
+model = Model(lattice; n_electrons=1, terms=[Kinetic()])
 
 # Step 3: Define a plane-wave basis using this model and a cutoff ``E_\text{cut}``
 # of 300 Hartree. The ``k``-point grid is given as a regular grid in the BZ

--- a/examples/cohen_bergstresser.jl
+++ b/examples/cohen_bergstresser.jl
@@ -17,7 +17,7 @@ positions = [ones(3)/8, -ones(3)/8]
 lattice = Si.lattice_constant / 2 .* [[0 1 1.]; [1 0 1.]; [1 1 0.]]
 
 # Next we build the rather simple model and discretize it with moderate `Ecut`:
-model = Model(lattice; atoms, positions, terms=[Kinetic(), AtomicLocal()])
+model = Model(lattice, atoms, positions; terms=[Kinetic(), AtomicLocal()])
 basis = PlaneWaveBasis(model, Ecut=10.0, kgrid=(1, 1, 1));
 
 # We diagonalise at the Gamma point to find a Fermi level ...

--- a/examples/custom_potential.jl
+++ b/examples/custom_potential.jl
@@ -45,7 +45,7 @@ n_electrons = 1  # Increase this for fun
 terms = [Kinetic(),
          AtomicLocal(),
          LocalNonlinearity(ρ -> C * ρ^α)]
-model = Model(lattice; atoms, positions, n_electrons, terms,
+model = Model(lattice, atoms, positions; n_electrons, terms,
               spin_polarization=:spinless);  # use "spinless electrons"
 
 # We discretize using a moderate Ecut and run a SCF algorithm to compute forces

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -90,7 +90,7 @@ symmetries completely.
 """
 function Model(lattice::AbstractMatrix{T}, atoms=Element[], positions=Vec3{T}[];
                model_name="custom",
-               n_electrons::Int=sum(n_elec_valence, atoms),
+               n_electrons::Int=sum(n_elec_valence, atoms; init=0),
                magnetic_moments=[],
                terms=[Kinetic()],
                temperature=T(0.0),
@@ -106,7 +106,7 @@ function Model(lattice::AbstractMatrix{T}, atoms=Element[], positions=Vec3{T}[];
     if length(atoms) != length(positions)
         error("Length of atoms and positions vectors need to agree.")
     end
-    n_electrons ≤ 0 && error("n_electrons should be larger zero. Ensure to provide a " *
+    n_electrons < 0 && error("n_electrons should be non-negative. Ensure to provide a " *
                              "non-empty atoms list or an appropriate `n_electrons` kwarg.")
     isempty(terms) && error("Model without terms not supported.")
     atom_groups = [findall(Ref(pot) .== atoms) for pot in Set(atoms)]

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -106,8 +106,8 @@ function Model(lattice::AbstractMatrix{T}, atoms=Element[], positions=Vec3{T}[];
     if length(atoms) != length(positions)
         error("Length of atoms and positions vectors need to agree.")
     end
-    n_electrions ≤ 0 && error("n_electrons should be larger zero. Ensure to provide a " *
-                              "non-empty atoms list or an appropriate `n_electrons` kwarg.")
+    n_electrons ≤ 0 && error("n_electrons should be larger zero. Ensure to provide a " *
+                             "non-empty atoms list or an appropriate `n_electrons` kwarg.")
     isempty(terms) && error("Model without terms not supported.")
     atom_groups = [findall(Ref(pot) .== atoms) for pot in Set(atoms)]
 

--- a/src/postprocess/stresses.jl
+++ b/src/postprocess/stresses.jl
@@ -8,11 +8,9 @@ Compute the stresses (= 1/Vol dE/d(M*lattice), taken at M=I) of an obtained SCF 
     function HF_energy(lattice::AbstractMatrix{T}) where T
         basis = scfres.basis
         model = basis.model
-        new_model = Model(lattice;
+        new_model = Model(lattice, model.atoms, model.positions;
                           model.n_electrons,
-                          model.atoms,
-                          model.positions,
-                          magnetic_moments=[], # not used because we give symmetries explicitly
+                          magnetic_moments=[], # not used because symmetries explicitly given
                           terms=model.term_types,
                           model.temperature,
                           model.smearing,

--- a/src/standard_models.jl
+++ b/src/standard_models.jl
@@ -7,8 +7,6 @@ Use `extra_terms` to add additional terms.
 function model_atomic(lattice::AbstractMatrix, atoms::Vector, positions::Vector;
                       extra_terms=[], kwargs...)
     @assert !(:terms in keys(kwargs))
-    @assert !(:atoms in keys(kwargs))
-    @assert !(:positions in keys(kwargs))
     terms = [Kinetic(),
              AtomicLocal(),
              AtomicNonlocal(),

--- a/src/standard_models.jl
+++ b/src/standard_models.jl
@@ -16,7 +16,7 @@ function model_atomic(lattice::AbstractMatrix, atoms::Vector, positions::Vector;
     if :temperature in keys(kwargs) && kwargs[:temperature] != 0
         terms = [terms..., Entropy()]
     end
-    Model(lattice; model_name="atomic", atoms, positions, terms, kwargs...)
+    Model(lattice, atoms, positions; model_name="atomic", terms, kwargs...)
 end
 
 

--- a/src/workarounds/forwarddiff_rules.jl
+++ b/src/workarounds/forwarddiff_rules.jl
@@ -130,7 +130,7 @@ end
 # stress computation.
 function construct_value(model::Model{T}) where {T <: ForwardDiff.Dual}
     newpositions = [ForwardDiff.value.(pos) for pos in model.positions]
-    Model(ForwardDiff.value.(model.lattice), atoms, positions;
+    Model(ForwardDiff.value.(model.lattice), model.atoms, model.positions;
           model_name=model.model_name,
           n_electrons=model.n_electrons,
           magnetic_moments=[],  # Symmetries given explicitly

--- a/src/workarounds/forwarddiff_rules.jl
+++ b/src/workarounds/forwarddiff_rules.jl
@@ -130,7 +130,7 @@ end
 # stress computation.
 function construct_value(model::Model{T}) where {T <: ForwardDiff.Dual}
     newpositions = [ForwardDiff.value.(pos) for pos in model.positions]
-    Model(ForwardDiff.value.(model.lattice), model.atoms, model.positions;
+    Model(ForwardDiff.value.(model.lattice), model.atoms, newpositions;
           model_name=model.model_name,
           n_electrons=model.n_electrons,
           magnetic_moments=[],  # Symmetries given explicitly

--- a/src/workarounds/forwarddiff_rules.jl
+++ b/src/workarounds/forwarddiff_rules.jl
@@ -129,11 +129,10 @@ end
 # go a nice convert function to get rid of the annoying conversion thing in the
 # stress computation.
 function construct_value(model::Model{T}) where {T <: ForwardDiff.Dual}
-    Model(ForwardDiff.value.(model.lattice);
+    newpositions = [ForwardDiff.value.(pos) for pos in model.positions]
+    Model(ForwardDiff.value.(model.lattice), atoms, positions;
           model_name=model.model_name,
           n_electrons=model.n_electrons,
-          atoms=model.atoms,
-          positions=[ForwardDiff.value.(pos) for pos in model.positions],
           magnetic_moments=[],  # Symmetries given explicitly
           terms=model.term_types,
           temperature=ForwardDiff.value(model.temperature),

--- a/test/Model.jl
+++ b/test/Model.jl
@@ -6,7 +6,7 @@ include("testcases.jl")
 @testset "Test reduced / cartesian conversion" begin
     Ecut = 3
     fft_size = [13, 15, 14]
-    model = Model(silicon.lattice; silicon.atoms, silicon.positions)
+    model = Model(silicon.lattice, silicon.atoms, silicon.positions)
 
     rred = randn(3)  # reduced "position"
     fred = randn(3)  # reduced "force"

--- a/test/PlaneWaveBasis.jl
+++ b/test/PlaneWaveBasis.jl
@@ -19,7 +19,7 @@ end
 @testset "PlaneWaveBasis: Check struct construction" begin
     Ecut = 3
     fft_size = [15, 15, 15]
-    model = Model(silicon.lattice; silicon.atoms, silicon.positions)
+    model = Model(silicon.lattice, silicon.atoms, silicon.positions)
     basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size)
 
     @test basis.model.lattice == silicon.lattice
@@ -67,7 +67,7 @@ end
 @testset "PlaneWaveBasis: Check index for kpoints" begin
     Ecut = 3
     fft_size = [7, 9, 11]
-    model = Model(silicon.lattice; silicon.atoms, silicon.positions)
+    model = Model(silicon.lattice, silicon.atoms, silicon.positions)
     basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size=fft_size)
     g_all = collect(G_vectors(basis))
 
@@ -87,7 +87,7 @@ end
 end
 
 @testset "PlaneWaveBasis: kpoint mapping" begin
-    model = Model(silicon.lattice; silicon.atoms, silicon.positions)
+    model = Model(silicon.lattice, silicon.atoms, silicon.positions)
     basis = PlaneWaveBasis(model; Ecut=3, kgrid=(2, 2, 2), fft_size=[7, 9, 11])
 
     for kpt in basis.kpoints
@@ -105,7 +105,7 @@ end
 @testset "PlaneWaveBasis: Check G_vector-like accessor functions" begin
     Ecut = 3
     fft_size = [15, 15, 15]
-    model = Model(silicon.lattice; silicon.atoms, silicon.positions)
+    model = Model(silicon.lattice, silicon.atoms, silicon.positions)
     basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size)
 
     @test length(G_vectors(fft_size)) == prod(fft_size)

--- a/test/compute_bands.jl
+++ b/test/compute_bands.jl
@@ -103,7 +103,7 @@ end
 
 @testset "High-symmetry kpath construction for 1D system" begin
     lattice = diagm([8.0, 0, 0])
-    model = Model(lattice, n_electrons=1, terms=[Kinetic()])
+    model = Model(lattice; n_electrons=1, terms=[Kinetic()])
     kcoords, klabels, kpath = high_symmetry_kpath(model; kline_density=20)
 
     @test length(kcoords) == 17

--- a/test/compute_fft_size.jl
+++ b/test/compute_fft_size.jl
@@ -23,7 +23,7 @@ end
 end
 
 @testset "Test compute_fft_size with :precise" begin
-    model = Model(silicon.lattice; silicon.atoms, silicon.positions, terms=[Kinetic()])
+    model = Model(silicon.lattice, silicon.atoms, silicon.positions; terms=[Kinetic()])
 
     function fft_precise(model, kcoords, Ecut; supersampling=2)
         fft_size_fast = compute_fft_size(model, Ecut; supersampling, algorithm=:fast)

--- a/test/diag_compare.jl
+++ b/test/diag_compare.jl
@@ -11,7 +11,7 @@ using DFTK
 
     Ecut = 100
     lattice = Float64[5 0 0; 0 0 0; 0 0 0]
-    model = Model(lattice, n_electrons=4, terms=[Kinetic()])
+    model = Model(lattice; n_electrons=4, terms=[Kinetic()])
     basis = PlaneWaveBasis(model; Ecut, kgrid=(1, 1, 1))
     ham = Hamiltonian(basis)
     reference = merge(diagonalize_all_kblocks(diag_full, ham, 6), (ham=ham,))

--- a/test/energy_nuclear.jl
+++ b/test/energy_nuclear.jl
@@ -14,7 +14,7 @@ using LinearAlgebra: Diagonal
     ]
 
     ref = -0.02196861  # TODO source?
-    γ_E = DFTK.energy_ewald(Model(lattice; atoms, positions, terms=[Ewald()]))
+    γ_E = DFTK.energy_ewald(Model(lattice, atoms, positions; terms=[Ewald()]))
     @test abs(γ_E - ref) < 1e-8
 end
 
@@ -27,7 +27,7 @@ end
     positions = [[1/8, 1/8, 1/8], [-1/8, -1/8, -1/8]]
 
     ref = -8.39789357839024  # from ABINIT
-    γ_E = DFTK.energy_ewald(Model(lattice; atoms, positions, terms=[Ewald()]))
+    γ_E = DFTK.energy_ewald(Model(lattice, atoms, positions; terms=[Ewald()]))
     @test abs(γ_E - ref) < 1e-10
 end
 
@@ -38,7 +38,7 @@ end
     Si = ElementPsp(14, psp=load_psp("hgh/lda/Si-q4"))
     atoms     = [Si, Si]
     positions = [[1/8, 1/8, 1/8], [-1/8, -1/8, -1/8]]
-    model = Model(lattice; atoms, positions, terms=[PspCorrection()])
+    model = Model(lattice, atoms, positions; terms=[PspCorrection()])
 
     ref = -0.294622067023269  # from ABINIT
     e_corr = DFTK.energy_psp_correction(model)

--- a/test/fourier_transforms.jl
+++ b/test/fourier_transforms.jl
@@ -4,7 +4,7 @@ using DFTK: PlaneWaveBasis, G_to_r!, r_to_G!, G_to_r, r_to_G
 include("testcases.jl")
 
 @testset "FFT and IFFT are an identity" begin
-    model = Model(silicon.lattice; n_electrons=silicon.n_electrons)
+    model = Model(silicon.lattice; silicon.n_electrons)
     pw    = PlaneWaveBasis(model; Ecut=4.0, fft_size=(8, 8, 8))
 
     @testset "Transformation on the cubic basis set" begin

--- a/test/hamiltonian_consistency.jl
+++ b/test/hamiltonian_consistency.jl
@@ -15,7 +15,7 @@ function test_consistency_term(term; rtol=1e-4, atol=1e-8, ε=1e-6, kgrid=[1, 2,
         n_dim = 3 - count(iszero, eachcol(lattice))
         Si = n_dim == 3 ? ElementPsp(14, psp=load_psp(silicon.psp)) : ElementCoulomb(:Si)
         atoms = [Si, Si]
-        model = Model(lattice; n_electrons=silicon.n_electrons, atoms, silicon.positions,
+        model = Model(lattice, atoms, silicon.positions; n_electrons=silicon.n_electrons,
                       terms=[term], spin_polarization, symmetries=true)
         basis = PlaneWaveBasis(model; Ecut, kgrid)
 

--- a/test/kernel.jl
+++ b/test/kernel.jl
@@ -18,7 +18,7 @@ function test_kernel(spin_polarization, termtype; test_compute=true)
             n_spin = 2
         end
 
-        model = Model(testcase.lattice; testcase.atoms, testcase.positions,
+        model = Model(testcase.lattice, testcase.atoms, testcase.positions;
                       terms=[termtype], magnetic_moments, spin_polarization)
         @test model.n_spin_components == n_spin
         basis = PlaneWaveBasis(model; Ecut=2, kgrid=kgrid)
@@ -56,12 +56,12 @@ function test_kernel_collinear_vs_noncollinear(termtype)
 
     xcsym = (termtype isa Xc) ? join(string.(termtype.functionals), " ") : ""
     @testset "Kernel $(typeof(termtype)) $xcsym (coll == noncoll)" begin
-        model = Model(testcase.lattice; testcase.atoms, testcase.positions,
+        model = Model(testcase.lattice, testcase.atoms, testcase.positions;
                       terms=[termtype])
         basis = PlaneWaveBasis(model; Ecut, kgrid)
         term  = only(basis.terms)
 
-        model_col = Model(testcase.lattice; testcase.atoms, testcase.positions,
+        model_col = Model(testcase.lattice, testcase.atoms, testcase.positions;
                           terms=[termtype], spin_polarization=:collinear)
         basis_col = PlaneWaveBasis(model_col; Ecut, kgrid)
         term_col  = only(basis_col.terms)

--- a/test/lobpcg.jl
+++ b/test/lobpcg.jl
@@ -8,7 +8,7 @@ include("./testcases.jl")
     # Construct a free-electron Hamiltonian
     Ecut = 5
     fft_size = [15, 15, 15]
-    model = Model(silicon.lattice; terms=[Kinetic()], silicon.atoms, silicon.positions)
+    model = Model(silicon.lattice, silicon.atoms, silicon.positions; terms=[Kinetic()])
     basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size)
     ham = Hamiltonian(basis)
 
@@ -57,7 +57,7 @@ if !isdefined(Main, :FAST_TESTS) || !FAST_TESTS
         fft_size = [33, 33, 33]
 
         Si = ElementPsp(silicon.atnum, psp=load_psp("hgh/lda/si-q4"))
-        model = Model(silicon.lattice; silicon.atoms, silicon.positions,
+        model = Model(silicon.lattice, silicon.atoms, silicon.positions;
                       terms=[Kinetic(),AtomicLocal()])
         basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops;
                                fft_size=fft_size)
@@ -86,7 +86,7 @@ end
     fft_size = [21, 21, 21]
 
     Si = ElementPsp(silicon.atnum, psp=load_psp("hgh/lda/si-q4"))
-    model = Model(silicon.lattice; silicon.atoms, silicon.positions,
+    model = Model(silicon.lattice, silicon.atoms, silicon.positions;
                   terms=[Kinetic(), AtomicLocal(), AtomicNonlocal()])
 
     basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size=fft_size)

--- a/test/occupation.jl
+++ b/test/occupation.jl
@@ -119,7 +119,7 @@ if mpi_nprocs() == 1 # can't be bothered to convert the tests
     )
 
     for (smearing, temperature, εF_ref) in parameters
-        model = Model(silicon.lattice; testcase.atoms, testcase.positions;
+        model = Model(silicon.lattice, testcase.atoms, testcase.positions;
                       n_electrons=testcase.n_electrons,
                       temperature, smearing, terms=[Kinetic()])
         basis = PlaneWaveBasis(model; Ecut, kgrid, fft_size)

--- a/test/occupation.jl
+++ b/test/occupation.jl
@@ -47,7 +47,7 @@ if mpi_nprocs() == 1 # can't be bothered to convert the tests
     εLUMO = minimum(energies[ik][n_occ + 1] for ik in 1:n_k)
 
     # Occupation for zero temperature
-    model = Model(silicon.lattice; silicon.atoms, silicon.positions, temperature=0.0,
+    model = Model(silicon.lattice, silicon.atoms, silicon.positions; temperature=0.0,
                   smearing=nothing, terms=[Kinetic()])
     basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size)
     occupation0, εF0 = DFTK.compute_occupation_bandgap(basis, energies)
@@ -57,7 +57,7 @@ if mpi_nprocs() == 1 # can't be bothered to convert the tests
     # See that the electron count still works if we add temperature
     Ts = (0, 1e-6, .1, 1.0)
     for temperature in Ts, smearing in smearing_methods
-        model = Model(silicon.lattice; silicon.atoms, silicon.positions,
+        model = Model(silicon.lattice, silicon.atoms, silicon.positions;
                       temperature, smearing, terms=[Kinetic()])
         basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size)
         occs, _ = with_logger(NullLogger()) do
@@ -69,7 +69,7 @@ if mpi_nprocs() == 1 # can't be bothered to convert the tests
     # See that the occupation is largely uneffected with only a bit of temperature
     Ts = (0, 1e-6, 1e-4)
     for temperature in Ts, smearing in smearing_methods
-        model = Model(silicon.lattice; silicon.atoms, silicon.positions,
+        model = Model(silicon.lattice, silicon.atoms, silicon.positions;
                       temperature, smearing, terms=[Kinetic()])
         basis = PlaneWaveBasis(model, Ecut, silicon.kcoords, silicon.ksymops; fft_size)
         occupation, _ = DFTK.compute_occupation(basis, energies)
@@ -119,9 +119,9 @@ if mpi_nprocs() == 1 # can't be bothered to convert the tests
     )
 
     for (smearing, temperature, εF_ref) in parameters
-        model = Model(silicon.lattice, n_electrons=testcase.n_electrons;
-                      temperature, smearing, terms=[Kinetic()],
-                      testcase.atoms, testcase.positions)
+        model = Model(silicon.lattice; testcase.atoms, testcase.positions;
+                      n_electrons=testcase.n_electrons,
+                      temperature, smearing, terms=[Kinetic()])
         basis = PlaneWaveBasis(model; Ecut, kgrid, fft_size)
         occupation, εF = with_logger(NullLogger()) do
             DFTK.compute_occupation(basis, energies)

--- a/test/pairwise.jl
+++ b/test/pairwise.jl
@@ -19,7 +19,7 @@ using Random
     # Test that the constructor has ordered the tuples
     @test (:H, :Li) ∈ keys(term.params)
 
-    model = Model(lattice; atoms, positions, terms=[term])
+    model = Model(lattice, atoms, positions; terms=[term])
     basis = PlaneWaveBasis(model; Ecut=20, kgrid=(1, 1, 1))
     forces = compute_forces(basis.terms[1], basis, nothing, nothing)
 


### PR DESCRIPTION
This makes the basic `Model` constructor more consistent with the `model_atomic`, `model_LDA` etc. constructors.