### PR TITLE
Make `solve_ΩplusK` MPI-compatible

### DIFF
--- a/src/response/cg.jl
+++ b/src/response/cg.jl
@@ -7,10 +7,18 @@ end
 """
 Implementation of the conjugate gradient method which allows for preconditioning
 and projection operations along iterations.
+
+To use this function with MPI:
+- Make `A`, `precon` and `proj` MPI-aware.
+- Pass a communicator to use for the `dot` and `norm` calls. By default, they do not communicate.
 """
 function cg!(x::AbstractVector{T}, A::LinearMap{T}, b::AbstractVector{T};
              precon=I, proj=identity, callback=identity,
-             tol=1e-10, maxiter=100, miniter=1) where {T}
+             tol=1e-10, maxiter=100, miniter=1,
+             comm::MPI.Comm=MPI.COMM_SELF) where {T}
+
+    mpi_dot(x1, x2) = mpi_sum(dot(x1, x2), comm)
+    mpi_norm(x1) = sqrt(mpi_sum(norm2(x1), comm))
 
     # initialisation
     # r = b - Ax is the residual
@@ -24,11 +32,11 @@ function cg!(x::AbstractVector{T}, A::LinearMap{T}, b::AbstractVector{T};
         r .-= c
     end
     ldiv!(c, precon, r)
-    γ = dot(r, c)
+    γ = mpi_dot(r, c)
     # p is the descent direction
     p = copy(c)
     n_iter = 0
-    residual_norm = norm(r)
+    residual_norm = mpi_norm(r)
 
     # convergence history
     converged = false
@@ -44,16 +52,16 @@ function cg!(x::AbstractVector{T}, A::LinearMap{T}, b::AbstractVector{T};
             break
         end
         mul!(c, A, p)
-        α = γ / dot(p, c)
+        α = γ / mpi_dot(p, c)
 
         # update iterate and residual while ensuring they stay in Ran(proj)
         x .= proj(x .+ α .* p)
         r .= proj(r .- α .* c)
-        residual_norm = norm(r)
+        residual_norm = mpi_norm(r)
 
         # apply preconditioner and prepare next iteration
         ldiv!(c, precon, r)
-        γ_prev, γ = γ, dot(r, c)
+        γ_prev, γ = γ, mpi_dot(r, c)
         β = γ / γ_prev
         p .= proj(c .+ β .* p)
     end

--- a/src/response/hessian.jl
+++ b/src/response/hessian.jl
@@ -69,11 +69,6 @@ Return δψ where (Ω+K) δψ = rhs
     # for now, all orbitals have to be fully occupied -> need to strip them beforehand
     @assert all(all(occ_k .== filled_occ) for occ_k in occupation)
 
-    # To mpi-parallelise we have to deal with the fact that the linear algebra
-    # in the CG (dot products, norms) couples k-Points. Maybe take a look at
-    # the PencilArrays.jl package to get this done automatically.
-    @assert mpi_nprocs() == 1  # Distributed implementation not yet available
-
     # compute quantites at the point which define the tangent space
     ρ = compute_density(basis, ψ, occupation)
     H = energy_hamiltonian(basis, ψ, occupation; ρ).ham
@@ -118,7 +113,7 @@ Return δψ where (Ω+K) δψ = rhs
         pack(δψ)
     end
     res = cg(J, rhs_pack; precon=FunctionPreconditioner(f_ldiv!), proj, tol,
-             callback)
+             callback, comm=basis.comm_kpts)
     (; δψ=unpack(res.x), res.converged, res.tol, res.residual_norm,
      res.n_iter)
 end


### PR DESCRIPTION
Only the `dot` and `norm` in the CG solver had to be made MPI-compatible.

Some quick numbers from benchmarking an operation dominated by `solve_ΩplusK` on my computer:

| MPI processes | running time |
|---|---|
|1|97.7s|
|2|49.4s|
|4|27.5s|