### PR TITLE
Fix normalization of wavefunctions

### DIFF
--- a/src/pseudo/PspUpf.jl
+++ b/src/pseudo/PspUpf.jl
@@ -126,8 +126,8 @@ function PspUpf(path; identifier=path, rcut=nothing)
     for l = 0:lmax-1
         pswfcs_l = filter(χ -> χ["angular_momentum"] == l, pseudo["atomic_wave_functions"])
         for pswfc_li in pswfcs_l
-            # Ry -> Ha, rχ -> r²χ
-            push!(r2_pswfcs[l+1], rgrid .* pswfc_li["radial_function"] ./ 2)
+            # rχ -> r²χ
+            push!(r2_pswfcs[l+1], rgrid .* pswfc_li["radial_function"])
             push!(pswfc_occs[l+1], pswfc_li["occupation"])
             push!(pswfc_energies[l+1], pswfc_li["pseudo_energy"])
             push!(pswfc_labels[l+1], pswfc_li["label"])


### PR DESCRIPTION
@azadoks Do you agree? The wavefunctions are not in units of energy, so there should not be a factor of 2 here.