### PR TITLE
Bugfix for computations of `δψ` and supercells

### DIFF
--- a/src/postprocess/stresses.jl
+++ b/src/postprocess/stresses.jl
@@ -13,8 +13,11 @@ Compute the stresses (= 1/Vol dE/d(M*lattice), taken at M=I) of an obtained SCF 
                           terms=model.term_types,
                           model.temperature,
                           model.smearing,
+                          model.εF,
                           model.spin_polarization,
-                          model.symmetries)
+                          model.symmetries,
+                          # Can be safely disabled: this has been checked for basis.model
+                          disable_electrostatics_check=true)
         new_basis = PlaneWaveBasis(new_model,
                                    basis.Ecut, basis.fft_size, basis.variational,
                                    basis.kcoords_global, basis.kweights_global,

--- a/src/response/chi0.jl
+++ b/src/response/chi0.jl
@@ -350,14 +350,14 @@ end
 
     occ_occ = [occ[ik][maskk] for (ik, maskk) in enumerate(mask_occ)]
 
-    # First we compute masked δoccupation and δεF…
+    # First we compute δoccupation and δεF for the occupied orbitals…
     δocc, δεF = compute_δocc(basis, ψ_occ, occ_occ, εF, ε_occ, δHψ_occ)
 
-    # … then masked δψ
+    # … then δψ for the occupied orbitals.
     δψ_occ = compute_δψ(basis, ham.blocks, ψ_occ, εF, ε_occ, δHψ_occ; ψ_extra,
                         kwargs_sternheimer...)
 
-    # Pad δoccupation and δψ
+    # Pad δoccupation and δψ.
     δoccupation = zero.(occ)
     δψ = zero.(ψ)
     for (ik, maskk) in enumerate(mask_occ)

--- a/src/response/chi0.jl
+++ b/src/response/chi0.jl
@@ -326,13 +326,6 @@ function compute_δψ!(δψ, basis, H, ψ, εF, ε, δHψ; ψ_extra=[zeros(size(
     end
 end
 
-function compute_δψ(basis, H, ψ, εF, ε, δHψ; ψ_extra=[zeros(size(ψk,1), 0) for ψk in ψ],
-                    kwargs_sternheimer...)
-    δψ = zero.(δHψ)
-    compute_δψ!(δψ, basis, H, ψ, εF, ε, δHψ; ψ_extra, kwargs_sternheimer...)
-    δψ
-end
-
 @views @timing function apply_χ0_4P(ham, ψ, occ, εF, eigenvalues, δHψ;
                                     occupation_threshold, kwargs_sternheimer...)
     basis  = ham.basis

--- a/src/scf/self_consistent_field.jl
+++ b/src/scf/self_consistent_field.jl
@@ -48,7 +48,7 @@ function next_density(ham::Hamiltonian,
     end
 
     ρout = compute_density(ham.basis, eigres.X, occupation)
-    (ψ=eigres.X, eigenvalues=eigres.λ, occupation, εF, ρout, diagonalization=eigres,
+    (; ψ=eigres.X, eigenvalues=eigres.λ, occupation, εF, ρout, diagonalization=eigres,
      n_bands_converge, nbandsalg.occupation_threshold)
 end
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -29,11 +29,14 @@ function Base.show(io::IO, ::MIME"text/plain", model::Model)
     end
 
     println(io)
-    showfieldln(io, "num. electrons",    model.n_electrons)
-    showfieldln(io, "spin polarization", model.spin_polarization)
-    showfieldln(io, "temperature",       @sprintf "%.5g Ha" model.temperature)
+    showfieldln(io, "num. electrons",        model.n_electrons)
+    showfieldln(io, "spin polarization",     model.spin_polarization)
+    showfieldln(io, "temperature",           @sprintf "%.5g Ha" model.temperature)
     if model.temperature > 0
-        showfieldln(io, "smearing",      model.smearing)
+        showfieldln(io, "smearing",          model.smearing)
+    end
+    if !isnothing(model.εF)
+        showfieldln(io, "fixed Fermi level", model.εF)
     end
 
     println(io)

--- a/src/show.jl
+++ b/src/show.jl
@@ -29,11 +29,13 @@ function Base.show(io::IO, ::MIME"text/plain", model::Model)
     end
 
     println(io)
-    showfieldln(io, "num. electrons",        model.n_electrons)
-    showfieldln(io, "spin polarization",     model.spin_polarization)
-    showfieldln(io, "temperature",           @sprintf "%.5g Ha" model.temperature)
+    if !isnothing(model.n_electrons)
+        showfieldln(io, "num. electrons", model.n_electrons)
+    end
+    showfieldln(io, "spin polarization",  model.spin_polarization)
+    showfieldln(io, "temperature",        @sprintf "%.5g Ha" model.temperature)
     if model.temperature > 0
-        showfieldln(io, "smearing",          model.smearing)
+        showfieldln(io, "smearing",       model.smearing)
     end
     if !isnothing(model.εF)
         showfieldln(io, "fixed Fermi level", model.εF)

--- a/src/supercell.jl
+++ b/src/supercell.jl
@@ -32,8 +32,12 @@ function cell_to_supercell(basis::PlaneWaveBasis)
     supercell_size = basis.kgrid
     supercell = create_supercell(model.lattice, model.atoms, model.positions, supercell_size)
     supercell_fft_size = basis.fft_size .* supercell_size
-    n_electrons_supercell = isnothing(model.n_electrons) ?
-                                nothing : prod(supercell_size) * model.n_electrons
+    if isnothing(model.n_electrons)
+        n_electrons_supercell = nothing
+    else
+        n_electrons_supercell = prod(supercell_size) * model.n_electrons
+    end
+
     # Assemble new model and new basis
     model_supercell = Model(supercell.lattice, supercell.atoms, supercell.positions;
                             n_electrons=n_electrons_supercell,

--- a/src/supercell.jl
+++ b/src/supercell.jl
@@ -34,7 +34,16 @@ function cell_to_supercell(basis::PlaneWaveBasis)
     supercell_fft_size = basis.fft_size .* supercell_size
     # Assemble new model and new basis
     model_supercell = Model(supercell.lattice, supercell.atoms, supercell.positions;
-                            terms=model.term_types, symmetries=false)
+                            n_electrons=isnothing(model.n_electrons) ?
+                                        nothing : prod(supercell_size) * model.n_electrons,
+                            terms=model.term_types,
+                            model.temperature,
+                            model.smearing,
+                            model.εF,
+                            model.spin_polarization,
+                            symmetries=false,
+                            # Can be safely disabled: this has been checked for basis.model
+                            disable_electrostatics_check=true)
     symmetries_respect_rgrid = false  # single point symmetry
     PlaneWaveBasis(model_supercell, basis.Ecut, supercell_fft_size,
                    basis.variational,
@@ -104,18 +113,20 @@ function cell_to_supercell(scfres::NamedTuple)
     ψ = scfres_unfold.ψ
 
     # Compute supercell basis, ψ, occupations and ρ
-    basis_supercell = cell_to_supercell(basis)
-    ψ_supercell     = [cell_to_supercell(ψ, basis, basis_supercell)]
-    occ_supercell   = [vcat(scfres_unfold.occupation...)]
-    ρ_supercell     = compute_density(basis_supercell, ψ_supercell, occ_supercell)
+    basis_supercell       = cell_to_supercell(basis)
+    ψ_supercell           = [cell_to_supercell(ψ, basis, basis_supercell)]
+    eigenvalues_supercell = [vcat(scfres_unfold.eigenvalues...)]
+    occ_supercell         = compute_occupation(basis_supercell, eigenvalues_supercell,
+                                               scfres.εF)
+    ρ_supercell           = compute_density(basis_supercell, ψ_supercell, occ_supercell)
 
     # Supercell Energies
-    eigvalues_supercell = [vcat(scfres_unfold.eigenvalues...)]
-    n_unit_cells = prod(basis.kgrid)
-    energies_supercell = [n_unit_cells * v for v in values(scfres_unfold.energies)]
-    E_supercell = Energies(basis.model.term_types, energies_supercell)
+    energies_supercell, ham_supercell = energy_hamiltonian(basis_supercell, ψ_supercell,
+                                                           occ_supercell; ρ=ρ_supercell,
+                                                           eigenvalues=eigenvalues_supercell,
+                                                           scfres.εF)
 
-    merge(scfres, (; basis=basis_supercell, ψ=ψ_supercell, energies=E_supercell,
-                   ρ=ρ_supercell, eigenvalues=eigvalues_supercell,
-                   occupation=occ_supercell))
+    merge(scfres, (; ham=ham_supercell, basis=basis_supercell, ψ=ψ_supercell,
+                   energies=energies_supercell, ρ=ρ_supercell,
+                   eigenvalues=eigenvalues_supercell, occupation=occ_supercell))
 end

--- a/src/terms/operators.jl
+++ b/src/terms/operators.jl
@@ -46,7 +46,7 @@ end
 
 """
 Real space multiplication by a potential:
-(Hψ)(r) V(r) ψ(r)
+(Hψ)(r) = V(r) ψ(r)
 """
 struct RealSpaceMultiplication{T <: Real, AT <: AbstractArray} <: RealFourierOperator
     basis::PlaneWaveBasis{T}

--- a/src/workarounds/forwarddiff_rules.jl
+++ b/src/workarounds/forwarddiff_rules.jl
@@ -147,14 +147,17 @@ function construct_value(model::Model{T}) where {T <: ForwardDiff.Dual}
     Model(ForwardDiff.value.(model.lattice),
           construct_value.(model.atoms),
           newpositions;
-          model_name=model.model_name,
-          n_electrons=model.n_electrons,
+          model.model_name,
+          model.n_electrons,
           magnetic_moments=[],  # Symmetries given explicitly
           terms=model.term_types,
           temperature=ForwardDiff.value(model.temperature),
-          smearing=model.smearing,
-          spin_polarization=model.spin_polarization,
-          symmetries=model.symmetries)
+          model.smearing,
+          εF=ForwardDiff.value(model.εF),
+          model.spin_polarization,
+          model.symmetries,
+          # Can be safely disabled: this has been checked for basis.model
+          disable_electrostatics_check=true)
 end
 
 construct_value(el::Element) = el

--- a/test/chi0.jl
+++ b/test/chi0.jl
@@ -15,7 +15,7 @@ function test_chi0(testcase; symmetries=false, temperature=0, spin_polarization=
     testtol  = 2e-6
 
     collinear   = spin_polarization == :collinear
-    is_metal    = !isnothing(testcase.temperature)
+    is_metal    = !iszero(testcase.temperature)
     is_εF_fixed = !isnothing(εF)
     eigsol = eigensolver == lobpcg_hyper
     label = [
@@ -45,7 +45,7 @@ function test_chi0(testcase; symmetries=false, temperature=0, spin_polarization=
         n_spin = model.n_spin_components
         δV = randn(eltype(basis), basis.fft_size..., n_spin)
         mpi_mean!(δV, MPI.COMM_WORLD)
-        δV_sym = DFTK.symmetrize_ρ(basis, δV, symmetries=model.symmetries)
+        δV_sym = DFTK.symmetrize_ρ(basis, δV; model.symmetries)
         if symmetries
             δV = δV_sym
         else

--- a/test/compute_jacobian_eigen.jl
+++ b/test/compute_jacobian_eigen.jl
@@ -85,8 +85,7 @@ if mpi_nprocs() == 1  # Distributed implementation not yet available
             model  = model_LDA(silicon.lattice, silicon.atoms, silicon.positions)
             basis  = PlaneWaveBasis(model; Ecut=5, kgrid=[1, 1, 1])
             scfres = self_consistent_field(basis; tol=1e-12)
-            ψ, occupation = select_occupied_orbitals(basis, scfres.ψ,
-                                                     scfres.occupation)
+            ψ, occupation = select_occupied_orbitals(basis, scfres.ψ, scfres.occupation)
 
             res = eigen_ΩplusK(basis, ψ, occupation, numval)
             @test res.λ[1] > 1e-3

--- a/test/forces.jl
+++ b/test/forces.jl
@@ -69,9 +69,8 @@ end
 
 @testset "Forces on spin-polarised case" begin
     function oxygen_energy_forces(positions)
-        O = ElementPsp(o2molecule.atnum, psp=load_psp("hgh/pbe/O-q6.hgh"))
         magnetic_moments = [1.0, 1.0]
-        model = model_PBE(diagm([7.0, 7.0, 7.0]), [O, O], positions;
+        model = model_PBE(diagm([7.0, 7.0, 7.0]), o2molecule.atoms, positions;
                           temperature=0.02, smearing=Smearing.Gaussian(), magnetic_moments)
         basis = PlaneWaveBasis(model; Ecut=4, kgrid=[1, 1, 1])
 

--- a/test/hessian.jl
+++ b/test/hessian.jl
@@ -83,7 +83,7 @@ include("testcases.jl")
         Ecut = 5
         fft_size = [9, 9, 9]
         model = model_DFT(magnesium.lattice, magnesium.atoms, magnesium.positions,
-                          [:lda_xc_teter93]; temperature=magnesium.temperature)
+                          [:lda_xc_teter93]; magnesium.temperature)
         basis = PlaneWaveBasis(model, Ecut, magnesium.kcoords, magnesium.kweights; fft_size)
         nbandsalg = AdaptiveBands(basis; occupation_threshold=1e-10)
         scfres = self_consistent_field(basis; tol=1e-12, nbandsalg)
@@ -101,7 +101,7 @@ include("testcases.jl")
         @testset "solve_ΩplusK_split convenience methods" begin
             δψ1 = solve_ΩplusK_split(scfres, rhs).δψ
             δψ2 = solve_ΩplusK_split(basis, ψ, rhs, scfres.occupation;
-                                     occupation_threshold=scfres.occupation_threshold).δψ
+                                     scfres.occupation_threshold).δψ
             @test norm(δψ1 - δψ2) < 1e-7
         end
 

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -6,23 +6,34 @@ include("testcases.jl")
 # data structures of DFTK. Point is not to test that the correct thing is printed,
 # rather to ensure that the code does not randomly stop working.
 @testset "Test printing" begin
-    for εF in (nothing, 0.5)
-        model  = model_LDA(magnesium.lattice, magnesium.atoms, magnesium.positions;
-                           magnesium.temperature, εF, disable_electrostatics_check=true)
-        basis  = PlaneWaveBasis(model; Ecut=5, kgrid=[1, 3, 2], kshift=[0, 0, 0])
-        scfres = self_consistent_field(basis; nbandsalg=FixedBands(; n_bands_converge=6),
-                                       tol=1e-3)
+    function test_basis_printing(; modelargs=(; temperature=1e-3),
+                                   basisargs=(; Ecut=5, kgrid=[1, 3, 2], kshift=[0, 0, 0]))
+        model = model_LDA(magnesium.lattice, magnesium.atoms, magnesium.positions;
+                          disable_electrostatics_check=true, modelargs...)
+        basis = PlaneWaveBasis(model; basisargs...)
 
         println(model)
-        display("text/plain", model)
+        show(stdout, "text/plain", model)
 
         println(basis)
-        display("text/plain", basis)
+        show(stdout, "text/plain", basis)
 
         println(basis.kpoints[1])
-        display("text/plain", basis.kpoints[1])
+        show(stdout, "text/plain", basis.kpoints[1])
+
+        basis
+    end
+
+    function test_scfres_printing(; kwargs...)
+        basis = test_basis_printing(; kwargs...)
+        scfres = self_consistent_field(basis;
+                                       nbandsalg=FixedBands(; n_bands_converge=6),
+                                       tol=1e-3)
 
         println(scfres.energies)
-        display("text/plain", scfres.energies)
+        show(stdout, "text/plain", scfres.energies)
     end
+
+    test_scfres_printing()
+    test_basis_printing(; modelargs=(; εF=0.5))
 end

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -6,19 +6,23 @@ include("testcases.jl")
 # data structures of DFTK. Point is not to test that the correct thing is printed,
 # rather to ensure that the code does not randomly stop working.
 @testset "Test printing" begin
-    model  = model_LDA(silicon.lattice, silicon.atoms, silicon.positions)
-    basis  = PlaneWaveBasis(model; Ecut=5, kgrid=[1, 3, 2], kshift=[0, 0, 0])
-    scfres = self_consistent_field(basis, tol=1e-2)
+    for εF in (nothing, 0.5)
+        model  = model_LDA(magnesium.lattice, magnesium.atoms, magnesium.positions;
+                           magnesium.temperature, εF, disable_electrostatics_check=true)
+        basis  = PlaneWaveBasis(model; Ecut=5, kgrid=[1, 3, 2], kshift=[0, 0, 0])
+        scfres = self_consistent_field(basis; nbandsalg=FixedBands(; n_bands_converge=6),
+                                       tol=1e-2)
 
-    println(model)
-    display("text/plain", model)
+        println(model)
+        display("text/plain", model)
 
-    println(basis)
-    display("text/plain", basis)
+        println(basis)
+        display("text/plain", basis)
 
-    println(basis.kpoints[1])
-    display("text/plain", basis.kpoints[1])
+        println(basis.kpoints[1])
+        display("text/plain", basis.kpoints[1])
 
-    println(scfres.energies)
-    display("text/plain", scfres.energies)
+        println(scfres.energies)
+        display("text/plain", scfres.energies)
+    end
 end

--- a/test/supercell.jl
+++ b/test/supercell.jl
@@ -21,52 +21,6 @@ if mpi_nprocs() == 1  # can't be bothered to convert the tests
     @test scfres.energies.total * prod(kgrid) ≈ scfres_supercell.energies.total
 end
 
-@testset "Supercell response" begin
-    Ecut    = 5.0
-    kgrid   = [2, 1, 1]
-    scf_kw  = (; is_converged=DFTK.ScfConvergenceDensity(1e-9),
-               determine_diagtol=DFTK.ScfDiagtol(diagtol_max=1e-9),
-               callback=identity)
-
-    system = magnesium
-    for extra_terms in ([], [Hartree()])
-        @info "with $extra_terms"
-        model = model_atomic(system.lattice, system.atoms, system.positions;
-                             symmetries=false, system.temperature, extra_terms)
-        basis = PlaneWaveBasis(model; Ecut, kgrid)
-        scfres = self_consistent_field(basis; scf_kw...)
-
-        n_spin = model.n_spin_components
-        δV = ifft(basis, fft(basis, randn(eltype(basis), basis.fft_size..., n_spin)))
-        δV = DFTK.symmetrize_ρ(basis, δV, symmetries=model.symmetries)
-        δV_supercell = vcat(δV, δV)
-
-        # Unit cell computations.
-        δρ = apply_χ0(scfres, δV)
-
-        # Supercell with manually empacking scfres.
-        scfres_supercell₁ = cell_to_supercell(scfres)
-        δρ_supercell₁ = apply_χ0(scfres_supercell₁, δV_supercell)
-
-        @test norm(δρ - δρ_supercell₁[1:size(δρ, 1), :, :]) < 1e-5
-
-        # Supercell with manually empacking only basis.
-        basis_supercell = cell_to_supercell(basis)
-        scfres_supercell₂ = self_consistent_field(basis_supercell; scf_kw...)
-        δρ_supercell₂ = apply_χ0(scfres_supercell₂, δV_supercell)
-
-        @test norm(δρ - δρ_supercell₂[1:size(δρ, 1), :, :]) < 1e-5
-
-        @test norm(Matrix(scfres_supercell₁.ham.blocks[1]) - Matrix(scfres_supercell₂.ham.blocks[1])) < 1e-8
-
-        if length(extra_terms) ≡ 1
-            term_hartree₁ = only(filter(e -> typeof(e) <: DFTK.TermHartree, scfres_supercell₁.basis.terms))
-            term_hartree₂ = only(filter(e -> typeof(e) <: DFTK.TermHartree, scfres_supercell₂.basis.terms))
-            @test norm(term_hartree₁.poisson_green_coeffs - term_hartree₂.poisson_green_coeffs) ≡ 0.0
-        end
-    end
-end
-
 @testset "Compare scf results in unit cell and supercell" begin
     Ecut    = 4
     kgrid   = [3, 3, 3]
@@ -91,6 +45,44 @@ end
     ρ_ref = DFTK.interpolate_density(dropdims(scfres.ρ, dims=4), basis, basis_supercell)
     @test norm(ρ_ref .- scfres_supercell.ρ) < 10*tol
     @test norm(ρ_ref .- scfres_supercell_manual.ρ) < 10*tol
+end
+
+@testset "Supercell response" begin
+    Ecut    = 5.0
+    kgrid   = [2, 1, 1]
+    scf_kw  = (; is_converged=DFTK.ScfConvergenceDensity(1e-9),
+               determine_diagtol=DFTK.ScfDiagtol(diagtol_max=1e-9),
+               eigensolver=diag_full,
+               callback=identity)
+
+    for system in (silicon, magnesium), extra_terms in ([], [Hartree()])
+        @testset "$(system.psp) with $extra_terms" begin
+            model = model_atomic(system.lattice, system.atoms, system.positions;
+                                 symmetries=false, system.temperature, extra_terms)
+            basis = PlaneWaveBasis(model; Ecut, kgrid)
+            scfres = self_consistent_field(basis; scf_kw...)
+
+            n_spin = model.n_spin_components
+            δV = ifft(basis, fft(basis, randn(eltype(basis), basis.fft_size..., n_spin)))
+            δV_supercell = vcat(δV, δV)
+
+            # Unit cell computations.
+            δρ = apply_χ0(scfres, δV)
+
+            # Supercell with manually unpacking scfres.
+            scfres_supercell₁ = cell_to_supercell(scfres)
+            δρ_supercell₁ = apply_χ0(scfres_supercell₁, δV_supercell)
+
+            @test norm(δρ - δρ_supercell₁[1:size(δρ, 1), :, :]) < 1e-5
+
+            # Supercell with manually empacking only basis.
+            basis_supercell = cell_to_supercell(basis)
+            scfres_supercell₂ = self_consistent_field(basis_supercell; scf_kw...)
+            δρ_supercell₂ = apply_χ0(scfres_supercell₂, δV_supercell)
+
+            @test norm(δρ - δρ_supercell₂[1:size(δρ, 1), :, :]) < 1e-5
+        end
+    end
 end
 
 end

--- a/test/supercell.jl
+++ b/test/supercell.jl
@@ -4,6 +4,69 @@ include("testcases.jl")
 
 if mpi_nprocs() == 1  # can't be bothered to convert the tests
 
+# Quick test to make sure temperature, smearing and Fermi level are correctly propagated
+@testset "Supercell copy" begin
+    Ecut    = 4
+    kgrid   = [2, 1, 1]
+    # Parameters
+    model = model_LDA(magnesium.lattice, magnesium.atoms, magnesium.positions;
+                      magnesium.temperature, εF=0.5, spin_polarization=:spinless,
+                      disable_electrostatics_check=true)
+    basis = PlaneWaveBasis(model; Ecut, kgrid)
+    # SCF
+    scfres = self_consistent_field(basis; nbandsalg=FixedBands(; n_bands_converge=20))
+    scfres_supercell = cell_to_supercell(scfres)
+
+    # Compare energies
+    @test scfres.energies.total * prod(kgrid) ≈ scfres_supercell.energies.total
+end
+
+@testset "Supercell response" begin
+    Ecut    = 5.0
+    kgrid   = [2, 1, 1]
+    scf_kw  = (; is_converged=DFTK.ScfConvergenceDensity(1e-9),
+               determine_diagtol=DFTK.ScfDiagtol(diagtol_max=1e-9),
+               callback=identity)
+
+    system = magnesium
+    for extra_terms in ([], [Hartree()])
+        @info "with $extra_terms"
+        model = model_atomic(system.lattice, system.atoms, system.positions;
+                             symmetries=false, system.temperature, extra_terms)
+        basis = PlaneWaveBasis(model; Ecut, kgrid)
+        scfres = self_consistent_field(basis; scf_kw...)
+
+        n_spin = model.n_spin_components
+        δV = ifft(basis, fft(basis, randn(eltype(basis), basis.fft_size..., n_spin)))
+        δV = DFTK.symmetrize_ρ(basis, δV, symmetries=model.symmetries)
+        δV_supercell = vcat(δV, δV)
+
+        # Unit cell computations.
+        δρ = apply_χ0(scfres, δV)
+
+        # Supercell with manually empacking scfres.
+        scfres_supercell₁ = cell_to_supercell(scfres)
+        δρ_supercell₁ = apply_χ0(scfres_supercell₁, δV_supercell)
+
+        @test norm(δρ - δρ_supercell₁[1:size(δρ, 1), :, :]) < 1e-5
+
+        # Supercell with manually empacking only basis.
+        basis_supercell = cell_to_supercell(basis)
+        scfres_supercell₂ = self_consistent_field(basis_supercell; scf_kw...)
+        δρ_supercell₂ = apply_χ0(scfres_supercell₂, δV_supercell)
+
+        @test norm(δρ - δρ_supercell₂[1:size(δρ, 1), :, :]) < 1e-5
+
+        @test norm(Matrix(scfres_supercell₁.ham.blocks[1]) - Matrix(scfres_supercell₂.ham.blocks[1])) < 1e-8
+
+        if length(extra_terms) ≡ 1
+            term_hartree₁ = only(filter(e -> typeof(e) <: DFTK.TermHartree, scfres_supercell₁.basis.terms))
+            term_hartree₂ = only(filter(e -> typeof(e) <: DFTK.TermHartree, scfres_supercell₂.basis.terms))
+            @test norm(term_hartree₁.poisson_green_coeffs - term_hartree₂.poisson_green_coeffs) ≡ 0.0
+        end
+    end
+end
+
 @testset "Compare scf results in unit cell and supercell" begin
     Ecut    = 4
     kgrid   = [3, 3, 3]
@@ -11,8 +74,7 @@ if mpi_nprocs() == 1  # can't be bothered to convert the tests
     tol     = 1e-12
     scf_tol = (; is_converged=DFTK.ScfConvergenceDensity(tol))
     # Parameters
-    Si = ElementPsp(silicon.atnum, psp=load_psp(silicon.psp))
-    model = model_LDA(silicon.lattice, [Si, Si], silicon.positions)
+    model = model_LDA(silicon.lattice, silicon.atoms, silicon.positions)
     basis = PlaneWaveBasis(model; Ecut, kgrid, kshift)
     basis_supercell = cell_to_supercell(basis)
     # SCF

--- a/test/testcases.jl
+++ b/test/testcases.jl
@@ -6,7 +6,7 @@ silicon = (
                5.131570667152971 5.131570667152971  0.0],
     atnum = 14,
     n_electrons = 8,
-    temperature = nothing,
+    temperature = 0.0,
     psp = "hgh/lda/si-q4",
     positions = [ones(3)/8, -ones(3)/8],  # in fractional coordinates
     kcoords = [[   0,   0, 0],  # in fractional coordinates
@@ -95,3 +95,5 @@ o2molecule = (
     positions = 0.1155 * [[0, 0, 1], [0, 0, -1]],
     temperature = 0.02,
 )
+o2molecule = merge(o2molecule,
+                   (; atoms=fill(ElementPsp(o2molecule.atnum, psp=load_psp(o2molecule.psp)), 2)))


### PR DESCRIPTION
Fix to propagate temperature, smearing and Fermi level with supercell method. Also creation of an `Hamiltonian` in `scfres` to enable the use of response functions.