### PR TITLE
Switch default scf solver to builtin Anderson

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,6 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearMaps = "7a12625a-238d-50fd-b39a-03d52299707e"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
-NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 PeriodicTable = "7b2266bf-644c-5ea3-82d8-af4bbd25a884"
@@ -66,7 +65,6 @@ Libxc = "0.3.9"
 LineSearches = "7"
 LinearMaps = "3"
 MPI = "0.19, 0.20"
-NLsolve = "4"
 Optim = "1"
 OrderedCollections = "1"
 PeriodicTable = "1"
@@ -106,4 +104,4 @@ WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 wannier90_jll = "c5400fa0-8d08-52c2-913f-1e3f656c1ce9"
 
 [targets]
-test = ["Test", "Aqua", "CUDA", "DoubleFloats", "FiniteDiff", "FiniteDifferences", "GenericLinearAlgebra", "IntervalArithmetic", "Plots", "Random", "KrylovKit", "Logging", "JLD2", "WriteVTK", "wannier90_jll", "QuadGK", "ComponentArrays"]
+test = ["Test", "Aqua", "CUDA", "ComponentArrays", "DoubleFloats", "FiniteDiff", "FiniteDifferences", "GenericLinearAlgebra", "IntervalArithmetic", "JLD2", "Logging", "Plots", "QuadGK", "Random", "KrylovKit", "WriteVTK", "wannier90_jll"]

--- a/src/DFTK.jl
+++ b/src/DFTK.jl
@@ -136,7 +136,6 @@ include("standard_models.jl")
 export KerkerMixing, KerkerDosMixing, SimpleMixing, DielectricMixing
 export LdosMixing, HybridMixing, χ0Mixing
 export FixedBands, AdaptiveBands
-export scf_nlsolve_solver
 export scf_damping_solver
 export scf_anderson_solver
 export scf_CROP_solver

--- a/src/scf/scf_solvers.jl
+++ b/src/scf/scf_solvers.jl
@@ -4,23 +4,7 @@
 # maxiter), where f(x) is the fixed-point map. It must return an
 # object supporting res.sol and res.converged
 
-using NLsolve
-
 # TODO max_iter could go to the solver generator function arguments
-
-"""
-Create a NLSolve-based SCF solver, by default using an Anderson-accelerated
-fixed-point scheme, keeping `m` steps for Anderson acceleration. See the
-NLSolve documentation for details about the other parameters and methods.
-"""
-function scf_nlsolve_solver(m=10, method=:anderson; kwargs...)
-    function fp_solver(f, x0, max_iter; tol=1e-6)
-        res = nlsolve(x -> f(x) - x, x0; method, m, xtol=tol,
-                      ftol=0.0, show_trace=false, iterations=max_iter, kwargs...)
-        (; fixpoint=res.zero, converged=converged(res))
-    end
-    fp_solver
-end
 
 """
 Create a damped SCF solver updating the density as

--- a/src/scf/self_consistent_field.jl
+++ b/src/scf/self_consistent_field.jl
@@ -67,7 +67,7 @@ Solve the Kohn-Sham equations with a SCF algorithm, starting at `ρ`.
                                        ψ=nothing,
                                        tol=1e-6,
                                        maxiter=100,
-                                       solver=scf_nlsolve_solver(),
+                                       solver=scf_anderson_solver(),
                                        eigensolver=lobpcg_hyper,
                                        determine_diagtol=ScfDiagtol(),
                                        damping=0.8,  # Damping parameter


### PR DESCRIPTION
Draft to see if some tests fail with this brutal change of the default SCF algorithm.
Will need proper timings also.
(`NLsolve` may be use as an example and not in a test maybe.)