### PR TITLE
update comments and dH->dV

### DIFF
--- a/src/response/chi0.jl
+++ b/src/response/chi0.jl
@@ -192,16 +192,16 @@ function sternheimer_solver(Hk, ψk, ε, rhs;
 end
 
 # Apply the four-point polarizability operator χ0_4P = -Ω^-1
-# Returns (δψ, δocc, δεF) corresponding to a change in *total* Hamiltonian δV
+# Returns (δψ, δocc, δεF) corresponding to a change in *total* Hamiltonian δH
 # We start from
 # P = f(H-εF) = ∑_n fn |ψn><ψn|, tr(P) = N
 # where P is the density matrix, f the occupation function.
 # Charge conservation yields δεF as follows:
-# δεn = <ψn|δV|ψn>
+# δεn = <ψn|δH|ψn>
 # 0 = ∑_n fn' (δεn - δεF) determines δεF
 # where fn' = f'((εn-εF)/T)/T.
 
-# Then <ψm|δP|ψn> = (fm-fn)/(εm-εn) <ψm|δV|ψn>,
+# Then <ψm|δP|ψn> = (fm-fn)/(εm-εn) <ψm|δH|ψn>,
 # except for the diagonal which is
 # <ψn|δP|ψn> = (fn'-δεF) δεn.
 
@@ -209,7 +209,7 @@ end
 # δψ is orthogonal at finite temperature. A formal differentiation yields
 # δP = ∑_n fn (|δψn><ψn| + |ψn><δψn|) + δfn |ψn><ψn|.
 # Identifying with <ψm|δP|ψn> we get for the off-diagonal terms
-# (fm-fn)/(εm-εn) <ψm|δV|ψn> = fm <δψm|ψn> + fn <ψm|δψn>.
+# (fm-fn)/(εm-εn) <ψm|δH|ψn> = fm <δψm|ψn> + fn <ψm|δψn>.
 # For the diagonal terms, n==m and we obtain
 # 0 = ∑_n Re (fn <ψn|δψn>) + δfn,
 # so that a gauge choice has to be made here. We choose to set <ψn|δψn> = 0 and
@@ -223,10 +223,10 @@ end
 # We split the computation of δψn in two contributions:
 # for the already-computed states, we add an explicit contribution
 # for the empty states, we solve a Sternheimer equation
-# (H-εn) δψn = - P_{ψ^⟂} δV ψn
+# (H-εn) δψn = - P_{ψ^⟂} δH ψn
 
 # The off-diagonal explicit term needs a careful consideration of stability.
-# Let <ψm|δψn> = αmn <ψm|δV|ψn>. αmn has to satisfy
+# Let <ψm|δψn> = αmn <ψm|δH|ψn>. αmn has to satisfy
 # fn αmn + fm αnm = ratio = (fn-fm)/(εn-εm)   (*)
 # The usual way is to impose orthogonality (=> αmn=-αnm),
 # but this means that αmn = 1/(εm-εn), which is unstable
@@ -249,7 +249,7 @@ end
 """
 Compute the derivatives of the occupations (and of the Fermi level).
 """
-function compute_δocc(basis, ψ, occ, εF::T, ε, δVψ) where {T}
+function compute_δocc(basis, ψ, occ, εF::T, ε, δHψ) where {T}
     model = basis.model
     temperature = model.temperature
     smearing = model.smearing
@@ -263,7 +263,7 @@ function compute_δocc(basis, ψ, occ, εF::T, ε, δVψ) where {T}
         D = zero(T)
         for ik = 1:Nk, (n, εnk) in enumerate(ε[ik])
             enred = (εnk - εF) / temperature
-            δεnk = real(dot(ψ[ik][:, n], δVψ[ik][:, n]))
+            δεnk = real(dot(ψ[ik][:, n], δHψ[ik][:, n]))
             fpnk = filled_occ * Smearing.occupation_derivative(smearing, enred) / temperature
             δocc[ik][n] = δεnk * fpnk
             D += fpnk * basis.kweights[ik]
@@ -287,7 +287,7 @@ end
 Compute the derivatives of the wave functions by solving a Sternheimer equation for each
 `k`-points.
 """
-function compute_δψ(basis, H, ψ, εF, ε, δVψ; ψ_extra=[zeros(size(ψk,1), 0) for ψk in ψ],
+function compute_δψ(basis, H, ψ, εF, ε, δHψ; ψ_extra=[zeros(size(ψk,1), 0) for ψk in ψ],
                     kwargs_sternheimer...)
     model = basis.model
     temperature = model.temperature
@@ -296,7 +296,7 @@ function compute_δψ(basis, H, ψ, εF, ε, δVψ; ψ_extra=[zeros(size(ψk,1),
     Nk = length(basis.kpoints)
 
     # Compute δψnk band per band
-    δψ = zero.(δVψ)
+    δψ = zero.(δHψ)
     for ik = 1:Nk
         Hk  = H[ik]
         ψk  = ψ[ik]
@@ -318,18 +318,18 @@ function compute_δψ(basis, H, ψ, εF, ε, δVψ; ψ_extra=[zeros(size(ψk,1),
                 ddiff = Smearing.occupation_divided_difference
                 ratio = filled_occ * ddiff(smearing, εk[m], εk[n], εF, temperature)
                 αmn = compute_αmn(fmk, fnk, ratio)  # fnk * αmn + fmk * αnm = ratio
-                δψk[:, n] .+= ψk[:, m] .* αmn .* dot(ψk[:, m], δVψ[ik][:, n])
+                δψk[:, n] .+= ψk[:, m] .* αmn .* dot(ψk[:, m], δHψ[ik][:, n])
             end
 
             # Sternheimer contribution
-            δψk[:, n] .+= sternheimer_solver(Hk, ψk, εk[n], δVψ[ik][:, n]; ψk_extra,
+            δψk[:, n] .+= sternheimer_solver(Hk, ψk, εk[n], δHψ[ik][:, n]; ψk_extra,
                                              εk_extra, Hψk_extra, kwargs_sternheimer...)
         end
     end
     δψ
 end
 
-@views @timing function apply_χ0_4P(ham, ψ, occ, εF, eigenvalues, δVψ;
+@views @timing function apply_χ0_4P(ham, ψ, occ, εF, eigenvalues, δHψ;
                                     occupation_threshold, kwargs_sternheimer...)
     basis  = ham.basis
 
@@ -351,7 +351,7 @@ end
     occ_occ = [occ[ik][maskk] for (ik, maskk) in enumerate(mask_occ)]
 
     # First we compute δoccupation and δεF
-    δocc, δεF = compute_δocc(basis, ψ_occ, occ_occ, εF, ε_occ, δVψ)
+    δocc, δεF = compute_δocc(basis, ψ_occ, occ_occ, εF, ε_occ, δHψ)
     # Pad δoccupation
     δoccupation = zero.(occ)
     for (ik, maskk) in enumerate(mask_occ)
@@ -359,7 +359,7 @@ end
     end
 
     # Keeping zeros for extra bands to keep the output δψ with the same size than the input ψ
-    δψ = compute_δψ(basis, ham.blocks, ψ_occ, εF, ε_occ, δVψ; ψ_extra, kwargs_sternheimer...)
+    δψ = compute_δψ(basis, ham.blocks, ψ_occ, εF, ε_occ, δHψ; ψ_extra, kwargs_sternheimer...)
 
     (; δψ, δoccupation, δεF)
 end
@@ -385,9 +385,9 @@ function apply_χ0(ham, ψ, occupation, εF, eigenvalues, δV;
     normδV < eps(typeof(εF)) && return zero(δV)
     δV ./= normδV
 
-    δVψ = [DFTK.RealSpaceMultiplication(basis, kpt, @views δV[:, :, :, kpt.spin]) * ψ[ik]
+    δHψ = [DFTK.RealSpaceMultiplication(basis, kpt, @views δV[:, :, :, kpt.spin]) * ψ[ik]
            for (ik, kpt) in enumerate(basis.kpoints)]
-    δψ, δoccupation, δεF = apply_χ0_4P(ham, ψ, occupation, εF, eigenvalues, δVψ;
+    δψ, δoccupation, δεF = apply_χ0_4P(ham, ψ, occupation, εF, eigenvalues, δHψ;
                                        occupation_threshold, kwargs_sternheimer...)
     δρ = DFTK.compute_δρ(basis, ψ, δψ, occupation, δoccupation)
     δρ * normδV

--- a/src/response/chi0.jl
+++ b/src/response/chi0.jl
@@ -365,7 +365,7 @@ end
 end
 
 """
-Get the density variation δρ corresponding to a total potential variation δV.
+Get the density variation δρ corresponding to a potential variation δV.
 """
 function apply_χ0(ham, ψ, occupation, εF, eigenvalues, δV;
                   occupation_threshold=default_occupation_threshold(),

--- a/test/forwarddiff.jl
+++ b/test/forwarddiff.jl
@@ -20,11 +20,10 @@ include("testcases.jl")
         end
         basis = PlaneWaveBasis(model; Ecut=5, kgrid=[2, 2, 2], kshift=[0, 0, 0])
 
-        mixing       = χ0Mixing(χ0terms=[DFTK.Applyχ0Model(; tol)])
         response     = ResponseOptions(verbose=true)
         is_converged = DFTK.ScfConvergenceDensity(tol)
 
-        scfres = self_consistent_field(basis; is_converged, mixing, response)
+        scfres = self_consistent_field(basis; is_converged, response)
         compute_forces_cart(scfres)
     end
 


### PR DESCRIPTION
Following https://github.com/JuliaMolSim/DFTK.jl/pull/758 and https://github.com/JuliaMolSim/DFTK.jl/commit/c799f8a11c241b3585d7f8e1b5e7d38e9f53d7d6 I rewrote the comment describing `apply_chi0_4P` which was out of date, with the new splitting docc / dpsi by Etienne and the reference to our paper. Also, I uniformed dV and dH into the `chi0.jl` file, which was a bit confusing in my opinion. 