### PR TITLE
Expand ForwardDiff support to LocalNonlinearity parameters

### DIFF
--- a/src/terms/local_nonlinearity.jl
+++ b/src/terms/local_nonlinearity.jl
@@ -12,8 +12,7 @@ end
 function ene_ops(term::TermLocalNonlinearity, basis::PlaneWaveBasis{T}, ψ, occupation;
                  ρ, kwargs...) where {T}
     fp(ρ) = ForwardDiff.derivative(term.f, ρ)
-    E = sum(term.f.(ρ)) * basis.dvol
-    E = convert_dual(T, E)
+    E = sum(fρ -> convert_dual(T, fρ), term.f.(ρ)) * basis.dvol
     potential = convert_dual.(T, fp.(ρ))
 
     # In the case of collinear spin, the potential is spin-dependent

--- a/src/terms/local_nonlinearity.jl
+++ b/src/terms/local_nonlinearity.jl
@@ -23,13 +23,13 @@ function ene_ops(term::TermLocalNonlinearity, basis::PlaneWaveBasis{T}, ψ, occu
 end
 
 
-function compute_kernel(term::TermLocalNonlinearity, ::PlaneWaveBasis{T}; ρ, kwargs...) where {T}
+function compute_kernel(term::TermLocalNonlinearity, ::AbstractBasis{T}; ρ, kwargs...) where {T}
     fp(ρ) = ForwardDiff.derivative(term.f, ρ)
     fpp(ρ) = ForwardDiff.derivative(fp, ρ)
     Diagonal(vec(convert_dual.(T, fpp.(ρ))))
 end
 
-function apply_kernel(term::TermLocalNonlinearity, ::PlaneWaveBasis{T}, δρ; ρ, kwargs...) where {T}
+function apply_kernel(term::TermLocalNonlinearity, ::AbstractBasis{T}, δρ; ρ, kwargs...) where {T}
     fp(ρ) = ForwardDiff.derivative(term.f, ρ)
     fpp(ρ) = ForwardDiff.derivative(fp, ρ)
     convert_dual.(T, fpp.(ρ) .* δρ)

--- a/src/terms/local_nonlinearity.jl
+++ b/src/terms/local_nonlinearity.jl
@@ -13,6 +13,7 @@ function ene_ops(term::TermLocalNonlinearity, basis::PlaneWaveBasis{T}, ψ, occu
                  ρ, kwargs...) where {T}
     fp(ρ) = ForwardDiff.derivative(term.f, ρ)
     E = sum(term.f.(ρ)) * basis.dvol
+    E = convert_dual(T, E)
     potential = convert_dual.(T, fp.(ρ))
 
     # In the case of collinear spin, the potential is spin-dependent
@@ -22,14 +23,14 @@ function ene_ops(term::TermLocalNonlinearity, basis::PlaneWaveBasis{T}, ψ, occu
 end
 
 
-function compute_kernel(term::TermLocalNonlinearity, ::AbstractBasis; ρ, kwargs...)
+function compute_kernel(term::TermLocalNonlinearity, ::PlaneWaveBasis{T}; ρ, kwargs...) where {T}
     fp(ρ) = ForwardDiff.derivative(term.f, ρ)
     fpp(ρ) = ForwardDiff.derivative(fp, ρ)
-    Diagonal(vec(fpp.(ρ)))
+    Diagonal(vec(convert_dual.(T, fpp.(ρ))))
 end
 
-function apply_kernel(term::TermLocalNonlinearity, ::AbstractBasis, δρ; ρ, kwargs...)
+function apply_kernel(term::TermLocalNonlinearity, ::PlaneWaveBasis{T}, δρ; ρ, kwargs...) where {T}
     fp(ρ) = ForwardDiff.derivative(term.f, ρ)
     fpp(ρ) = ForwardDiff.derivative(fp, ρ)
-    fpp.(ρ) .* δρ
+    convert_dual.(T, fpp.(ρ) .* δρ)
 end

--- a/src/terms/terms.jl
+++ b/src/terms/terms.jl
@@ -87,7 +87,7 @@ In this case the matrix has effectively 4 blocks
     end
     kernel
 end
-compute_kernel(::Term, ::AbstractBasis; kwargs...) = nothing  # By default no kernel
+compute_kernel(::Term, ::AbstractBasis{T}; kwargs...) where {T} = nothing  # By default no kernel
 
 
 """

--- a/src/terms/terms.jl
+++ b/src/terms/terms.jl
@@ -114,4 +114,4 @@ as a 4D (i,j,k,σ) array.
     end
     δV
 end
-apply_kernel(::Term, ::AbstractBasis, δρ; kwargs...) = nothing  # by default, no kernel
+apply_kernel(::Term, ::AbstractBasis{T}, δρ; kwargs...) where {T} = nothing  # by default, no kernel

--- a/test/forwarddiff.jl
+++ b/test/forwarddiff.jl
@@ -134,15 +134,12 @@ end
 @testset "LocalNonlinearity sensitivity using ForwardDiff" begin
     function compute_force(ε::T) where {T}
         # solve the 1D Gross-Pitaevskii equation with ElementGaussian potential
-        a = 10.0
-        lattice = a .* [[1 0 0.]; [0 0 0]; [0 0 0]]
+        lattice = 10.0 .* [[1 0 0.]; [0 0 0]; [0 0 0]]
         positions = [[0.2, 0, 0], [0.8, 0, 0]]
         gauss = ElementGaussian(1.0, 0.5)
         atoms = [gauss, gauss]
-        C = 1.0
-        α = 2
         n_electrons = 1
-        terms = [Kinetic(), AtomicLocal(), LocalNonlinearity(ρ -> (C + ε) * ρ^α)]
+        terms = [Kinetic(), AtomicLocal(), LocalNonlinearity(ρ -> (1.0 + ε) * ρ^2)]
         model = Model(Matrix{T}(lattice), atoms, positions;
                       n_electrons, terms, spin_polarization=:spinless)
         basis = PlaneWaveBasis(model; Ecut=500, kgrid=(1, 1, 1))

--- a/test/forwarddiff.jl
+++ b/test/forwarddiff.jl
@@ -147,11 +147,12 @@ end
                       n_electrons, terms, spin_polarization=:spinless)
         basis = PlaneWaveBasis(model; Ecut=500, kgrid=(1, 1, 1))
         ρ = zeros(Float64, basis.fft_size..., 1)
-        scfres = self_consistent_field(basis; tol=1e-8, ρ,
+        is_converged = DFTK.ScfConvergenceDensity(1e-10)
+        scfres = self_consistent_field(basis; ρ, is_converged,
                                        response=ResponseOptions(verbose=true))
         compute_forces_cart(scfres)
     end
-    derivative_ε = let ε = 1e-2
+    derivative_ε = let ε = 1e-5
         (compute_force(ε) - compute_force(-ε)) / 2ε
     end
     derivative_fd = ForwardDiff.derivative(compute_force, 0.0)

--- a/test/forwarddiff.jl
+++ b/test/forwarddiff.jl
@@ -151,7 +151,7 @@ end
                                        response=ResponseOptions(verbose=true))
         compute_forces_cart(scfres)
     end
-    derivative_ε = let ε = 1e-5
+    derivative_ε = let ε = 1e-2
         (compute_force(ε) - compute_force(-ε)) / 2ε
     end
     derivative_fd = ForwardDiff.derivative(compute_force, 0.0)


### PR DESCRIPTION
This PR modifies the generic LocalNonlinearity term to allow for ForwardDiff.Dual numbers inside the term. This enables differentiation of e.g. forces w.r.t. parameters inside LocalNonlinearity as shown in the new testcase. Possible follow-up work would be going along these lines for other terms too.