### PR TITLE
Update Brillouin to 0.5.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -50,7 +50,7 @@ spglib_jll = "ac4a9f1e-bdb2-5204-990c-47c8b2f70d4e"
 [compat]
 AbstractFFTs = "1"
 AtomsBase = "0.2.2"
-Brillouin = "0.5.4"
+Brillouin = "0.5.10"
 ChainRulesCore = "1.15"
 Conda = "1"
 DftFunctionals = "0.2"


### PR DESCRIPTION
Fix https://github.com/JuliaMolSim/DFTK.jl/issues/767 . I couldn't find which version exports this, so I just required the latest