### PR TITLE
Warn for slated pymatgen removal

### DIFF
--- a/src/external/pymatgen.jl
+++ b/src/external/pymatgen.jl
@@ -9,6 +9,9 @@ pymatgen_lattice(model::Model) = pymatgen_lattice(model.lattice)
 
 
 function pymatgen_structure(model_or_lattice, atoms, positions)
+    @warn("pymatgen_structure is planned to be discontinued in DFTK 0.6.0. " *
+          "If you rely on this feature please open an issue at https://dftk.org/issues "
+          "to discuss.")
     Structure = pyimport("pymatgen.core.structure").Structure
     Structure(pymatgen_lattice(model_or_lattice),
               charge_nuclear.(atoms),
@@ -18,6 +21,9 @@ pymatgen_structure(model::Model) = pymatgen_structure(model, model.atoms, model.
 
 
 function load_lattice_pymatgen(pyobj::PyObject)
+    @warn("load_lattice, load_atoms and load_positions using pymatgen data structures " *
+          "is planned to be discontinued in DFTK 0.6.0. If you rely on this feature " *
+          "please open an issue at https://dftk.org/issues to discuss.")
     Structure = pyimport("pymatgen.core.structure").Structure
     Lattice   = pyimport("pymatgen.core.lattice").Lattice
 
@@ -36,12 +42,18 @@ end
 
 
 function load_atoms_pymatgen(pyobj::PyObject)
+    @warn("load_lattice, load_atoms and load_positions using pymatgen data structures " *
+          "is planned to be discontinued in DFTK 0.6.0. If you rely on this feature " *
+          "please open an issue at https://dftk.org/issues to discuss.")
     @assert pyisinstance(pyobj, pyimport("pymatgen.core.structure").Structure)
     [ElementCoulomb(spec.number) for spec in pyobj.species]
 end
 
 
 function load_positions_pymatgen(pyobj::PyObject)
+    @warn("load_lattice, load_atoms and load_positions using pymatgen data structures " *
+          "is planned to be discontinued in DFTK 0.6.0. If you rely on this feature " *
+          "please open an issue at https://dftk.org/issues to discuss.")
     @assert pyisinstance(pyobj, pyimport("pymatgen.core.structure").Structure)
     [Vec3{Float64}(site.frac_coords) for site in pyobj.sites]
 end

--- a/src/external/pymatgen.jl
+++ b/src/external/pymatgen.jl
@@ -10,7 +10,7 @@ pymatgen_lattice(model::Model) = pymatgen_lattice(model.lattice)
 
 function pymatgen_structure(model_or_lattice, atoms, positions)
     @warn("pymatgen_structure is planned to be discontinued in DFTK 0.6.0. " *
-          "If you rely on this feature please open an issue at https://dftk.org/issues "
+          "If you rely on this feature please open an issue at https://dftk.org/issues " *
           "to discuss.")
     Structure = pyimport("pymatgen.core.structure").Structure
     Structure(pymatgen_lattice(model_or_lattice),


### PR DESCRIPTION
With [ASEconvert](https://github.com/mfherbst/ASEconvert.jl) I found a pretty neat way to have ASE installation and conversion to AtomsBase done reliably (well hopefully). I use ASE quite a bit so I'm happy to maintain that. For pymatgen I don't have such a use case and don't have the time to take care of it in a similar way.

In DFTK 0.6.0 I want do drop the `load_atoms`, `load_positions`, ... functions to avoid the duplication of efforts with AtomsBase and ASEconvert inside DFTK. Since there is no pymatgen equivalent to ASEconvert, the out-of-the-box support for pymatgen in DFTK will effectively go as well. Of course in principle it can still be used by manual conversion from pymatgen to atomsbase.

This is just to make our users aware and see if anyone actually uses DFTK with pymatgen. If yes than maybe some external momentum forms to produce a package like ASEconvert, but for pymatgen datastructures.