### PR TITLE
Fix Fermi-Dirac occupation overflow and remove custom ForwardDiff rule (#514)

### DIFF
--- a/src/Smearing.jl
+++ b/src/Smearing.jl
@@ -67,9 +67,13 @@ struct None <: SmearingFunction end
 occupation(S::None, x) = x > 0 ? zero(x) : one(x)
 entropy(S::None, x) = zero(x)
 
-"""Fermi dirac smearing"""
+"""Fermi-Dirac smearing"""
 struct FermiDirac <: SmearingFunction end
-occupation(S::FermiDirac, x) = 1 / (1 + exp(x))
+function occupation(S::FermiDirac, x::T) where T
+    max_exp_arg = -log(eps(T)) + 5  # add some wiggle room
+    (x > max_exp_arg) && return zero(x)
+    1 / (1 + exp(x))
+end
 function xlogx(x)
     iszero(x) ? zero(x) : x * log(x)
 end

--- a/src/Smearing.jl
+++ b/src/Smearing.jl
@@ -70,8 +70,12 @@ entropy(S::None, x) = zero(x)
 """Fermi-Dirac smearing"""
 struct FermiDirac <: SmearingFunction end
 function occupation(S::FermiDirac, x::T) where T
-    max_exp_arg = -log(eps(T)) + 5  # add some wiggle room
-    (x > max_exp_arg) && return zero(x)
+    # Avoids overflow of exp for large positive x by using the identity
+    # 1 / (1 + exp(x)) = exp(-x) / (1 + exp(-x))
+    if x > 0
+        y = exp(-x)
+        return y / (1 + y)
+    end
     1 / (1 + exp(x))
 end
 function xlogx(x)

--- a/src/workarounds/forwarddiff_rules.jl
+++ b/src/workarounds/forwarddiff_rules.jl
@@ -249,18 +249,6 @@ function LinearAlgebra.norm(x::SVector{S,<:Dual{Tg,T,N}}) where {S,Tg,T,N}
     Dual{Tg}(y, dy)
 end
 
-# problem: the derivative of 1/(1+exp(x)) = -exp(x) / (1+exp(x))^2.
-# When x is too large, exp(x) = Inf and this is a NaN.
-function Smearing.occupation(S::Smearing.FermiDirac, d::Dual{T}) where {T}
-    x = ForwardDiff.value(d)
-    if exp(x) > floatmax(typeof(x)) / 1e3
-        ∂occ = -zero(x)
-    else
-        ∂occ = -exp(x) / (1 + exp(x))^2
-    end
-    Dual{T}(Smearing.occupation(S, x), ∂occ * ForwardDiff.partials(d))
-end
-
 # Fix for https://github.com/JuliaDiff/ForwardDiff.jl/issues/514
 function Base.:^(x::Complex{Dual{T,V,N}}, y::Complex{Dual{T,V,N}}) where {T,V,N}
     xx = complex(ForwardDiff.value(real(x)), ForwardDiff.value(imag(x)))


### PR DESCRIPTION
From the discussion at (#514).