### PR TITLE
Fix bug on magnetization in guess_density

### DIFF
--- a/src/guess_density.jl
+++ b/src/guess_density.jl
@@ -62,7 +62,7 @@ function _guess_spin_density(basis::PlaneWaveBasis{T}, atoms, positions, magneti
 
     # If no magnetic moments start with a zero spin density
     magmoms = Vec3{T}[normalize_magnetic_moment(magmom) for magmom in magnetic_moments]
-    if isempty(filter(!iszero, magmoms))
+    if all(iszero, magmoms)
         @warn("Returning zero spin density guess, because no initial magnetization has " *
               "been specified in any of the given elements / atoms. Your SCF will likely " *
               "not converge to a spin-broken solution.")
@@ -78,6 +78,7 @@ function _guess_spin_density(basis::PlaneWaveBasis{T}, atoms, positions, magneti
         )
         magmom[3], T(atom_decay_length(atom))::T, position
     end
+    gaussians = filter(g -> !iszero(g[1]), gaussians)
     gaussian_superposition(basis, gaussians)
 end
 

--- a/src/guess_density.jl
+++ b/src/guess_density.jl
@@ -62,15 +62,14 @@ function _guess_spin_density(basis::PlaneWaveBasis{T}, atoms, positions, magneti
 
     # If no magnetic moments start with a zero spin density
     magmoms = Vec3{T}[normalize_magnetic_moment(magmom) for magmom in magnetic_moments]
-    magmoms = filter(!iszero, magmoms)
-    if isempty(magmoms)
+    if isempty(filter(!iszero, magmoms))
         @warn("Returning zero spin density guess, because no initial magnetization has " *
               "been specified in any of the given elements / atoms. Your SCF will likely " *
               "not converge to a spin-broken solution.")
         return zeros(T, basis.fft_size)
     end
 
-    @assert length(magnetic_moments) == length(atoms) == length(positions)
+    @assert length(magmoms) == length(atoms) == length(positions)
     gaussians = map(zip(atoms, positions, magmoms)) do (atom, position, magmom)
         iszero(magmom[1:2]) || error("Non-collinear magnetization not yet implemented")
         magmom[3] ≤ n_elec_valence(atom) || error(

--- a/src/response/chi0.jl
+++ b/src/response/chi0.jl
@@ -107,6 +107,9 @@ precondprep!(P::FunctionPreconditioner, ::Any) = P
 # Solves (1-P) (H-εn) (1-P) δψn = - (1-P) rhs
 # where 1-P is the projector on the orthogonal of ψk
 # n is used for the preconditioning with ψk[:,n] and the optional callback
+# /!\ for the solver to return the good output, εk_extra needs to be equal to
+# the diagonal of ψk_extra'Hk*ψk_extra (when not empty), which is the case by
+# default when using the extra eigenvalues
 function sternheimer_solver(Hk, ψk, εnk, rhs, n; callback=info->nothing,
                             ψk_extra=zeros(size(ψk,1), 0), εk_extra=zeros(0),
                             abstol=1e-9, reltol=0, verbose=false)

--- a/src/response/chi0.jl
+++ b/src/response/chi0.jl
@@ -107,9 +107,8 @@ precondprep!(P::FunctionPreconditioner, ::Any) = P
 # Solves (1-P) (H-εn) (1-P) δψn = - (1-P) rhs
 # where 1-P is the projector on the orthogonal of ψk
 # n is used for the preconditioning with ψk[:,n] and the optional callback
-# /!\ for the solver to return the good output, εk_extra needs to be equal to
-# the diagonal of ψk_extra'Hk*ψk_extra (when not empty), which is the case by
-# default when using the extra eigenvalues
+# /!\ It is assumed (and not checked) that ψk'Hk*ψk = Diagonal(εk) (extra states
+# included).
 function sternheimer_solver(Hk, ψk, εnk, rhs, n; callback=info->nothing,
                             ψk_extra=zeros(size(ψk,1), 0), εk_extra=zeros(0),
                             abstol=1e-9, reltol=0, verbose=false)

--- a/src/response/chi0.jl
+++ b/src/response/chi0.jl
@@ -112,8 +112,6 @@ function sternheimer_solver(Hk, ψk, εnk, rhs, n; callback=info->nothing,
                             abstol=1e-9, reltol=0, verbose=false)
     basis = Hk.basis
     kpoint = Hk.kpoint
-    model = basis.model
-    temperature = model.temperature
 
     # We use a Schur decomposition of the orthogonal of the occupied states
     # into a part where we have the partially converged, non-occupied bands


### PR DESCRIPTION
Short fix for two things : 
- cleaning some leftovers in sternheimer + some useful doc
- fixing a bug in guess_density https://github.com/JuliaMolSim/DFTK.jl/blob/4f810fa0e9806659a12ea7c4d15579475d343b10/src/guess_density.jl#L65 where it can happen that we have `atoms = [A, B, C]` with `magnetic_moments = [m, 0, m]` with `m>0`. then, the filter will remove the 0 from `magnetic_moments` and raise an error later because the correspondance between `atoms` and `magnetic_moments` lists is not valid anymore.