### PR TITLE
Change default thread setup

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ else
 end
 
 # Setup threading in DFTK
-setup_threading(; n_blas=2)
+setup_threading()
 
 # Initialize seed
 Random.seed!(0)


### PR DESCRIPTION
You learn every day regarding the peculiarities of threading. Short story is: The default setup in pretty much all blas libraries is suboptimal.