### PR TITLE
Use latest pre-release version instead of nightly for CI against upcoming versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
           - {mode: stable,  os: macOS-latest,   payload: noslow         }
           - {mode: stable,  os: windows-latest, payload: noslow         }
           - {mode: stable,  os: ubuntu-latest,  payload: noslow-mpi     }
-          - {mode: pre, os: ubuntu-latest,  payload: noslow         }
+          - {mode: latest,  os: ubuntu-latest,  payload: noslow         }
     env:
       GKS_ENCODING: utf8
       GKSwstype: 100       # Needed for Plots-related tests
@@ -41,15 +41,13 @@ jobs:
           version: '1.10'
           arch: x64
         if: ${{ matrix.mode == 'stable' }}
-      - name: Setup Julia pre-release
+      - name: Setup Julia latest (pre-releases included)
         uses: julia-actions/setup-julia@v1
         with:
           version: '1'
           include-all-prereleases: true
           arch: x64
-        if: ${{ matrix.mode == 'pre' }}
-      - name: "[TEMPORARY] Print julia version"
-        run: julia --version
+        if: ${{ matrix.mode == 'latest' }}
 
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,8 @@ jobs:
       - name: Setup Julia pre-release
         uses: julia-actions/setup-julia@v1
         with:
-          version: pre
+          version: '1'
+          include-all-prereleases: true
           arch: x64
         if: ${{ matrix.mode == 'pre' }}
       - name: "[TEMPORARY] Print julia version"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
           version: pre
           arch: x64
         if: ${{ matrix.mode == 'pre' }}
-      - name: [TEMPORARY] Print julia version
+      - name: "[TEMPORARY] Print julia version"
         run: julia --version
 
       - uses: julia-actions/cache@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
           - {mode: stable,  os: macOS-latest,   payload: noslow         }
           - {mode: stable,  os: windows-latest, payload: noslow         }
           - {mode: stable,  os: ubuntu-latest,  payload: noslow-mpi     }
-          - {mode: nightly, os: ubuntu-latest,  payload: noslow         }
+          - {mode: pre, os: ubuntu-latest,  payload: noslow         }
     env:
       GKS_ENCODING: utf8
       GKSwstype: 100       # Needed for Plots-related tests
@@ -41,12 +41,14 @@ jobs:
           version: '1.10'
           arch: x64
         if: ${{ matrix.mode == 'stable' }}
-      - name: Setup Julia nightly
+      - name: Setup Julia pre-release
         uses: julia-actions/setup-julia@v1
         with:
-          version: nightly
+          version: pre
           arch: x64
-        if: ${{ matrix.mode == 'nightly' }}
+        if: ${{ matrix.mode == 'pre' }}
+      - name: [TEMPORARY] Print julia version
+        run: julia --version
 
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1


### PR DESCRIPTION
It should be a lot more stable. This is setup to test against the latest version, pre-releases included. Right now this checks against 1.11.1, but I expect it to test against 1.12 pre-releases once they get released.

Thanks to @gdalle for the idea.