### PR TITLE
Updating SCF doc

### DIFF
--- a/src/scf/self_consistent_field.jl
+++ b/src/scf/self_consistent_field.jl
@@ -92,7 +92,7 @@ Overview of parameters:
     solver=scf_anderson_solver(),
     eigensolver=lobpcg_hyper,
     determine_diagtol=ScfDiagtol(),
-    nbandsalg::NbandsAlgorithm=AdaptiveBands(basis.model),
+    nbandsalg::NbandsAlgorithm=AdaptiveBands(basis.model; occupation_threshold=tol/10),
     fermialg::AbstractFermiAlgorithm=default_fermialg(basis.model),
     callback=ScfDefaultCallback(; show_damping=false),
     compute_consistent_energies=true,

--- a/src/scf/self_consistent_field.jl
+++ b/src/scf/self_consistent_field.jl
@@ -77,6 +77,8 @@ Overview of parameters:
 - `nbandsalg`: By default DFTK uses `nbandsalg=AdaptiveBands(model)`, which adaptively determines
   the number of bands to compute. If you want to influence this algorithm or use a predefined
   number of bands in each SCF step, pass a [`FixedBands`](@ref) or [`AdaptiveBands`](@ref).
+  Beware that with non-zero temperature, the convergence of the SCF algorithm may be limited
+  by the `default_occupation_threshold` parameter.
 - `callback`: Function called at each SCF iteration. Usually takes care of printing the
   intermediate state.
 """
@@ -92,7 +94,7 @@ Overview of parameters:
     solver=scf_anderson_solver(),
     eigensolver=lobpcg_hyper,
     determine_diagtol=ScfDiagtol(),
-    nbandsalg::NbandsAlgorithm=AdaptiveBands(basis.model; occupation_threshold=tol/10),
+    nbandsalg::NbandsAlgorithm=AdaptiveBands(basis.model),
     fermialg::AbstractFermiAlgorithm=default_fermialg(basis.model),
     callback=ScfDefaultCallback(; show_damping=false),
     compute_consistent_energies=true,

--- a/src/scf/self_consistent_field.jl
+++ b/src/scf/self_consistent_field.jl
@@ -78,7 +78,8 @@ Overview of parameters:
   the number of bands to compute. If you want to influence this algorithm or use a predefined
   number of bands in each SCF step, pass a [`FixedBands`](@ref) or [`AdaptiveBands`](@ref).
   Beware that with non-zero temperature, the convergence of the SCF algorithm may be limited
-  by the `default_occupation_threshold` parameter.
+  by the `default_occupation_threshold` parameter. For highly accurate calculations we thus
+  recommend increasing the `default_occupation_threshold` of the `AdaptiveBands`.
 - `callback`: Function called at each SCF iteration. Usually takes care of printing the
   intermediate state.
 """
@@ -94,7 +95,7 @@ Overview of parameters:
     solver=scf_anderson_solver(),
     eigensolver=lobpcg_hyper,
     determine_diagtol=ScfDiagtol(),
-    nbandsalg::NbandsAlgorithm=AdaptiveBands(basis.model; occupation_threshold=tol/10),
+    nbandsalg::NbandsAlgorithm=AdaptiveBands(basis.model),
     fermialg::AbstractFermiAlgorithm=default_fermialg(basis.model),
     callback=ScfDefaultCallback(; show_damping=false),
     compute_consistent_energies=true,


### PR DESCRIPTION
Really simple fix for a "strange" behavior: If the computations are asked with temperature, then actually the tolerance of the SCF solver will be that of the maximum between the asked `scf_tol` and the `default_occupation_threshold` of 10⁻⁶.
I think this is not intuitive.
I would have changed `default_occupation_threshold` to take into account the `scf_tol`, but this seems to change quiet a bit the structures, so I think this PR is a sane middle ground @mfherbst.