### PR TITLE
Transfer phonon

### DIFF
--- a/src/transfer.jl
+++ b/src/transfer.jl
@@ -140,7 +140,7 @@ function find_equivalent_kpt(basis::PlaneWaveBasis{T}, kcoord, spin; tol=sqrt(ep
     indices_σ = krange_spin(basis, spin)
     kcoords_σ = getfield.(basis.kpoints[indices_σ], :coordinate)
     # Unique by construction.
-    index::Int = findfirst(isapprox.(kcoords_σ, Ref(kcoord_red); atol=tol)) + indices_σ[1]-1
+    index::Int = findfirst(isapprox(kcoord_red; atol=tol), kcoords_σ) + (indices_σ[1] - 1)
 
     return (; index, ΔG)
 end

--- a/src/transfer.jl
+++ b/src/transfer.jl
@@ -97,38 +97,6 @@ function transfer_blochwave_kpt(ψk_in, basis::PlaneWaveBasis, kpt_in, kpt_out, 
 end
 
 """
-Find the equivalent index of the coordinate `kcoord` ∈ ℝ³ in a list `kcoords` ∈ [-½, ½)³.
-`ΔG` is the vector of ℤ³ such that `kcoords[index] = kcoord + ΔG`.
-"""
-function find_equivalent_kpt(kcoords::Vector{Vec3{T}}, kcoord; tol=100*eps(T)) where {T}
-    kcoord_normalized = mod.(Vector(kcoord), 1)  # coordinate in [0, 1)³
-    kcoord_normalized[kcoord_normalized .≥ 0.5  - tol] .-= 1  # coordinate in [-½, ½)
-
-    indices = findall(e -> is_approx_integer(e - kcoord_normalized; tol), kcoords)
-    index = only(indices)
-
-    ΔG = kcoord_normalized - kcoord
-
-    # ΔG should be an integer.
-    @assert all(is_approx_integer.(ΔG; tol))
-    ΔG = round.(Int, ΔG)
-
-    return (; index, ΔG)
-end
-
-"""
-Return the Fourier coefficients for `ψk · e^{i q·r}` in the basis of `kpt_out`, where `ψk`
-is defined on a basis `kpt_in`.
-"""
-function multiply_by_expiqr(basis, kpt_in, q, ψk; transfer_fn=transfer_blochwave_kpt)
-    kcoords = getfield.(basis.kpoints, :coordinate)
-    shifted_kcoord = kpt_in.coordinate .+ q  # coordinate of ``k``-point in ℝ
-    (index, ΔG) = find_equivalent_kpt(kcoords, shifted_kcoord)
-    kpt_out = basis.kpoints[index]
-    return transfer_fn(ψk, basis, kpt_in, kpt_out, ΔG)
-end
-
-"""
 Transfer Bloch wave between two basis sets. Limited feature set.
 """
 function transfer_blochwave(ψ_in, basis_in::PlaneWaveBasis{T},
@@ -152,4 +120,48 @@ function transfer_blochwave(ψ_in, basis_in::PlaneWaveBasis{T},
     map(enumerate(basis_out.kpoints)) do (ik, kpt_out)
         transfer_blochwave_kpt(ψ_in[ik], basis_in, basis_in.kpoints[ik], basis_out, kpt_out)
     end
+end
+
+"""
+Find the equivalent index of the coordinate `kcoord` ∈ ℝ³ in a list `kcoords` ∈ [-½, ½)³.
+`ΔG` is the vector of ℤ³ such that `kcoords[index] = kcoord + ΔG`.
+"""
+function find_equivalent_kpt(kpoints::Vector{Kpoint{T}}, kcoord, spin; tol=sqrt(eps(T))) where {T}
+    kcoord_red = map(kcoord) do k
+                     k = mod(k, 1)              # coordinate in [0, 1)³
+                     k ≥ 0.5 - tol ? k - 1 : k  # coordinate in [-½, ½)³
+                 end
+
+    ΔG = kcoord_red - kcoord
+    # ΔG should be an integer.
+    @assert all(is_approx_integer.(ΔG))
+    ΔG = round.(Int, ΔG)
+
+    index::Int = findfirst(k -> k.spin == spin && isapprox(k.coordinate, kcoord_red; atol=tol),
+                           kpoints)  # unique by construction
+
+    return (; index, ΔG)
+end
+
+"""
+Return the Fourier coefficients for `ψk · e^{i q·r}` in the basis of `kpt_out`, where `ψk`
+is defined on a basis `kpt_in`.
+"""
+function multiply_by_expiqr(basis, kpt_in, q, ψk)
+    shifted_kcoord = kpt_in.coordinate .+ q  # coordinate of ``k``-point in ℝ
+    index, ΔG = find_equivalent_kpt(basis.kpoints, shifted_kcoord, kpt_in.spin)
+    kpt_out = basis.kpoints[index]
+    return transfer_blochwave_kpt(ψk, basis, kpt_in, kpt_out, ΔG)
+end
+
+"""
+Return an `ordering` function that reorders the `kpoints`. That is for each `kpoint` of the
+`basis`: `kpoints[ik].coordinate + q = ordering(kpoints)[ik].coordinate`.
+"""
+function kpoints_ordering(basis::PlaneWaveBasis, qcoord)
+    kpoints = basis.kpoints
+    indices = [find_equivalent_kpt(kpoints, kpt.coordinate + qcoord, kpt.spin).index
+               for kpt in kpoints]
+    @assert sort(indices) == 1:length(kpoints)
+    x -> view(x, indices)
 end

--- a/src/transfer.jl
+++ b/src/transfer.jl
@@ -139,6 +139,7 @@ function find_equivalent_kpt(basis::PlaneWaveBasis{T}, kcoord, spin; tol=sqrt(ep
 
     indices_σ = krange_spin(basis, spin)
     kcoords_σ = getfield.(basis.kpoints[indices_σ], :coordinate)
+    # Unique by construction.
     index::Int = findfirst(isapprox.(kcoords_σ, Ref(kcoord_red); atol=tol)) + indices_σ[1]-1
 
     return (; index, ΔG)

--- a/src/transfer.jl
+++ b/src/transfer.jl
@@ -157,10 +157,10 @@ function multiply_by_expiqr(basis, kpt_in, q, ψk)
 end
 
 """
-Return an `ordering` function that reorders the `kpoints`. That is for each `kpoint` of the
-`basis`: `kpoints[ik].coordinate + q = ordering(kpoints)[ik].coordinate`.
+Return the indices of the `kpoints` shifted by `q`. That is for each `kpoint` of the `basis`:
+`kpoints[ik].coordinate + q = kpoints[indices[ik]].coordinate`.
 """
-function kpoints_ordering(basis::PlaneWaveBasis, qcoord)
+function k_to_kpq_mapping(basis::PlaneWaveBasis, qcoord)
     kpoints = basis.kpoints
     indices = [find_equivalent_kpt(basis, kpt.coordinate + qcoord, kpt.spin).index
                for kpt in kpoints]

--- a/test/phonon.jl
+++ b/test/phonon.jl
@@ -160,7 +160,7 @@ end
             ψk = fft(basis, kpt, ψ)
 
             ψk_out_four = DFTK.multiply_by_expiqr(basis, kpt, q, ψk)
-            ψk_out_real = begin
+            ψk_out_real = let
                 shifted_kcoord = kpt.coordinate .+ q
                 index, ΔG = DFTK.find_equivalent_kpt(basis, shifted_kcoord, kpt.spin)
                 kpt_out = basis.kpoints[index]

--- a/test/phonon.jl
+++ b/test/phonon.jl
@@ -173,13 +173,11 @@ end
     end
 
     @testset "Ordering function" begin
-        @time begin
-            kpoints_plus_q = DFTK.kpoints_ordering(basis, q)
-            ordering(kdata) = kdata[kpoints_plus_q]
-            kcoords = getfield.(basis.kpoints, :coordinate)
-            for (ik, kcoord) in enumerate(kcoords)
-                @test mod.(kcoord + q .- tol, 1) ≈ mod.(ordering(kcoords)[ik] .- tol, 1)
-            end
+        kpoints_plus_q = DFTK.kpoints_ordering(basis, q)
+        ordering(kdata) = kdata[kpoints_plus_q]
+        kcoords = getfield.(basis.kpoints, :coordinate)
+        for (ik, kcoord) in enumerate(kcoords)
+            @test mod.(kcoord + q .- tol, 1) ≈ mod.(ordering(kcoords)[ik] .- tol, 1)
         end
     end
 end

--- a/test/phonon.jl
+++ b/test/phonon.jl
@@ -173,7 +173,7 @@ end
     end
 
     @testset "Ordering function" begin
-        kpoints_plus_q = DFTK.kpoints_ordering(basis, q)
+        kpoints_plus_q = DFTK.k_to_kpq_mapping(basis, q)
         ordering(kdata) = kdata[kpoints_plus_q]
         kcoords = getfield.(basis.kpoints, :coordinate)
         for (ik, kcoord) in enumerate(kcoords)

--- a/test/phonon.jl
+++ b/test/phonon.jl
@@ -110,16 +110,16 @@ end
 
 
 @testset "Phonon consistency" begin
-    max_radius = 1e3
-    tolerance = 1e-6
+    tol = 1e-6
     n_points = 10
+    max_radius = 1e3
 
     ph_bands = [test_ph_disp(; n_scell, max_radius, n_points) for n_scell in 1:3]
 
     # Recover the same extremum for the system whatever case we test
     for n_scell in 2:3
-        @test minimum(fold(ph_bands[1])) ≈ minimum(fold(ph_bands[n_scell])) atol=tolerance
-        @test maximum(fold(ph_bands[1])) ≈ maximum(fold(ph_bands[n_scell])) atol=tolerance
+        @test minimum(fold(ph_bands[1])) ≈ minimum(fold(ph_bands[n_scell])) atol=tol
+        @test maximum(fold(ph_bands[1])) ≈ maximum(fold(ph_bands[n_scell])) atol=tol
     end
 
     # Test consistency between supercell method at `q = 0` and direct `q`-points computations
@@ -127,13 +127,13 @@ end
         r_q0 = test_supercell_q0(; n_scell, max_radius)
         @assert length(r_q0) == n_scell
         ph_band_q0 = ph_bands[n_scell][n_points÷2+1]
-        @test norm(r_q0 - ph_band_q0) < tolerance
+        @test norm(r_q0 - ph_band_q0) < tol
     end
 end
 
-@testset "Test shifting function" begin
+@testset "Shifting functions" begin
     Random.seed!()
-    tolerance = 1e-12
+    tol = 1e-12
 
     case = prepare_3d_system()
 
@@ -142,7 +142,7 @@ end
     n_atoms = length(case.positions)
 
     model = Model(case.lattice, atoms, case.positions; n_electrons=n_atoms,
-                  symmetries=false, spin_polarization=:spinless)
+                  symmetries=false, spin_polarization=:collinear)
     kgrid = rand(2:20, 3)
     k1, k2, k3 = kgrid
     basis = PlaneWaveBasis(model; Ecut=100, kgrid)
@@ -154,15 +154,29 @@ end
     # Random `q` shift
     q0 = rand(basis.kpoints).coordinate
     ishift = [rand(-k1*2:k1*2), rand(-k2*2:k2*2), rand(-k3*2:k3*2)]
-    q = q0 .* ishift
-    for kpt in unique(rand(basis.kpoints, 4))
-        ψk = fft(basis, kpt, ψ)
+    q = Vec3(q0 .* ishift)
+    @testset "Transfer function" begin
+        for kpt in unique(rand(basis.kpoints, 4))
+            ψk = fft(basis, kpt, ψ)
 
-        ψk_out_four = DFTK.multiply_by_expiqr(basis, kpt, q, ψk)
-        ψk_out_real = DFTK.multiply_by_expiqr(basis, kpt, q, ψk;
-                                              transfer_fn=transfer_blochwave_kpt_real)
-        @testset "Testing kpoint $(kpt.coordinate) on kgrid $kgrid" begin
-            @test norm(ψk_out_four - ψk_out_real) < tolerance
+            ψk_out_four = DFTK.multiply_by_expiqr(basis, kpt, q, ψk)
+            ψk_out_real = begin
+                shifted_kcoord = kpt.coordinate .+ q
+                index, ΔG = DFTK.find_equivalent_kpt(basis.kpoints, shifted_kcoord, kpt.spin)
+                kpt_out = basis.kpoints[index]
+                transfer_blochwave_kpt_real(ψk, basis, kpt, kpt_out, ΔG)
+            end
+            @testset "Testing kpoint $(kpt.coordinate) on kgrid $kgrid" begin
+                @test norm(ψk_out_four - ψk_out_real) < tol
+            end
+        end
+    end
+
+    @testset "Ordering function" begin
+        ordering = DFTK.kpoints_ordering(basis, q)
+        kcoords = getfield.(basis.kpoints, :coordinate)
+        for (ik, kcoord) in enumerate(kcoords)
+            @test mod1.(kcoord + q .- tol, 1) ≈ mod1.(ordering(kcoords)[ik] .- tol, 1)
         end
     end
 end


### PR DESCRIPTION
Some ground work to simplify the review of the phonon PR (https://github.com/JuliaMolSim/DFTK.jl/pull/752).

Modification to remove transfer function as argument, and to take care of spins.