### PR TITLE
Introduce `irfft` for inverse FFT of real-valued quantities

### DIFF
--- a/examples/publications/2022_cazalis.jl
+++ b/examples/publications/2022_cazalis.jl
@@ -17,7 +17,7 @@ function DFTK.ene_ops(term::Term2DHartree, basis::PlaneWaveBasis{T},
 
     ρtot_fourier = fft(basis, total_density(ρ))
     pot_fourier = poisson_green_coeffs .* ρtot_fourier
-    pot_real = ifft(basis, pot_fourier)
+    pot_real = irfft(basis, pot_fourier)
     E = real(dot(pot_fourier, ρtot_fourier) / 2)
     ops = [DFTK.RealSpaceMultiplication(basis, kpt, pot_real) for kpt in basis.kpoints]
     (E=E, ops=ops)

--- a/src/DFTK.jl
+++ b/src/DFTK.jl
@@ -56,6 +56,7 @@ export G_vectors, G_vectors_cart, r_vectors, r_vectors_cart
 export Gplusk_vectors, Gplusk_vectors_cart
 export Kpoint
 export ifft
+export irfft
 export ifft!
 export fft
 export fft!

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -62,11 +62,11 @@ function ifft(basis::PlaneWaveBasis, f_fourier::AbstractArray)
     f_real
 end
 """
-Perform a real valued iFFT; see `ifft`.
+Perform a real valued iFFT; see [`ifft`](@ref).
 """
 function irfft(basis::PlaneWaveBasis{T}, f_fourier::AbstractArray; check=Val(true)) where {T}
     f_real = ifft(basis, f_fourier)
-    (check == Val(true)) && @assert isapprox(norm(imag(f_real)), 0.0, atol=sqrt(eps(T)))
+    (check == Val(true)) && @assert norm(imag(f_real)) < sqrt(eps(T))
     real(f_real)
 end
 function ifft(basis::PlaneWaveBasis, kpt::Kpoint, f_fourier::AbstractVector; kwargs...)

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -52,17 +52,22 @@ Perform an iFFT to obtain the quantity defined by `f_fourier` defined
 on the k-dependent spherical basis set (if `kpt` is given) or the
 k-independent cubic (if it is not) on the real-space grid.
 """
-function ifft(basis::PlaneWaveBasis, f_fourier::AbstractArray; assume_real=Val(true))
-    # assume_real is true by default because this is the most common usage
-    # (for densities & potentials). Val(true) to help const-prop;
-    # see https://github.com/JuliaLang/julia/issues/44330
+function ifft(basis::PlaneWaveBasis, f_fourier::AbstractArray)
     f_real = similar(f_fourier)
     @assert length(size(f_fourier)) ∈ (3, 4)
     # this exploits trailing index convention
     for iσ = 1:size(f_fourier, 4)
         @views ifft!(f_real[:, :, :, iσ], basis, f_fourier[:, :, :, iσ])
     end
-    (assume_real == Val(true)) ? real(f_real) : f_real
+    f_real
+end
+"""
+Perform a real valued iFFT; see `ifft`.
+"""
+function irfft(basis::PlaneWaveBasis{T}, f_fourier::AbstractArray; check=Val(true)) where {T}
+    f_real = ifft(basis, f_fourier)
+    (check == Val(true)) && @assert isapprox(norm(imag(f_real)), 0.0, atol=sqrt(eps(T)))
+    real(f_real)
 end
 function ifft(basis::PlaneWaveBasis, kpt::Kpoint, f_fourier::AbstractVector; kwargs...)
     ifft!(similar(f_fourier, basis.fft_size...), basis, kpt, f_fourier; kwargs...)

--- a/src/guess_density.jl
+++ b/src/guess_density.jl
@@ -94,7 +94,7 @@ and are placed at `position` (in fractional coordinates).
 """
 function gaussian_superposition(basis::PlaneWaveBasis{T}, gaussians) where {T}
     ρ = zeros(complex(T), basis.fft_size)
-    isempty(gaussians) && return ifft(basis, ρ)
+    isempty(gaussians) && return irfft(basis, ρ)
 
     # Fill ρ with the (unnormalized) Fourier transform, i.e. ∫ e^{-iGx} f(x) dx,
     # where f(x) is a weighted gaussian
@@ -109,7 +109,7 @@ function gaussian_superposition(basis::PlaneWaveBasis{T}, gaussians) where {T}
     end
 
     # projection in the normalized plane wave basis
-    ifft(basis, ρ / sqrt(basis.model.unit_cell_volume))
+    irfft(basis, ρ / sqrt(basis.model.unit_cell_volume))
 end
 
 

--- a/src/scf/chi0models.jl
+++ b/src/scf/chi0models.jl
@@ -66,7 +66,7 @@ function (χ0::DielectricModel)(basis; kwargs...)
     function apply!(δρ, δV, α=1)
         loc_δV = fft(basis, apply_sqrtL(δV))
         dielectric_loc_δV = @. C0 * kTF^2 * Gsq / 4T(π) / (kTF^2 - C0 * Gsq) * loc_δV
-        δρ .+= α .* apply_sqrtL(ifft(basis, dielectric_loc_δV))
+        δρ .+= α .* apply_sqrtL(irfft(basis, dielectric_loc_δV))
         δρ
     end
 end

--- a/src/scf/mixing.jl
+++ b/src/scf/mixing.jl
@@ -74,7 +74,7 @@ end
     δFspin_fourier = spin_density(δF_fourier)
 
     δρtot_fourier = δFtot_fourier .* G² ./ (kTF.^2 .+ G²)
-    δρtot = ifft(basis, δρtot_fourier)
+    δρtot = irfft(basis, δρtot_fourier)
 
     # Copy DC component, otherwise it never gets updated
     δρtot .+= mean(total_density(δF)) .- mean(δρtot)
@@ -83,7 +83,7 @@ end
         ρ_from_total_and_spin(δρtot, nothing)
     else
         δρspin_fourier = @. δFspin_fourier - δFtot_fourier * (4π * ΔDOS_Ω) / (kTF^2 + G²)
-        δρspin = ifft(basis, δρspin_fourier)
+        δρspin = irfft(basis, δρspin_fourier)
         ρ_from_total_and_spin(δρtot, δρspin)
     end
 end
@@ -138,7 +138,7 @@ end
     Gsq = [sum(abs2, G) for G in G_vectors_cart(basis)]
     δF_fourier = fft(basis, δF)
     δρ = @. δF_fourier * (kTF^2 - C0 * Gsq) / (εr * kTF^2 - C0 * Gsq)
-    δρ = ifft(basis, δρ)
+    δρ = irfft(basis, δρ)
     δρ .+= mean(δF) .- mean(δρ)
 end
 

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -334,8 +334,10 @@ function unfold_kcoords(kcoords, symmetries)
     end
 end
 
-# Filter the wavevectors that don't have an opposite, to ensure fourier_coeffs is real in
-# real space
-function force_real!(fourier_coeffs, basis)
+"""
+Ensure its real-space equivalent of passed Fourier-space representation is entirely real by
+removing wavevectors `G` that don't have a `-G` counterpart in the basis.
+"""
+function force_real!(basis, fourier_coeffs)
     lowpass_for_symmetry!(fourier_coeffs, basis; symmetries=[SymOp(-Mat3(I), Vec3(0, 0, 0))])
 end

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -209,7 +209,7 @@ Symmetrize a density by applying all the basis (by default) symmetries and formi
                                     ρin_fourier[:, :, :, σ], basis, symmetries)
         do_lowpass && lowpass_for_symmetry!(ρout_fourier[:, :, :, σ], basis; symmetries)
     end
-    ifft(basis, ρout_fourier ./ length(symmetries))
+    irfft(basis, ρout_fourier ./ length(symmetries))
 end
 
 """
@@ -332,4 +332,10 @@ function unfold_kcoords(kcoords, symmetries)
         digits = ceil(Int, -log10(SYMMETRY_TOLERANCE))
         normalize_kpoint_coordinate(round.(k; digits))
     end
+end
+
+# Filter the wavevectors that don't have an opposite, to ensure fourier_coeffs is real in
+# real space
+function force_real!(fourier_coeffs, basis)
+    lowpass_for_symmetry!(fourier_coeffs, basis; symmetries=[SymOp(-Mat3(I), Vec3(0, 0, 0))])
 end

--- a/src/terms/anyonic.jl
+++ b/src/terms/anyonic.jl
@@ -54,7 +54,7 @@ function make_div_free(basis::PlaneWaveBasis{T}, A) where {T}
             out[1][iG], out[2][iG] = vec
         end
     end
-    # TODO: see https://github.com/JuliaMolSim/DFTK.jl/pull/722
+    # TODO: forcing real-valued ifft; should be enforced at creation of array
     [irfft(basis, out[α]; check=Val(false)) for α = 1:2]
 end
 
@@ -119,7 +119,7 @@ function ene_ops(term::TermAnyonic, basis::PlaneWaveBasis{T}, ψ, occ; ρ, kwarg
             A2[iG] = -2T(π) * G[1] / G2 * (ρ_fourier[iG] - ρref_fourier[iG]) * im
         end
     end
-    # TODO: see https://github.com/JuliaMolSim/DFTK.jl/pull/722
+    # TODO: forcing real-valued ifft; should be enforced at creation of array
     Areal = [irfft(basis, A1; check=Val(false)) + term.Aref[1],
              irfft(basis, A2; check=Val(false)) + term.Aref[2],
              zeros(T, basis.fft_size)]
@@ -147,7 +147,7 @@ function ene_ops(term::TermAnyonic, basis::PlaneWaveBasis{T}, ψ, occ; ρ, kwarg
             eff_pot_fourier[iG] += +4T(π)*β * im * G[1] / G2 * eff_current_fourier[2][iG]
         end
     end
-    # TODO: see https://github.com/JuliaMolSim/DFTK.jl/pull/722
+    # TODO: forcing real-valued ifft; should be enforced at creation of array
     eff_pot_real = irfft(basis, eff_pot_fourier; check=Val(false))
     ops_ham = [ops_energy..., RealSpaceMultiplication(basis, basis.kpoints[1], eff_pot_real)]
 

--- a/src/terms/anyonic.jl
+++ b/src/terms/anyonic.jl
@@ -54,7 +54,8 @@ function make_div_free(basis::PlaneWaveBasis{T}, A) where {T}
             out[1][iG], out[2][iG] = vec
         end
     end
-    [ifft(basis, out[α]) for α = 1:2]
+    # TODO: see https://github.com/JuliaMolSim/DFTK.jl/pull/722
+    [irfft(basis, out[α]; check=Val(false)) for α = 1:2]
 end
 
 struct Anyonic
@@ -118,8 +119,9 @@ function ene_ops(term::TermAnyonic, basis::PlaneWaveBasis{T}, ψ, occ; ρ, kwarg
             A2[iG] = -2T(π) * G[1] / G2 * (ρ_fourier[iG] - ρref_fourier[iG]) * im
         end
     end
-    Areal = [ifft(basis, A1) + term.Aref[1],
-             ifft(basis, A2) + term.Aref[2],
+    # TODO: see https://github.com/JuliaMolSim/DFTK.jl/pull/722
+    Areal = [irfft(basis, A1; check=Val(false)) + term.Aref[1],
+             irfft(basis, A2; check=Val(false)) + term.Aref[2],
              zeros(T, basis.fft_size)]
 
     # 2 hbar β (-i∇)⋅A + β^2 |A|^2
@@ -145,7 +147,8 @@ function ene_ops(term::TermAnyonic, basis::PlaneWaveBasis{T}, ψ, occ; ρ, kwarg
             eff_pot_fourier[iG] += +4T(π)*β * im * G[1] / G2 * eff_current_fourier[2][iG]
         end
     end
-    eff_pot_real = ifft(basis, eff_pot_fourier)
+    # TODO: see https://github.com/JuliaMolSim/DFTK.jl/pull/722
+    eff_pot_real = irfft(basis, eff_pot_fourier; check=Val(false))
     ops_ham = [ops_energy..., RealSpaceMultiplication(basis, basis.kpoints[1], eff_pot_real)]
 
     E = zero(T)

--- a/src/terms/hartree.jl
+++ b/src/terms/hartree.jl
@@ -38,7 +38,7 @@ function TermHartree(basis::PlaneWaveBasis{T}, scaling_factor) where T
         @assert sum_charges == model.n_electrons
     end
     poisson_green_coeffs[1] = 0  # Compensating charge background => Zero DC
-    force_real!(poisson_green_coeffs, basis)  # Symmetrize Fourier coeffs to have real iFFT
+    force_real!(basis, poisson_green_coeffs)  # Symmetrize Fourier coeffs to have real iFFT
 
     TermHartree(T(scaling_factor), T(scaling_factor) .* poisson_green_coeffs)
 end

--- a/src/terms/hartree.jl
+++ b/src/terms/hartree.jl
@@ -38,6 +38,7 @@ function TermHartree(basis::PlaneWaveBasis{T}, scaling_factor) where T
         @assert sum_charges == model.n_electrons
     end
     poisson_green_coeffs[1] = 0  # Compensating charge background => Zero DC
+    force_real!(poisson_green_coeffs, basis)  # Symmetrize Fourier coeffs to have real iFFT
 
     TermHartree(T(scaling_factor), T(scaling_factor) .* poisson_green_coeffs)
 end
@@ -46,7 +47,7 @@ end
                                             ψ, occ; ρ, kwargs...) where {T}
     ρtot_fourier = fft(basis, total_density(ρ))
     pot_fourier = term.poisson_green_coeffs .* ρtot_fourier
-    pot_real = ifft(basis, pot_fourier)
+    pot_real = irfft(basis, pot_fourier)
     E = real(dot(pot_fourier, ρtot_fourier) / 2)
 
     ops = [RealSpaceMultiplication(basis, kpt, pot_real) for kpt in basis.kpoints]
@@ -64,5 +65,5 @@ function apply_kernel(term::TermHartree, basis::PlaneWaveBasis, δρ; kwargs...)
     δV = zero(δρ)
     δρtot = total_density(δρ)
     # note broadcast here: δV is 4D, and all its spin components get the same potential
-    δV .= ifft(basis, term.poisson_green_coeffs .* fft(basis, δρtot))
+    δV .= irfft(basis, term.poisson_green_coeffs .* fft(basis, δρtot))
 end

--- a/src/terms/local.jl
+++ b/src/terms/local.jl
@@ -51,7 +51,7 @@ function (external::ExternalFromFourier)(basis::PlaneWaveBasis{T}) where {T}
     pot_fourier = map(G_vectors_cart(basis)) do G
         convert_dual(complex(T), external.potential(G) / sqrt(unit_cell_volume))
     end
-    force_real!(pot_fourier, basis)  # Symmetrize Fourier coeffs to have real iFFT
+    force_real!(basis, pot_fourier)  # Symmetrize Fourier coeffs to have real iFFT
     TermExternal(irfft(basis, pot_fourier))
 end
 
@@ -83,7 +83,7 @@ function (::AtomicLocal)(basis::PlaneWaveBasis{T}) where {T}
         end
         pot / sqrt(model.unit_cell_volume)
     end
-    force_real!(pot_fourier, basis)  # Symmetrize Fourier coeffs to have real iFFT
+    force_real!(basis, pot_fourier)  # Symmetrize Fourier coeffs to have real iFFT
 
     pot_real = irfft(basis, pot_fourier)
     TermAtomicLocal(pot_real)

--- a/src/terms/local.jl
+++ b/src/terms/local.jl
@@ -51,7 +51,8 @@ function (external::ExternalFromFourier)(basis::PlaneWaveBasis{T}) where {T}
     pot_fourier = map(G_vectors_cart(basis)) do G
         convert_dual(complex(T), external.potential(G) / sqrt(unit_cell_volume))
     end
-    TermExternal(ifft(basis, pot_fourier))
+    force_real!(pot_fourier, basis)  # Symmetrize Fourier coeffs to have real iFFT
+    TermExternal(irfft(basis, pot_fourier))
 end
 
 
@@ -82,8 +83,9 @@ function (::AtomicLocal)(basis::PlaneWaveBasis{T}) where {T}
         end
         pot / sqrt(model.unit_cell_volume)
     end
+    force_real!(pot_fourier, basis)  # Symmetrize Fourier coeffs to have real iFFT
 
-    pot_real = ifft(basis, pot_fourier)
+    pot_real = irfft(basis, pot_fourier)
     TermAtomicLocal(pot_real)
 end
 

--- a/src/terms/xc.jl
+++ b/src/terms/xc.jl
@@ -100,7 +100,7 @@ end
             mG² = [-sum(abs2, G) for G in G_vectors_cart(basis)]
             Vl  = reshape(terms.Vl, n_spin, basis.fft_size...)
             Vl_fourier = fft(basis, Vl[s, :, :, :])
-            # TODO: see https://github.com/JuliaMolSim/DFTK.jl/pull/722
+            # TODO: forcing real-valued ifft; should be enforced at creation of array
             potential[:, :, :, s] .+= irfft(basis, mG² .* Vl_fourier; check=Val(false))  # ΔVl
         end
     end
@@ -235,7 +235,7 @@ function LibxcDensities(basis, max_derivative::Integer, ρ, τ)
         for α = 1:3
             iGα = [im * G[α] for G in G_vectors_cart(basis)]
             for σ = 1:n_spin
-                # TODO: see https://github.com/JuliaMolSim/DFTK.jl/pull/722
+                # TODO: forcing real-valued ifft; should be enforced at creation of array
                 ∇ρ_real[σ, :, :, :, α] .= irfft(basis, iGα .* @view ρ_fourier[σ, :, :, :];
                                                 check=Val(false))
             end
@@ -257,7 +257,7 @@ function LibxcDensities(basis, max_derivative::Integer, ρ, τ)
         Δρ_real = similar(ρ_real, n_spin, basis.fft_size...)
         mG² = [-sum(abs2, G) for G in G_vectors_cart(basis)]
         for σ = 1:n_spin
-            # TODO: see https://github.com/JuliaMolSim/DFTK.jl/pull/722
+            # TODO: forcing real-valued ifft; should be enforced at creation of array
             Δρ_real[σ, :, :, :] .= irfft(basis, mG² .* @view ρ_fourier[σ, :, :, :];
                                          check=Val(false))
         end
@@ -451,6 +451,6 @@ function divergence_real(operand, basis)
         del_α = im * [G[α] for G in G_vectors_cart(basis)]
         del_α .* operand_α
     end
-    # TODO: see https://github.com/JuliaMolSim/DFTK.jl/pull/722
+    # TODO: forcing real-valued ifft; should be enforced at creation of array
     irfft(basis, gradsum; check=Val(false))
 end

--- a/src/terms/xc.jl
+++ b/src/terms/xc.jl
@@ -100,7 +100,8 @@ end
             mG² = [-sum(abs2, G) for G in G_vectors_cart(basis)]
             Vl  = reshape(terms.Vl, n_spin, basis.fft_size...)
             Vl_fourier = fft(basis, Vl[s, :, :, :])
-            potential[:, :, :, s] .+= ifft(basis, mG² .* Vl_fourier)  # ΔVl
+            # TODO: see https://github.com/JuliaMolSim/DFTK.jl/pull/722
+            potential[:, :, :, s] .+= irfft(basis, mG² .* Vl_fourier; check=Val(false))  # ΔVl
         end
     end
 
@@ -234,7 +235,9 @@ function LibxcDensities(basis, max_derivative::Integer, ρ, τ)
         for α = 1:3
             iGα = [im * G[α] for G in G_vectors_cart(basis)]
             for σ = 1:n_spin
-                ∇ρ_real[σ, :, :, :, α] .= ifft(basis, iGα .* @view ρ_fourier[σ, :, :, :])
+                # TODO: see https://github.com/JuliaMolSim/DFTK.jl/pull/722
+                ∇ρ_real[σ, :, :, :, α] .= irfft(basis, iGα .* @view ρ_fourier[σ, :, :, :];
+                                                check=Val(false))
             end
         end
 
@@ -254,7 +257,9 @@ function LibxcDensities(basis, max_derivative::Integer, ρ, τ)
         Δρ_real = similar(ρ_real, n_spin, basis.fft_size...)
         mG² = [-sum(abs2, G) for G in G_vectors_cart(basis)]
         for σ = 1:n_spin
-            Δρ_real[σ, :, :, :] .= ifft(basis, mG² .* @view ρ_fourier[σ, :, :, :])
+            # TODO: see https://github.com/JuliaMolSim/DFTK.jl/pull/722
+            Δρ_real[σ, :, :, :] .= irfft(basis, mG² .* @view ρ_fourier[σ, :, :, :];
+                                         check=Val(false))
         end
     end
 
@@ -446,5 +451,6 @@ function divergence_real(operand, basis)
         del_α = im * [G[α] for G in G_vectors_cart(basis)]
         del_α .* operand_α
     end
-    ifft(basis, gradsum)
+    # TODO: see https://github.com/JuliaMolSim/DFTK.jl/pull/722
+    irfft(basis, gradsum; check=Val(false))
 end

--- a/test/fourier_transforms.jl
+++ b/test/fourier_transforms.jl
@@ -14,7 +14,7 @@ include("testcases.jl")
         ifft!(f_R, pw, f_G)
 
         f2_G = fft(pw, f_R)
-        f2_R = ifft(pw, f2_G; assume_real=Val(false))
+        f2_R = ifft(pw, f2_G)
         f3_G = fft!(similar(f_R), pw, f_R)
 
         @test maximum(abs.(f2_G - f_G)) < 1e-12

--- a/test/hamiltonian_consistency.jl
+++ b/test/hamiltonian_consistency.jl
@@ -82,7 +82,7 @@ end
     test_consistency_term(AtomicLocal())
     test_consistency_term(AtomicNonlocal())
     test_consistency_term(ExternalFromReal(X -> cos(X[1])))
-    test_consistency_term(ExternalFromFourier(X -> randn()))
+    test_consistency_term(ExternalFromFourier(X -> abs(norm(X))))
     test_consistency_term(LocalNonlinearity(ρ -> ρ^2))
     test_consistency_term(Hartree())
     test_consistency_term(Ewald())


### PR DESCRIPTION
Related to #36.

Introducing `irfft` when the inverse Fourier transform is expected to be real, with a check on imaginary part by default.
For some quantities where the Fourier coefficients are computed by hand, we apply `force_real!` to ensure that the inverse Fourier transform is real by removing coefficients for `G` that do not have a `-G` counterpart in the basis.
For some quantities the check has been lazily disabled (which was done silently by default). There are put as `TODO` in comments, as we should have a way not to cast them brutally as real.