### PR TITLE
Precompute Ewald summation bounds

### DIFF
--- a/src/terms/ewald.jl
+++ b/src/terms/ewald.jl
@@ -60,6 +60,29 @@ function energy_ewald(lattice, charges, positions; η=nothing, forces=nothing)
     energy_ewald(lattice, compute_recip_lattice(lattice), charges, positions; η, forces)
 end
 
+function compute_Glims_Rlims_ewald(lattice, recip_lattice, positions, max_exp_arg, max_erfc_arg, η; ceil_int=true)
+    # As a general statement, with A a lattice matrix, then if ||Ax|| <= R, 
+    # then xi = <ei, A^-1 Ax> = <A^-T ei, Ax> <= ||A^-T ei|| R.
+    #
+    # In the reciprocal-space term we have exp(-||B G||^2 / 4η^2), 
+    # where B is the reciprocal-space lattice, and 
+    # thus use the bound  ||B G|| / 2η ≤ sqrt(max_exp_arg)
+    Glims = [norm(inv(recip_lattice')[:, i]) * sqrt(max_exp_arg) * 2η  for i in 1:3]
+
+    # In the real-space term we have erfc(η ||A(rj - rk - R)||), 
+    # where A is the real-space lattice, rj and rk are atomic positions and
+    # thus use the bound  ||A(rj - rk - R)|| * η ≤ max_erfc_arg
+    poslims = [maximum(rj[i] - rk[i] for rj in positions for rk in positions) for i in 1:3]
+    Rlims = [norm(inv(lattice')[:, i]) * max_erfc_arg / η + poslims[i] for i in 1:3]
+    
+    if ceil_int
+        Glims = ceil.(Int, Glims)
+        Rlims = ceil.(Int, Rlims)
+    end
+
+    Glims, Rlims
+end
+
 # This could be factorised with Pairwise, but its use of `atom_types` would slow down this
 # computationally intensive Ewald sums. So we leave it as it for now.
 function energy_ewald(lattice, recip_lattice, charges, positions; η=nothing, forces=nothing)
@@ -83,17 +106,8 @@ function energy_ewald(lattice, recip_lattice, charges, positions; η=nothing, fo
     max_erfc_arg = sqrt(max_exp_arg)  # erfc(x) ~= exp(-x^2)/(sqrt(π)x) for large x
 
     # Precomputing summation bounds from cutoffs.
-    # As a general statement, with A a lattice matrix, then if ||Ax|| <= R, 
-    # then xi = <ei, A^-1 Ax> = <A^-T ei, Ax> <= ||A^-T ei|| R.
-    #
-    # Reciprocal space:  ||B G|| / 2η ≤ max_erfc_arg
-    # where B is the reciprocal space lattice
-    # Real space: ||A(rj - rk - R)|| * η ≤ max_erfc_arg
-    # where A is the real-space lattice, rj and rk are atomic positions
-    Glims = ceil.(Int, [norm(inv(recip_lattice')[:, i]) * max_erfc_arg * 2η  for i in 1:3])
-    poslims = [maximum(rj[i] - rk[i] for rj in positions for rk in positions) for i in 1:3]
-    Rlims = ceil.(Int, [norm(inv(lattice')[:, i]) * max_erfc_arg / η + poslims[i] for i in 1:3])
-
+    Glims, Rlims = compute_Glims_Rlims_ewald(lattice, recip_lattice, positions, max_exp_arg, max_erfc_arg, η)
+    
     #
     # Reciprocal space sum
     #

--- a/src/terms/ewald.jl
+++ b/src/terms/ewald.jl
@@ -88,8 +88,8 @@ function energy_ewald(lattice, recip_lattice, charges, positions; η=nothing, fo
     #
     # Reciprocal space:  ||B G|| / 2η ≤ max_erfc_arg
     # where B is the reciprocal space lattice
-    # Real space: ||A(ti - tj - R)|| * η ≤ max_erfc_arg
-    # where A is the real-space lattice
+    # Real space: ||A(rj - rk - R)|| * η ≤ max_erfc_arg
+    # where A is the real-space lattice, rj and rk are atomic positions
     Glims = ceil.(Int, [norm(inv(recip_lattice')[:, i]) * max_erfc_arg * 2η  for i in 1:3])
     poslims = [maximum(rj[i] - rk[i] for rj in positions for rk in positions) for i in 1:3]
     Rlims = ceil.(Int, [norm(inv(lattice')[:, i]) * max_erfc_arg / η + poslims[i] for i in 1:3])

--- a/src/terms/ewald.jl
+++ b/src/terms/ewald.jl
@@ -82,8 +82,12 @@ function energy_ewald(lattice, recip_lattice, charges, positions; η=nothing, fo
     max_exp_arg = -log(eps(T)) + 5  # add some wiggle room
     max_erfc_arg = sqrt(max_exp_arg)  # erfc(x) ~= exp(-x^2)/(sqrt(π)x) for large x
 
-    # let A be the lattice matrix, then if ||Ax|| <= R, 
+    # Precomputing summation bounds from cutoffs.
+    # Let A be the lattice matrix, then if ||Ax|| <= R, 
     # then xi = <ei, A^-1 Ax> = <A^-T ei, Ax> <= ||A^-T ei|| R.
+    #
+    # Reciprocal space:  ||A^-1 G|| / 2η ≤ max_erfc_arg
+    # Real space: ||A(ti - tj - R)|| * η ≤ max_erfc_arg
     Glims = ceil.(Int, [norm(lattice'[:, i]) * max_erfc_arg * 2η  for i in 1:3])
     poslims = [maximum(rj[i] - rk[i] for rj in positions for rk in positions) for i in 1:3]
     Rlims = ceil.(Int, [norm(recip_lattice'[:, i]) * max_erfc_arg / η + poslims[i] for i in 1:3])

--- a/src/terms/ewald.jl
+++ b/src/terms/ewald.jl
@@ -88,9 +88,9 @@ function energy_ewald(lattice, recip_lattice, charges, positions; η=nothing, fo
     #
     # Reciprocal space:  ||A^-1 G|| / 2η ≤ max_erfc_arg
     # Real space: ||A(ti - tj - R)|| * η ≤ max_erfc_arg
-    Glims = ceil.(Int, [norm(lattice'[:, i]) * max_erfc_arg * 2η  for i in 1:3])
+    Glims = ceil.(Int, [norm(inv(recip_lattice')[:, i]) * max_erfc_arg * 2η  for i in 1:3])
     poslims = [maximum(rj[i] - rk[i] for rj in positions for rk in positions) for i in 1:3]
-    Rlims = ceil.(Int, [norm(recip_lattice'[:, i]) * max_erfc_arg / η + poslims[i] for i in 1:3])
+    Rlims = ceil.(Int, [norm(inv(lattice')[:, i]) * max_erfc_arg / η + poslims[i] for i in 1:3])
 
     #
     # Reciprocal space sum

--- a/src/workarounds/intervals.jl
+++ b/src/workarounds/intervals.jl
@@ -45,3 +45,13 @@ function local_potential_fourier(el::ElementCohenBergstresser, q::T) where {T <:
     @assert iszero(round(lor - hir, digits=3))
     T(local_potential_fourier(el, IntervalArithmetic.mid(q)))
 end
+
+function compute_Glims_Rlims_ewald(lattice::AbstractMatrix{<:Interval}, recip_lattice, positions, max_exp_arg, max_erfc_arg, η)
+    # This is done to avoid a call like ceil(Int, ::Interval)
+    # where it is in general cases not clear, what to do.
+    # In this case we just take the largest possible summation bounds.
+    Glims, Rlims = compute_Glims_Rlims_ewald(lattice, recip_lattice, positions, max_exp_arg, max_erfc_arg, η; ceil_int=false)
+    Glims = map(x -> ceil(Int, x.hi), Glims)
+    Rlims = map(x -> ceil(Int, x.hi), Rlims)
+    Glims, Rlims
+end

--- a/src/workarounds/intervals.jl
+++ b/src/workarounds/intervals.jl
@@ -46,12 +46,20 @@ function local_potential_fourier(el::ElementCohenBergstresser, q::T) where {T <:
     T(local_potential_fourier(el, IntervalArithmetic.mid(q)))
 end
 
-function compute_Glims_Rlims_ewald(lattice::AbstractMatrix{<:Interval}, recip_lattice, positions, max_exp_arg, max_erfc_arg, η)
-    # This is done to avoid a call like ceil(Int, ::Interval)
-    # where it is in general cases not clear, what to do.
-    # In this case we just take the largest possible summation bounds.
-    Glims, Rlims = compute_Glims_Rlims_ewald(lattice, recip_lattice, positions, max_exp_arg, max_erfc_arg, η; ceil_int=false)
-    Glims = map(x -> ceil(Int, x.hi), Glims)
-    Rlims = map(x -> ceil(Int, x.hi), Rlims)
-    Glims, Rlims
+# function compute_Glims_Rlims_ewald(lattice::AbstractMatrix{<:Interval}, recip_lattice, positions, max_exp_arg, max_erfc_arg, η)
+#     # This is done to avoid a call like ceil(Int, ::Interval)
+#     # where it is in general cases not clear, what to do.
+#     # In this case we just take the largest possible summation bounds.
+#     Glims, Rlims = compute_Glims_Rlims_ewald(lattice, recip_lattice, positions, max_exp_arg, max_erfc_arg, η; ceil_int=false)
+#     Glims = map(x -> ceil(Int, x.hi), Glims)
+#     Rlims = map(x -> ceil(Int, x.hi), Rlims)
+#     Glims, Rlims
+# end
+
+function estimate_integer_lattice_bounds(M::AbstractMatrix{<:Interval}, δ, shift=zeros(3))
+    # As a general statement, with M a lattice matrix, then if ||Mx|| <= δ, 
+    # then xi = <ei, M^-1 Mx> = <M^-T ei, Mx> <= ||M^-T ei|| δ.
+    # Below code does not support non-3D systems.
+    xlims = [norm(inv(M')[:, i]) * δ + shift[i] for i in 1:3]
+    map(x -> ceil(Int, x.hi), xlims)
 end

--- a/src/workarounds/intervals.jl
+++ b/src/workarounds/intervals.jl
@@ -46,16 +46,6 @@ function local_potential_fourier(el::ElementCohenBergstresser, q::T) where {T <:
     T(local_potential_fourier(el, IntervalArithmetic.mid(q)))
 end
 
-# function compute_Glims_Rlims_ewald(lattice::AbstractMatrix{<:Interval}, recip_lattice, positions, max_exp_arg, max_erfc_arg, η)
-#     # This is done to avoid a call like ceil(Int, ::Interval)
-#     # where it is in general cases not clear, what to do.
-#     # In this case we just take the largest possible summation bounds.
-#     Glims, Rlims = compute_Glims_Rlims_ewald(lattice, recip_lattice, positions, max_exp_arg, max_erfc_arg, η; ceil_int=false)
-#     Glims = map(x -> ceil(Int, x.hi), Glims)
-#     Rlims = map(x -> ceil(Int, x.hi), Rlims)
-#     Glims, Rlims
-# end
-
 function estimate_integer_lattice_bounds(M::AbstractMatrix{<:Interval}, δ, shift=zeros(3))
     # As a general statement, with M a lattice matrix, then if ||Mx|| <= δ, 
     # then xi = <ei, M^-1 Mx> = <M^-T ei, Mx> <= ||M^-T ei|| δ.


### PR DESCRIPTION
This PR adresses #656, precomputing the summation bounds (@antoine-levitt) in reciprocal- and real-space and thus replacing the while-loop over shells by dense cubic for-loops. 

This doesn't yet include functionalization of the loops or non-mutating forces, which are left to a possible follow-up PR when needed.