### PR TITLE
Optimize `apply_K`

### DIFF
--- a/src/densities.jl
+++ b/src/densities.jl
@@ -56,7 +56,7 @@ end
 # Variation in density corresponding to a variation in the orbitals and occupations.
 @views @timing function compute_δρ(basis::PlaneWaveBasis{T}, ψ, δψ, occupation,
                                    δoccupation=zero.(occupation);
-                                   occupation_threshold=zero(T), q=zero(Vec3{T})) where {T}
+                                   occupation_threshold=zero(T), q=zero(Vec3{T}), ψ_real=nothing) where {T}
     Tψ = promote_type(T, eltype(ψ[1]))
     # δρ is expected to be real when computations are not phonon-related.
     Tδρ = iszero(q) ? real(Tψ) : Tψ
@@ -84,7 +84,11 @@ end
         (ik, n) = kn
 
         kpt = basis.kpoints[ik]
-        ifft!(storage.ψnk_real, basis, kpt, ψ[ik][:, n])
+        if isnothing(ψ_real)
+            ifft!(storage.ψnk_real, basis, kpt, ψ[ik][:, n])
+        else
+            storage.ψnk_real .= ψ_real[ik][:, :, :, n]
+        end
         # … and then we compute the real Fourier transform in the adequate basis.
         ifft!(storage.δψnk_real, basis, δψ_plus_k[ik].kpt, δψ_plus_k[ik].ψk[:, n])
 

--- a/src/densities.jl
+++ b/src/densities.jl
@@ -56,7 +56,7 @@ end
 # Variation in density corresponding to a variation in the orbitals and occupations.
 @views @timing function compute_δρ(basis::PlaneWaveBasis{T}, ψ, δψ, occupation,
                                    δoccupation=zero.(occupation);
-                                   occupation_threshold=zero(T), q=zero(Vec3{T}), ψ_real=nothing) where {T}
+                                   occupation_threshold=zero(T), q=zero(Vec3{T})) where {T}
     Tψ = promote_type(T, eltype(ψ[1]))
     # δρ is expected to be real when computations are not phonon-related.
     Tδρ = iszero(q) ? real(Tψ) : Tψ
@@ -84,11 +84,7 @@ end
         (ik, n) = kn
 
         kpt = basis.kpoints[ik]
-        if isnothing(ψ_real)
-            ifft!(storage.ψnk_real, basis, kpt, ψ[ik][:, n])
-        else
-            storage.ψnk_real .= ψ_real[ik][:, :, :, n]
-        end
+        ifft!(storage.ψnk_real, basis, kpt, ψ[ik][:, n])
         # … and then we compute the real Fourier transform in the adequate basis.
         ifft!(storage.δψnk_real, basis, δψ_plus_k[ik].kpt, δψ_plus_k[ik].ψk[:, n])
 

--- a/src/densities.jl
+++ b/src/densities.jl
@@ -88,8 +88,8 @@ end
         # … and then we compute the real Fourier transform in the adequate basis.
         ifft!(storage.δψnk_real, basis, δψ_plus_k[ik].kpt, δψ_plus_k[ik].ψk[:, n])
 
-        storage.δρ[:, :, :, kpt.spin] .+= real_qzero(
-            2 .* occupation[ik][n] .* basis.kweights[ik] .* conj(storage.ψnk_real)
+        storage.δρ[:, :, :, kpt.spin] .+= real_qzero.(
+            2 .* occupation[ik][n] .* basis.kweights[ik] .* conj.(storage.ψnk_real)
                                                          .* storage.δψnk_real
                 .+ δoccupation[ik][n] .* basis.kweights[ik] .* abs2.(storage.ψnk_real))
 

--- a/src/response/hessian.jl
+++ b/src/response/hessian.jl
@@ -37,9 +37,9 @@ end
 Compute the application of K defined at ψ to δψ. ρ is the density issued from ψ.
 δψ also generates a δρ, computed with `compute_δρ`.
 """
-@views @timing function apply_K(basis::PlaneWaveBasis{T}, δψ, ψ, ρ, occupation) where {T}
+@views @timing function apply_K(basis::PlaneWaveBasis{T}, δψ, ψ, ρ, occupation; ψ_real=nothing) where {T}
     δψ = proj_tangent(δψ, ψ)
-    δρ = compute_δρ(basis, ψ, δψ, occupation)
+    δρ = compute_δρ(basis, ψ, δψ, occupation; ψ_real)
     δV = apply_kernel(basis, δρ; ρ)
 
     ψnk_real = similar(basis.G_vectors, promote_type(T, eltype(ψ[1])))
@@ -48,7 +48,11 @@ Compute the application of K defined at ψ to δψ. ρ is the density issued fro
         δVψk = similar(ψk)
 
         for n = 1:size(ψk, 2)
-            ifft!(ψnk_real, basis, kpt, ψk[:, n])
+            if isnothing(ψ_real)
+                ifft!(ψnk_real, basis, kpt, ψk[:, n])
+            else
+                ψnk_real .= ψ_real[ik][:, :, :, n]
+            end
             ψnk_real .*= δV[:, :, :, kpt.spin]
             fft!(δVψk[:, n], basis, kpt, ψnk_real)
         end
@@ -100,13 +104,20 @@ Return δψ where (Ω+K) δψ = rhs
         x .= pack(Pδψ)
     end
 
+    # Precompute IFFT of ψ
+    ψ_real = map(enumerate(basis.kpoints)) do (ik, kpt)
+        stack(map(eachcol(ψ[ik])) do ψnk
+            ifft(basis, kpt, ψnk)
+        end)
+    end
+
     # Rayleigh-coefficients
     Λ = [ψk'Hψk for (ψk, Hψk) in zip(ψ, H * ψ)]
 
     # mapping of the linear system on the tangent space
     function ΩpK(x)
         δψ = unsafe_unpack(x)
-        Kδψ = apply_K(basis, δψ, ψ, ρ, occupation)
+        Kδψ = apply_K(basis, δψ, ψ, ρ, occupation; ψ_real)
         Ωδψ = apply_Ω(δψ, ψ, H, Λ)
         pack(Ωδψ + Kδψ)
     end

--- a/src/response/hessian.jl
+++ b/src/response/hessian.jl
@@ -38,6 +38,11 @@ Compute the application of K defined at ψ to δψ. ρ is the density issued fro
 δψ also generates a δρ, computed with `compute_δρ`.
 """
 @views @timing function apply_K(basis::PlaneWaveBasis{T}, δψ, ψ, ρ, occupation) where {T}
+    # ~45% of apply_K is spent computing ifft(ψ) twice: once in compute_δρ and once again below.
+    # By caching the result, we could compute it only once for a single application of K,
+    # or even across many applications when using solve_ΩplusK.
+    # But we don't because the memory requirements would be too high (typically an order of magnitude higher than ψ).
+
     δψ = proj_tangent(δψ, ψ)
     δρ = compute_δρ(basis, ψ, δψ, occupation)
     δV = apply_kernel(basis, δρ; ρ)

--- a/src/response/hessian.jl
+++ b/src/response/hessian.jl
@@ -37,19 +37,20 @@ end
 Compute the application of K defined at ψ to δψ. ρ is the density issued from ψ.
 δψ also generates a δρ, computed with `compute_δρ`.
 """
-@views @timing function apply_K(basis::PlaneWaveBasis, δψ, ψ, ρ, occupation)
+@views @timing function apply_K(basis::PlaneWaveBasis{T}, δψ, ψ, ρ, occupation) where {T}
     δψ = proj_tangent(δψ, ψ)
     δρ = compute_δρ(basis, ψ, δψ, occupation)
     δV = apply_kernel(basis, δρ; ρ)
 
+    ψnk_real = similar(basis.G_vectors, promote_type(T, eltype(ψ[1])))
     Kδψ = map(enumerate(ψ)) do (ik, ψk)
         kpt = basis.kpoints[ik]
         δVψk = similar(ψk)
 
         for n = 1:size(ψk, 2)
-            ψnk_real = ifft(basis, kpt, ψk[:, n])
-            δVψnk_real = δV[:, :, :, kpt.spin] .* ψnk_real
-            δVψk[:, n] = fft(basis, kpt, δVψnk_real)
+            ifft!(ψnk_real, basis, kpt, ψk[:, n])
+            ψnk_real .*= δV[:, :, :, kpt.spin]
+            fft!(δVψk[:, n], basis, kpt, ψnk_real)
         end
         δVψk
     end


### PR DESCRIPTION
A few low-hanging fruits to optimize `solve_ΩplusK`, which is currently dominated by `apply_K`.

### 1. Optimize allocations in `compute_δρ`
A couple of `.` were missing to fuse array operations together.

Before:
```julia
julia> @time δρ = DFTK.compute_δρ(basis_ref, ψ_upscaled, δψ.δψ, occupation);
  0.422897 seconds (5.26 k allocations: 538.114 MiB, 4.43% gc time)
```
After:
```julia
julia> @time δρ = DFTK.compute_δρ(basis_ref, ψ_upscaled, δψ.δψ, occupation);
  0.328420 seconds (4.61 k allocations: 23.110 MiB)
```

### 2. Optimize allocations in `apply_K`
For each k-point, `apply_K` was allocating three arrays per band: one to hold the IFFT, one to hold `δV .* ψnk_real`, and one to hold the FFT.

The change is to now preallocate a single array to hold the result of the IFFT, and of the multiplication by `δV`.

Before:
```julia
julia> @time x = DFTK.apply_K(basis_ref, δψ.δψ, ψ_upscaled, ρ, occupation);
  0.870054 seconds (6.35 k allocations: 689.433 MiB, 5.23% gc time)
```

After:
```julia
julia> @time x = DFTK.apply_K(basis_ref, δψ.δψ, ψ_upscaled, ρ, occupation);
  0.644315 seconds (5.49 k allocations: 65.835 MiB)
```

### 3. Reuse IFFT of `ψ`
~~Every time $\pmb{K}$ is applied, the IFFT of `ψ` was computed **twice**: once in `compute_δρ` and once in `apply_K` itself. It does not change over the entire `solve_ΩplusK` call, so we can compute it once and reuse it.~~

Reverted because it increases memory requirements by an order of magnitude.