### PR TITLE
Use the Simpson rule for integration of local part of PSPs

### DIFF
--- a/src/pseudo/PspUpf.jl
+++ b/src/pseudo/PspUpf.jl
@@ -194,7 +194,7 @@ function eval_psp_local_fourier(psp::PspUpf, p::T)::T where {T<:Real}
     # C(r) = -Z/r; H[-Z/r] = -Z/p^2
     rgrid = @view psp.rgrid[1:psp.ircut]
     vloc  = @view psp.vloc[1:psp.ircut]
-    I = trapezoidal(rgrid) do i, r
+    I = simpson(rgrid) do i, r
          r * (r * vloc[i] - -psp.Zion * erf(r)) * sphericalbesselj_fast(0, p * r)
     end
     4T(π) * (I + -psp.Zion / p^2 * exp(-p^2 / T(4)))
@@ -223,7 +223,7 @@ end
 function eval_psp_energy_correction(T, psp::PspUpf, n_electrons)
     rgrid = @view psp.rgrid[1:psp.ircut]
     vloc = @view psp.vloc[1:psp.ircut]
-    4T(π) * n_electrons * trapezoidal(rgrid) do i, r
+    4T(π) * n_electrons * simpson(rgrid) do i, r
         r * (r * vloc[i] - -psp.Zion)
     end
 end


### PR DESCRIPTION
This PR switches the integration of the local part of the pseudopotentials on radial grids from the trapezoidal to the Simpson's method.

This change induces a shift in the total energy, due to the PspCorrection and AtomicLocal terms. This is a rigid shift: the electronic density, energy gradients, and the physics are not modified. This energy shift is in the order of 10^-5 Ha, and the exact number depends on the system and the choice of pseudopotential.

As far as my numerical analysis understanding goes, the Simpson's method should be more accurate. My main motivation for this PR however, is that it makes DFTK total energies more comparable to other codes (tested against QE and SIRIUS).

Note: despite that shift in total energies, all the tests pass on my local machine. Are the tolerance threshold a bit too loose, maybe?