### PR TITLE
Fix fast test execution

### DIFF
--- a/src/supercell.jl
+++ b/src/supercell.jl
@@ -24,7 +24,7 @@ Construct a plane-wave basis whose unit cell is the supercell associated to
 an input basis ``k``-grid. All other parameters are modified so that the respective physical
 systems associated to both basis are equivalent.
 """
-function cell_to_supercell(basis::PlaneWaveBasis)
+function cell_to_supercell(basis::PlaneWaveBasis{T}) where {T}
     iszero(basis.kshift) || error("Only kshift of 0 implemented.")
     model = basis.model
 
@@ -44,10 +44,10 @@ function cell_to_supercell(basis::PlaneWaveBasis)
     symmetries_respect_rgrid = false  # single point symmetry
     PlaneWaveBasis(model_supercell, basis.Ecut, supercell_fft_size,
                    basis.variational,
-                   [zeros(Float64, 3)],  # kcoords
-                   [one(Float64)],       # kweights
-                   ones(3),              # kgrid = Γ point only
-                   basis.kshift,         # kshift
+                   [zeros(T, 3)],  # kcoords
+                   [one(T)],       # kweights
+                   ones(3),        # kgrid = Γ point only
+                   basis.kshift,   # kshift
                    symmetries_respect_rgrid,
                    basis.comm_kpts, basis.architecture)
 end
@@ -85,7 +85,7 @@ function cell_to_supercell(ψ, basis::PlaneWaveBasis{T},
     # Transfer all ψ[k] independantly and return the hcat of all blocs
     ψ_out_blocs = []
     for (ik, kpt) in enumerate(basis.kpoints)
-        ψk_supercell = zeros(ComplexF64, num_kpG, num_bands)
+        ψk_supercell = zeros(complex(T), num_kpG, num_bands)
         ψk_supercell[cell_supercell_mapping(kpt), :] .= ψ[ik]
         push!(ψ_out_blocs, ψk_supercell)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,8 +22,9 @@ end
 
 const FAST_TESTS = "fast" in DFTK_TEST_ARGS
 const TAGS = let
-    # Tags supplied by the user ... filter out "fast" (already dealt with)
-    tags = filter(e -> !(e in ["fast"]), DFTK_TEST_ARGS)
+    # Tags supplied by the user.
+    # Replace "fast" with "all": the notice for quick checks has been dealt with above.
+    tags = replace(e -> e == "fast" ? "all" : e, DFTK_TEST_ARGS)
     isempty(tags) ? ["all"] : tags
 end
 

--- a/test/testcases.jl
+++ b/test/testcases.jl
@@ -59,9 +59,12 @@ aluminium_primitive = (
     atnum = 13,
     n_electrons = 3,
     psp = "hgh/lda/al-q3",
-    positions = [[0, 0, 0]],
+    positions = [zeros(3)],
     temperature = 0.0009500431544769484,
 )
+aluminium_primitive = merge(aluminium_primitive,
+                            (; atoms=fill(ElementPsp(aluminium_primitive.atnum,
+                                                     psp=load_psp(aluminium_primitive.psp)), 1)))
 
 
 platinum_hcp = (


### PR DESCRIPTION
The current CI does not run tests if `fast` is specified along one or more arguments.
In particular `"fast,example"` only run `example`.