### PR TITLE
Reallow to skip precompilation

### DIFF
--- a/src/DFTK.jl
+++ b/src/DFTK.jl
@@ -242,23 +242,26 @@ function __init__()
 end
 
 # Precompilation block with a basic workflow
-@setup_workload begin
-    # very artificial silicon ground state example
-    a = 10.26
-    lattice = a / 2 * [[0 1 1.];
-                       [1 0 1.];
-                       [1 1 0.]]
-    Si = ElementPsp(:Si, psp=load_psp("hgh/lda/Si-q4"))
-    atoms     = [Si, Si]
-    positions = [ones(3)/8, -ones(3)/8]
-    magnetic_moments = [2, -2]
+if isnothing(get(ENV, "DFTK_NO_PRECOMPILATION", nothing))
+    @setup_workload begin
+        # very artificial silicon ground state example
+        a = 10.26
+        lattice = a / 2 * [[0 1 1.];
+                        [1 0 1.];
+                        [1 1 0.]]
+        Si = ElementPsp(:Si, psp=load_psp("hgh/lda/Si-q4"))
+        atoms     = [Si, Si]
+        positions = [ones(3)/8, -ones(3)/8]
+        magnetic_moments = [2, -2]
 
-    @compile_workload begin
-        model = model_LDA(lattice, atoms, positions;
-                          magnetic_moments, temperature=0.1, spin_polarization=:collinear)
-        basis = PlaneWaveBasis(model; Ecut=5, kgrid=[2, 2, 2])
-        ρ0 = guess_density(basis, magnetic_moments)
-        scfres = self_consistent_field(basis; ρ=ρ0, tol=1e-2, maxiter=3, callback=identity)
+        @compile_workload begin
+            model = model_LDA(lattice, atoms, positions;
+                            magnetic_moments, temperature=0.1, spin_polarization=:collinear)
+            basis = PlaneWaveBasis(model; Ecut=5, kgrid=[2, 2, 2])
+            ρ0 = guess_density(basis, magnetic_moments)
+            scfres = self_consistent_field(basis; ρ=ρ0, tol=1e-2, maxiter=3, callback=identity)
+        end
     end
 end
+
 end # module DFTK

--- a/src/eigen/diag.jl
+++ b/src/eigen/diag.jl
@@ -29,8 +29,8 @@ function diagonalize_all_kblocks(eigensolver, ham::Hamiltonian, nev_per_kpoint::
         # Get ψguessk
         if !isnothing(ψguess)
             if n_Gk != size(ψguess[ik], 1)
-                error("Mismatch in dimension between guess ($(size(ψguess, 1)) and " *
-                      "Hamiltonian $n_Gk")
+                error("Mismatch in dimension between guess ($(size(ψguess[ik], 1)) and " *
+                      "Hamiltonian ($n_Gk)")
             end
             nev_guess = size(ψguess[ik], 2)
             if nev_guess > nev_per_kpoint


### PR DESCRIPTION
Not sure why the possibility was removed. It is useful for API-breaking changes.