### PR TITLE
Fix damping solver

### DIFF
--- a/src/scf/scf_solvers.jl
+++ b/src/scf/scf_solvers.jl
@@ -28,6 +28,7 @@ Create a damped SCF solver updating the density as
 """
 function scf_damping_solver(β=0.2)
     function fp_solver(f, x0, max_iter; tol=1e-6)
+        β = convert(eltype(x0), β)
         converged = false
         x = copy(x0)
         for i in 1:max_iter


### PR DESCRIPTION
This PR enables the use of the damping solver for arbitrary types. Currently, the relaxation parameter `β` is hardcoded to be a `Float64` and is not converted to the same type as `x0`, which can lead to some problems down the line (for example, bugs in the FFTs).
A simple conversion is all we need to make this solver work with types other than `Float64`.