### PR TITLE
Consistently employ n_bands_converge

### DIFF
--- a/src/input_output.jl
+++ b/src/input_output.jl
@@ -211,6 +211,7 @@ function band_data_to_dict!(dict, band_data::NamedTuple; save_ψ=false, save_ρ=
 
     n_bands = length(band_data.eigenvalues[1])
     dict["n_bands"] = n_bands  # n_spin_components and n_kpoints already stored
+    dict["n_bands_converge"] = band_data.n_bands_converge
 
     if !isnothing(band_data.εF)
         haskey(dict, "εF") && delete!(dict, "εF")
@@ -306,7 +307,7 @@ function scfres_to_dict!(dict, scfres::NamedTuple; save_ψ=true, save_ρ=true)
     band_data_to_dict!(dict, scfres; save_ψ)
 
     # These are either already done above or will be ignored or dealt with below.
-    special = (:ham, :basis, :energies, :stage,
+    special = (:ham, :basis, :energies, :stage, :n_bands_converge,
                :ρ, :ψ, :eigenvalues, :occupation, :εF, :diagonalization)
     propmap = Dict(:α => :damping_value, )  # compatibility mapping
     if mpi_master()

--- a/src/postprocess/band_structure.jl
+++ b/src/postprocess/band_structure.jl
@@ -48,7 +48,7 @@ All kwargs not specified below are passed to [`diagonalize_all_kblocks`](@ref):
     #      types subtype. In a first version the ScfResult could just contain
     #      the currently used named tuple and forward all operations to it.
     (; basis=bs_basis, ψ=eigres.X, eigenvalues=eigres.λ, ρ, εF, occupation,
-     diagonalization=[eigres])
+     diagonalization=[eigres], n_bands_converge=n_bands)
 end
 
 """

--- a/src/scf/newton.jl
+++ b/src/scf/newton.jl
@@ -150,7 +150,8 @@ function newton(basis::PlaneWaveBasis{T}, ψ0;
     # return results and call callback one last time with final state for clean
     # up
     info = (; ham=H, basis, energies, converged, ρ, eigenvalues, occupation, εF, n_iter, ψ,
-            stage=:finalize, algorithm="Newton", runtime_ns=time_ns() - start_ns)
+            stage=:finalize, algorithm="Newton", runtime_ns=time_ns() - start_ns,
+            n_bands_converge=n_bands)
     callback(info)
     info
 end


### PR DESCRIPTION
@Technici4n @antoine-levitt 

TODOs:
- [X] Consistently return `n_bands_converge` in all band structure objects
- [ ] Employ `n_bands_converge` in DOS, Wannier etc. to shrink range of considered bands