### PR TITLE
Save some matrix-vector products in Sternheimer solver

### DIFF
--- a/src/response/chi0.jl
+++ b/src/response/chi0.jl
@@ -295,10 +295,10 @@ end
 
     # compute δψnk band per band
     δψ = zero.(ψ)
-    Hψ_extra = ham * ψ_extra
     for ik = 1:Nk
         ψk = ψ_occ[ik]
         δψk = δψ[ik]
+        Hψk_extra = ham.blocks[ik] * ψ_extra[ik]
 
         εk = ε_occ[ik]
         for n = 1:length(εk)
@@ -316,7 +316,7 @@ end
             # Sternheimer contribution
             δψk[:, n] .+= sternheimer_solver(ham.blocks[ik], ψk, εk[n], δHψ[ik][:, n], n;
                                              ψk_extra=ψ_extra[ik], εk_extra=ε_extra[ik],
-                                             Hψk_extra=Hψ_extra[ik], kwargs_sternheimer...)
+                                             Hψk_extra, kwargs_sternheimer...)
         end
     end
 

--- a/src/response/chi0.jl
+++ b/src/response/chi0.jl
@@ -111,6 +111,7 @@ precondprep!(P::FunctionPreconditioner, ::Any) = P
 # included).
 function sternheimer_solver(Hk, ψk, εnk, rhs, n; callback=info->nothing,
                             ψk_extra=zeros(size(ψk,1), 0), εk_extra=zeros(0),
+                            Hψk_extra=zeros(size(ψk,1), 0),
                             abstol=1e-9, reltol=0, verbose=false)
     basis = Hk.basis
     kpoint = Hk.kpoint
@@ -163,7 +164,6 @@ function sternheimer_solver(Hk, ψk, εnk, rhs, n; callback=info->nothing,
     # is defined above and b is the projection of -rhs onto Ran(Q).
     #
     b = -Q(rhs)
-    Hψk_extra = H(ψk_extra)
     bb = R(b -  Hψk_extra * (ψk_exHψk_ex \ ψk_extra'b))
     function RAR(ϕ)
         Rϕ = R(ϕ)
@@ -295,6 +295,7 @@ end
 
     # compute δψnk band per band
     δψ = zero.(ψ)
+    Hψ_extra = ham * ψ_extra
     for ik = 1:Nk
         ψk = ψ_occ[ik]
         δψk = δψ[ik]
@@ -315,7 +316,7 @@ end
             # Sternheimer contribution
             δψk[:, n] .+= sternheimer_solver(ham.blocks[ik], ψk, εk[n], δHψ[ik][:, n], n;
                                              ψk_extra=ψ_extra[ik], εk_extra=ε_extra[ik],
-                                             kwargs_sternheimer...)
+                                             Hψk_extra=Hψ_extra[ik], kwargs_sternheimer...)
         end
     end
 

--- a/src/response/chi0.jl
+++ b/src/response/chi0.jl
@@ -169,7 +169,7 @@ function sternheimer_solver(Hk, ψk, εnk, rhs, n; callback=info->nothing,
         Rϕ = R(ϕ)
         # Schur complement of (1-P) (H-εn) (1-P)
         # with the splitting Ran(1-P) = Ran(P_extra) ⊕ Ran(R)
-        R(H(Rϕ)) - R(Hψk_extra) * (ψk_exHψk_ex \ Hψk_extra'Rϕ)
+        R(H(Rϕ) - Hψk_extra * (ψk_exHψk_ex \ Hψk_extra'Rϕ))
     end
     precon = PreconditionerTPA(basis, kpoint)
     precondprep!(precon, ψk[:, n])

--- a/src/response/chi0.jl
+++ b/src/response/chi0.jl
@@ -163,13 +163,13 @@ function sternheimer_solver(Hk, ψk, εnk, rhs, n; callback=info->nothing,
     # is defined above and b is the projection of -rhs onto Ran(Q).
     #
     b = -Q(rhs)
-    bb = R(b -  H(ψk_extra * (ψk_exHψk_ex \ ψk_extra'b)))
+    Hψk_extra = H(ψk_extra)
+    bb = R(b -  Hψk_extra * (ψk_exHψk_ex \ ψk_extra'b))
     function RAR(ϕ)
         Rϕ = R(ϕ)
-        # A denotes here the Schur complement of (1-P) (H-εn) (1-P)
+        # Schur complement of (1-P) (H-εn) (1-P)
         # with the splitting Ran(1-P) = Ran(P_extra) ⊕ Ran(R)
-        ARϕ = Rϕ - ψk_extra * (ψk_exHψk_ex \ ψk_extra'H(Rϕ))
-        R(H(ARϕ))
+        R(H(Rϕ)) - R(Hψk_extra) * (ψk_exHψk_ex \ Hψk_extra'Rϕ)
     end
     precon = PreconditionerTPA(basis, kpoint)
     precondprep!(precon, ψk[:, n])

--- a/src/terms/Hamiltonian.jl
+++ b/src/terms/Hamiltonian.jl
@@ -119,7 +119,7 @@ end
     n_bands = size(ψ, 2)
     # return empty array if ψ is empty
     if iszero(n_bands)
-        return zeros(size(ψ,1), 0)
+        return zeros(eltype(ψ), size(ψ,1), 0)
     end
     have_divAgrad = !isnothing(H.divAgrad_op)
 

--- a/src/terms/Hamiltonian.jl
+++ b/src/terms/Hamiltonian.jl
@@ -117,6 +117,10 @@ end
                                                                            H::DftHamiltonianBlock,
                                                                            ψ::AbstractArray)
     n_bands = size(ψ, 2)
+    # return empty array if ψ is empty
+    if iszero(n_bands)
+        return zeros(size(ψ,1), 0)
+    end
     have_divAgrad = !isnothing(H.divAgrad_op)
 
     # Notice that we use unnormalized plans for extra speed

--- a/src/terms/Hamiltonian.jl
+++ b/src/terms/Hamiltonian.jl
@@ -117,10 +117,7 @@ end
                                                                            H::DftHamiltonianBlock,
                                                                            ψ::AbstractArray)
     n_bands = size(ψ, 2)
-    # return empty array if ψ is empty
-    if iszero(n_bands)
-        return zeros(eltype(ψ), size(ψ,1), 0)
-    end
+    iszero(n_bands) && return Hψ  # Nothing to do if ψ empty
     have_divAgrad = !isnothing(H.divAgrad_op)
 
     # Notice that we use unnormalized plans for extra speed

--- a/test/chi0.jl
+++ b/test/chi0.jl
@@ -72,6 +72,17 @@ function test_chi0(testcase; symmetries=false, temperature=0,
         diff_applied_χ0 = apply_χ0(scfres, δV)
         @test norm(diff_findiff - diff_applied_χ0) < testtol
 
+        # Test apply_χ0 without extra bands
+        ψ_occ, occ_occ = DFTK.select_occupied_orbitals(basis,
+                                                       scfres.ψ,
+                                                       scfres.occupation;
+                                                       threshold=scfres.occupation_threshold)
+        ε_occ = [scfres.eigenvalues[ik][1:size(ψk,2)] for (ik, ψk) in enumerate(ψ_occ)]
+
+        diff_applied_χ0_noextra = apply_χ0(scfres.ham, ψ_occ, occ_occ, scfres.εF,
+                                           ε_occ, δV; scfres.occupation_threshold)
+        @test norm(diff_applied_χ0_noextra - diff_applied_χ0) < testtol
+
         # just to cover it here
         if temperature > 0
             D = compute_dos(εF, basis, res.eigenvalues)

--- a/test/chi0.jl
+++ b/test/chi0.jl
@@ -77,7 +77,7 @@ function test_chi0(testcase; symmetries=false, temperature=0,
                                                        scfres.ψ,
                                                        scfres.occupation;
                                                        threshold=scfres.occupation_threshold)
-        ε_occ = [scfres.eigenvalues[ik][1:size(ψk,2)] for (ik, ψk) in enumerate(ψ_occ)]
+        ε_occ = [scfres.eigenvalues[ik][1:size(ψk, 2)] for (ik, ψk) in enumerate(ψ_occ)]
 
         diff_applied_χ0_noextra = apply_χ0(scfres.ham, ψ_occ, occ_occ, scfres.εF,
                                            ε_occ, δV; scfres.occupation_threshold)


### PR DESCRIPTION
Two small things I realized yesterday and that I optimized.
- The Schur complement in the Sternheimer solver was not optimized with two Hamiltonian applications per CG iteration, even when extra arrays were empty. So I changed it to one Hamiltonian application per CG iteration, with additional `ham * ψ_extra` which is required only once. This makes it about twice faster !
- Doing this, I realized that `ham * ψ` with `ψ` an array of size zero was not supported in the optimized version of `DftHamiltonian multiplication`, so I added a test to support that. We did not see this before because we had `ψ_extra' * ham * ψ` with `ψ_extra` empty, which is not optimal at all ;)