### PR TITLE
Fix definition of erfc

### DIFF
--- a/src/workarounds/forwarddiff_rules.jl
+++ b/src/workarounds/forwarddiff_rules.jl
@@ -306,6 +306,6 @@ function erfc(x::Complex{ForwardDiff.Dual{T,V,N}}) where {T,V,N}
     xx = complex(ForwardDiff.value(real(x)), ForwardDiff.value(imag(x)))
     dx = complex.(ForwardDiff.partials(real(x)), ForwardDiff.partials(imag(x)))
     dgamma = -2*exp(-xx^2)/sqrt(π) * dx
-    complex(ForwardDiff.Dual{T,V,N}(real(gamma(0.5, xx^2)), ForwardDiff.Partials{N,V}(tuple(real(dgamma)...))),
-            ForwardDiff.Dual{T,V,N}(imag(gamma(0.5, xx^2)), ForwardDiff.Partials{N,V}(tuple(imag(dgamma)...))))
+    complex(ForwardDiff.Dual{T,V,N}(real(erfc(xx)), ForwardDiff.Partials{N,V}(tuple(real(dgamma)...))),
+            ForwardDiff.Dual{T,V,N}(imag(erfc(xx)), ForwardDiff.Partials{N,V}(tuple(imag(dgamma)...))))
 end

--- a/src/workarounds/forwarddiff_rules.jl
+++ b/src/workarounds/forwarddiff_rules.jl
@@ -305,8 +305,7 @@ end
 function erfc(x::Complex{ForwardDiff.Dual{T,V,N}}) where {T,V,N}
     xx = complex(ForwardDiff.value(real(x)), ForwardDiff.value(imag(x)))
     dx = complex.(ForwardDiff.partials(real(x)), ForwardDiff.partials(imag(x)))
-    Tx = typeof(xx)
-    dgamma = -2*exp(-xx^2)/sqrt(Tx(π)) * dx
+    dgamma = -2*exp(-xx^2)/sqrt(V(π)) * dx
     complex(ForwardDiff.Dual{T,V,N}(real(erfc(xx)), ForwardDiff.Partials{N,V}(tuple(real(dgamma)...))),
             ForwardDiff.Dual{T,V,N}(imag(erfc(xx)), ForwardDiff.Partials{N,V}(tuple(imag(dgamma)...))))
 end

--- a/src/workarounds/forwarddiff_rules.jl
+++ b/src/workarounds/forwarddiff_rules.jl
@@ -305,7 +305,8 @@ end
 function erfc(x::Complex{ForwardDiff.Dual{T,V,N}}) where {T,V,N}
     xx = complex(ForwardDiff.value(real(x)), ForwardDiff.value(imag(x)))
     dx = complex.(ForwardDiff.partials(real(x)), ForwardDiff.partials(imag(x)))
-    dgamma = -2*exp(-xx^2)/sqrt(π) * dx
+    Tx = typeof(xx)
+    dgamma = -2*exp(-xx^2)/sqrt(Tx(π)) * dx
     complex(ForwardDiff.Dual{T,V,N}(real(erfc(xx)), ForwardDiff.Partials{N,V}(tuple(real(dgamma)...))),
             ForwardDiff.Dual{T,V,N}(imag(erfc(xx)), ForwardDiff.Partials{N,V}(tuple(imag(dgamma)...))))
 end

--- a/test/forwarddiff.jl
+++ b/test/forwarddiff.jl
@@ -122,7 +122,7 @@ end
     tol = 1e-10
     α = randn(ComplexF64)
     erfcα = x -> erfc(α * x)
-    
+
     x0  = randn()
     fd1 = ForwardDiff.derivative(erfcα , x0)
     fd2 = FiniteDifferences.central_fdm(5, 1)(erfcα, x0)


### PR DESCRIPTION
Sorry, messed up previous commit, `erfc(x) = Γ(0.5, x)/sqrt(π)`... and I only checked derivatives which where ok.