### PR TITLE
Make LOBPCG GPU-compatible

### DIFF
--- a/src/workarounds/gpu_arrays.jl
+++ b/src/workarounds/gpu_arrays.jl
@@ -1,0 +1,16 @@
+#TODO: remove this when it is implemented in GPUArrays
+import LinearAlgebra.dot, LinearAlgebra.eigen, LinearAlgebra.RealHermSymComplexHerm
+using LinearAlgebra
+using GPUArrays
+using CUDA
+
+LinearAlgebra.dot(x::AbstractGPUArray, D::Diagonal,y::AbstractGPUArray) = x'*(D*y)
+
+function LinearAlgebra.eigen(A::RealHermSymComplexHerm{T,AT}) where {T,AT <: CuArray}
+    if eltype(A) <: Complex
+        vals, vects = CUDA.CUSOLVER.heevd!('V','U', A.data)
+    else
+        vals, vects = CUDA.CUSOLVER.syevd!('V','U',A.data)
+    end
+    (vectors = vects, values = vals)
+end


### PR DESCRIPTION
This draft PR implements GPU compatibility for LOBPCG. 
At the highest level, the goal is to be able to call LOBPCG with either Arrays or any type of GPU Arrays. This means the user should be able to make the following calls (A is a Hermitian matrix and X is vector)
`LOBPCG(A,X) #CPU`
`LOBPCG(CuArray(A),CuArray(X)) #GPU`
`LOBPCG(ROCArray(A),ROCArray(X)) #GPU`
LOBPCG returns a named tuple. One of the field is an array of the eigenvalues found, and another is the corresponding eigenvectors. These two fields have the same array type as the input: if the user calls LOBPCG with CuArrays, then the eigenvalues and eigenvectors will be stored in a CuArray.

I tried to make the code as abstract as possible so as not to rely on a hardware-specific library. The only part where I needed to call specific CUDA functions (I am using an NVIDIA GPU) is when computing eigenvalues. If I am not mistaken, there is no generic `eigen` function in CUDA.jl, so I had to manually call the eigendecomposition functions (CUDA.syevd! and CUDA.heevd!). 