### PR TITLE
Remove nonnegative density check

### DIFF
--- a/src/densities.jl
+++ b/src/densities.jl
@@ -1,10 +1,6 @@
 # Densities (and potentials) are represented by arrays
 # ρ[ix,iy,iz,iσ] in real space, where iσ ∈ [1:n_spin_components]
 
-function _check_nonnegative(ρ::AbstractArray{T}; tol=eps(T)) where {T}
-    minimum(ρ) < -tol && @warn("Negative ρ detected", min_ρ=minimum(ρ))
-end
-
 """
     compute_density(basis::PlaneWaveBasis, ψ::AbstractVector, occupation::AbstractVector)
 
@@ -55,7 +51,6 @@ using an optional `occupation_threshold`. By default all occupation numbers are 
 
     mpi_sum!(ρ, basis.comm_kpts)
     ρ = symmetrize_ρ(basis, ρ; do_lowpass=false)
-    _check_nonnegative(ρ; tol=5occupation_threshold)
     ρ
 end
 


### PR DESCRIPTION
It's just obnoxious. We build a density that is positive by construction. Then we symmetrize it, which can make it numerically negative. That is fine and expected behavior. Either we enforce it to be positive by clipping to zero, or we don't, but there's no point in warning about it.