### PR TITLE
Refactor Pairwise term to precompute summation bounds

### DIFF
--- a/src/fft.jl
+++ b/src/fft.jl
@@ -239,11 +239,7 @@ end
 function compute_Glims_fast(lattice::AbstractMatrix{T}, Ecut; supersampling=2, tol=sqrt(eps(T))) where T
     Gmax = supersampling * sqrt(2 * Ecut)
     recip_lattice = compute_recip_lattice(lattice)
-    Glims = estimate_integer_lattice_bounds(recip_lattice, Gmax)
-
-    # Round up, unless exactly zero (in which case keep it zero in
-    # order to just have one G vector for 1D or 2D systems)
-    Glims = [Glim == 0 ? 0 : ceil(Int, Glim .- tol) for Glim in Glims]
+    Glims = estimate_integer_lattice_bounds(recip_lattice, Gmax; tol=tol)
     Glims
 end
 

--- a/src/structure.jl
+++ b/src/structure.jl
@@ -42,3 +42,15 @@ function diameter(lattice::AbstractMatrix)
     end
     diam
 end
+
+"""
+Estimate integer bounds for dense space loops from a given inequality ||Mx|| ≤ δ.
+For 1D and 2D systems the limit will be zero in the auxiliary dimensions.
+"""
+function estimate_integer_lattice_bounds(M, δ, shift=zeros(3))
+    # As a general statement, with M a lattice matrix, then if ||Mx|| <= δ, 
+    # then xi = <ei, M^-1 Mx> = <M^-T ei, Mx> <= ||M^-T ei|| δ.
+    inv_lattice_t = compute_inverse_lattice(M')
+    xlims = [norm(inv_lattice_t[:, i]) * δ + shift[i] for i in 1:3]
+    ceil.(Int, xlims)
+end

--- a/src/structure.jl
+++ b/src/structure.jl
@@ -48,7 +48,7 @@ Estimate integer bounds for dense space loops from a given inequality ||Mx|| ≤
 For 1D and 2D systems the limit will be zero in the auxiliary dimensions.
 """
 function estimate_integer_lattice_bounds(M, δ, shift=zeros(3))
-    # As a general statement, with M a lattice matrix, then if ||Mx|| <= δ, 
+    # As a general statement, with M a lattice matrix, then if ||Mx|| <= δ,
     # then xi = <ei, M^-1 Mx> = <M^-T ei, Mx> <= ||M^-T ei|| δ.
     inv_lattice_t = compute_inverse_lattice(M')
     xlims = [norm(inv_lattice_t[:, i]) * δ + shift[i] for i in 1:3]

--- a/src/structure.jl
+++ b/src/structure.jl
@@ -47,10 +47,14 @@ end
 Estimate integer bounds for dense space loops from a given inequality ||Mx|| ≤ δ.
 For 1D and 2D systems the limit will be zero in the auxiliary dimensions.
 """
-function estimate_integer_lattice_bounds(M, δ, shift=zeros(3))
+function estimate_integer_lattice_bounds(M::AbstractMatrix{T}, δ, shift=zeros(3); tol=sqrt(eps(T))) where T
     # As a general statement, with M a lattice matrix, then if ||Mx|| <= δ,
     # then xi = <ei, M^-1 Mx> = <M^-T ei, Mx> <= ||M^-T ei|| δ.
     inv_lattice_t = compute_inverse_lattice(M')
     xlims = [norm(inv_lattice_t[:, i]) * δ + shift[i] for i in 1:3]
-    ceil.(Int, xlims)
+    
+    # Round up, unless exactly zero (in which case keep it zero in
+    # order to just have one x vector for 1D or 2D systems)
+    xlims = [xlim == 0 ? 0 : ceil(Int, xlim .- tol) for xlim in xlims]
+    xlims
 end

--- a/src/terms/ewald.jl
+++ b/src/terms/ewald.jl
@@ -83,17 +83,17 @@ function energy_ewald(lattice, recip_lattice, charges, positions; η=nothing, fo
     max_erfc_arg = sqrt(max_exp_arg)  # erfc(x) ~= exp(-x^2)/(sqrt(π)x) for large x
 
     # Precomputing summation bounds from cutoffs.
-    # In the reciprocal-space term we have exp(-||B G||^2 / 4η^2), 
-    # where B is the reciprocal-space lattice, and 
+    # In the reciprocal-space term we have exp(-||B G||^2 / 4η^2),
+    # where B is the reciprocal-space lattice, and
     # thus use the bound  ||B G|| / 2η ≤ sqrt(max_exp_arg)
     Glims = estimate_integer_lattice_bounds(recip_lattice, sqrt(max_exp_arg) * 2η)
 
-    # In the real-space term we have erfc(η ||A(rj - rk - R)||), 
+    # In the real-space term we have erfc(η ||A(rj - rk - R)||),
     # where A is the real-space lattice, rj and rk are atomic positions and
     # thus use the bound  ||A(rj - rk - R)|| * η ≤ max_erfc_arg
     poslims = [maximum(rj[i] - rk[i] for rj in positions for rk in positions) for i in 1:3]
     Rlims = estimate_integer_lattice_bounds(lattice, max_erfc_arg / η, poslims)
-        
+
     #
     # Reciprocal space sum
     #

--- a/src/terms/ewald.jl
+++ b/src/terms/ewald.jl
@@ -60,14 +60,6 @@ function energy_ewald(lattice, charges, positions; η=nothing, forces=nothing)
     energy_ewald(lattice, compute_recip_lattice(lattice), charges, positions; η, forces)
 end
 
-function estimate_integer_lattice_bounds(M, δ, shift=zeros(3))
-    # As a general statement, with M a lattice matrix, then if ||Mx|| <= δ, 
-    # then xi = <ei, M^-1 Mx> = <M^-T ei, Mx> <= ||M^-T ei|| δ.
-    # Below code does not support non-3D systems.
-    xlims = [norm(inv(M')[:, i]) * δ + shift[i] for i in 1:3]
-    ceil.(Int, xlims)
-end
-
 # This could be factorised with Pairwise, but its use of `atom_types` would slow down this
 # computationally intensive Ewald sums. So we leave it as it for now.
 function energy_ewald(lattice, recip_lattice, charges, positions; η=nothing, forces=nothing)

--- a/src/terms/pairwise.jl
+++ b/src/terms/pairwise.jl
@@ -66,7 +66,8 @@ function energy_pairwise(lattice, symbols, positions, V, params;
         forces_pairwise = copy(forces)
     end
 
-    # We use the bound  ||A (ti - tj - R)|| ≤ max_radius
+    # The potential V(dist) decays very quickly with dist = ||A (ri - rj - R)||,
+    # so we cut off at some point. We use the bound  ||A (ri - rj - R)|| ≤ max_radius
     # where A is the real-space lattice, rj and rk are atomic positions.
     poslims = [maximum(rj[i] - rk[i] for rj in positions for rk in positions) for i in 1:3]
     Rlims = estimate_integer_lattice_bounds(lattice, max_radius, poslims)

--- a/src/terms/pairwise.jl
+++ b/src/terms/pairwise.jl
@@ -72,6 +72,11 @@ function energy_pairwise(lattice, symbols, positions, V, params;
     poslims = [maximum(rj[i] - rk[i] for rj in positions for rk in positions) for i in 1:3]
     Rlims = estimate_integer_lattice_bounds(lattice, max_radius, poslims)
 
+    # Check if some coordinates are not used.
+    is_dim_trivial = [norm(lattice[:,i]) == 0 for i=1:3]
+    max_shell(n, trivial) = trivial ? 0 : n
+    Rlims = max_shell.(Rlims, is_dim_trivial)
+
     #
     # Energy loop
     #

--- a/src/terms/pairwise.jl
+++ b/src/terms/pairwise.jl
@@ -69,7 +69,7 @@ function energy_pairwise(lattice, symbols, positions, V, params;
     # We use the bound  ||A (ti - tj - R)|| ≤ max_radius
     # where A is the real-space lattice, rj and rk are atomic positions.
     poslims = [maximum(rj[i] - rk[i] for rj in positions for rk in positions) for i in 1:3]
-    Rlims = estimate_integer_lattice_bounds(lattice, max_radius, poslims)    
+    Rlims = estimate_integer_lattice_bounds(lattice, max_radius, poslims)
 
     #
     # Energy loop

--- a/src/terms/pairwise.jl
+++ b/src/terms/pairwise.jl
@@ -66,8 +66,8 @@ function energy_pairwise(lattice, symbols, positions, V, params;
         forces_pairwise = copy(forces)
     end
 
-    # The potential V(dist) decays very quickly with dist = ||A (ri - rj - R)||,
-    # so we cut off at some point. We use the bound  ||A (ri - rj - R)|| ≤ max_radius
+    # The potential V(dist) decays very quickly with dist = ||A (rj - rk - R)||,
+    # so we cut off at some point. We use the bound  ||A (rj - rk - R)|| ≤ max_radius
     # where A is the real-space lattice, rj and rk are atomic positions.
     poslims = [maximum(rj[i] - rk[i] for rj in positions for rk in positions) for i in 1:3]
     Rlims = estimate_integer_lattice_bounds(lattice, max_radius, poslims)

--- a/src/terms/pairwise.jl
+++ b/src/terms/pairwise.jl
@@ -66,59 +66,36 @@ function energy_pairwise(lattice, symbols, positions, V, params;
         forces_pairwise = copy(forces)
     end
 
-    # Function to return the indices corresponding
-    # to a particular shell.
-    # Not performance critical, so we do not type the function
-    max_shell(n, trivial) = trivial ? 0 : n
-    # Check if some coordinates are not used.
-    is_dim_trivial = [norm(lattice[:,i]) == 0 for i=1:3]
-    function shell_indices(nsh)
-        ish, jsh, ksh = max_shell.(nsh, is_dim_trivial)
-        [[i,j,k] for i in -ish:ish for j in -jsh:jsh for k in -ksh:ksh
-         if maximum(abs.([i,j,k])) == nsh]
-    end
+    # We use the bound  ||A (ti - tj - R)|| ≤ max_radius
+    # where A is the real-space lattice, rj and rk are atomic positions.
+    poslims = [maximum(rj[i] - rk[i] for rj in positions for rk in positions) for i in 1:3]
+    Rlims = estimate_integer_lattice_bounds(lattice, max_radius, poslims)    
 
     #
     # Energy loop
     #
     sum_pairwise::T = zero(T)
-    # Loop over real-space shells
-    rsh = 0 # Include R = 0
-    any_term_contributes = true
-    while any_term_contributes || rsh <= 1
-        any_term_contributes = false
-
-        # Loop over R vectors for this shell patch
-        for R in shell_indices(rsh)
-            for i = 1:length(positions), j = 1:length(positions)
-                # Avoid self-interaction
-                rsh == 0 && i == j && continue
-
-                ti = positions[i]
-                tj = positions[j]
-                ai, aj = minmax(symbols[i], symbols[j])
-                param_ij =params[(ai, aj)]
-
-                Δr = lattice * (ti .- tj .- R)
-                dist = norm(Δr)
-
-                # the potential decays very quickly, so cut off at some point
-                dist > max_radius && continue
-
-                any_term_contributes = true
-                energy_contribution = V(dist, param_ij)
-                sum_pairwise += energy_contribution
-                if forces !== nothing
-                    # We use ForwardDiff for the forces
-                    dE_ddist = ForwardDiff.derivative(d -> V(d, param_ij), dist)
-                    dE_dti = lattice' * dE_ddist / dist * Δr
-                    forces_pairwise[i] -= dE_dti
-                    forces_pairwise[j] += dE_dti
-                end
-            end # i,j
-        end # R
-        rsh += 1
-    end
+    # Loop over real-space
+    for R1 in -Rlims[1]:Rlims[1], R2 in -Rlims[2]:Rlims[2], R3 in -Rlims[3]:Rlims[3]
+        R = Vec3(R1, R2, R3)
+        for i = 1:length(positions), j = 1:length(positions)
+            # Avoid self-interaction
+            R == zero(R) && i == j && continue
+            ai, aj = minmax(symbols[i], symbols[j])
+            param_ij = params[(ai, aj)]
+            Δr = lattice * (positions[i] - positions[j] - R)
+            dist = norm(Δr)
+            energy_contribution = V(dist, param_ij)
+            sum_pairwise += energy_contribution
+            if forces !== nothing
+                # We use ForwardDiff for the forces
+                dE_ddist = ForwardDiff.derivative(d -> V(d, param_ij), dist)
+                dE_dti = lattice' * dE_ddist / dist * Δr
+                forces_pairwise[i] -= dE_dti
+                forces_pairwise[j] += dE_dti
+            end
+        end # i,j
+    end # R
     energy = sum_pairwise / 2  # Divide by 2 (because of double counting)
     if forces !== nothing
         forces .= forces_pairwise ./ 2

--- a/test/energies_guess_density.jl
+++ b/test/energies_guess_density.jl
@@ -63,7 +63,7 @@ include("testcases.jl")
     @test E["ExternalFromReal"]    ≈ -0.01756831422361496 atol=5e-8
     @test E["ExternalFromFourier"] ≈  0.06493077052321815 atol=5e-8
     @test E["LocalNonlinearity"]   ≈  0.14685350034704006 atol=5e-8
-    @test E["PairwisePotential"]   ≈ -4.1511598946254615  atol=5e-8
+    @test E["PairwisePotential"]   ≈ -4.151269801749716   atol=5e-8
 
     # TODO This is not really a test ... and it does not really work stably.
     # @test E["Magnetic"]            ≈  1.99901120545585e-7 atol=5e-8


### PR DESCRIPTION
This PR follows up on #656 now analogously on the Pairwise term, replacing the shell_indices & while loop by a dense for-loop over space. Later, this can also be now easily modified further into mapreduce-like patterns for GPU or AD.