### PR TITLE
add a keyword argument to plot_dos to support user-defined unit

### DIFF
--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -65,10 +65,13 @@ function plot_band_data(kpath::KPathInterpolant, band_data;
 end
 
 
-function plot_dos(basis, eigenvalues; εF=nothing, kwargs...)
+function plot_dos(basis, eigenvalues; εF=nothing, unit=u"hartree", kwargs...)
     n_spin = basis.model.n_spin_components
     εs = range(minimum(minimum(eigenvalues)) - .5,
                maximum(maximum(eigenvalues)) + .5, length=1000)
+
+     # Constant to convert from AU to the desired unit
+     to_unit = ustrip(auconvert(unit, 1.0))
 
     p = Plots.plot(;kwargs...)
     spinlabels = spin_components(basis.model)
@@ -77,11 +80,12 @@ function plot_dos(basis, eigenvalues; εF=nothing, kwargs...)
     for σ in 1:n_spin
         D = [Dσ[σ] for Dσ in Dεs]
         label = n_spin > 1 ? "DOS $(spinlabels[σ]) spin" : "DOS"
-        Plots.plot!(p, εs, D; label, color=colors[σ])
+        Plots.plot!(p, εs .* to_unit, D; label, color=colors[σ])
     end
     if !isnothing(εF)
-        Plots.vline!(p, [εF], label="εF", color=:green, lw=1.5)
+        Plots.vline!(p, [εF * to_unit], label="εF", color=:green, lw=1.5)
     end
+    Plots.xlabel!(p, "eigenvalues  ($(string(unit)))")
     p
 end
 plot_dos(scfres; kwargs...) = plot_dos(scfres.basis, scfres.eigenvalues; scfres.εF, kwargs...)


### PR DESCRIPTION
The function "plot_bandstructure" supports user-defined units, while "plot_dos" doesn't. The behaviors of these two functions are not consistent in this sense.

This PR adds a keyword argument "unit" to the function "plot_dos" to fix the above consistency problem.

Here is an example of sodium metal dos plot generated by following command: 
```julia
plot_dos(scfres, unit=u"eV", xlims=[-5, 20], ylims=[0, 40])
```

![dos_in_eV](https://user-images.githubusercontent.com/2466956/199869429-9eef7950-dd1b-4a59-914a-05dfaf6c248f.svg)

