### PR TITLE
Speed-up symmetrize_ρ

### DIFF
--- a/src/PlaneWaveBasis.jl
+++ b/src/PlaneWaveBasis.jl
@@ -400,6 +400,21 @@ Returns nothing if outside the range of valid wave vectors.
     end
 end
 
+@inline function index_G_vectors(fft_start::Tuple, fft_stop:: Tuple, fft_lengths::Tuple,
+                                 G::AbstractVector{<:Integer})
+
+    # FFTs store wavevectors as [0 1 2 3 -2 -1] (example for N=5)
+    function G_to_index(length, G)
+        G >= 0 && return 1 + G
+        return 1 + length + G
+    end
+    if all(fft_start .<= G .<= fft_stop)
+        CartesianIndex(Tuple(G_to_index.(fft_lengths, G)))
+    else
+        nothing  # Outside range of valid indices
+    end
+end
+
 function index_G_vectors(basis::PlaneWaveBasis, G::AbstractVector{<:Integer})
     index_G_vectors(basis.fft_size, G)
 end

--- a/src/PlaneWaveBasis.jl
+++ b/src/PlaneWaveBasis.jl
@@ -400,22 +400,8 @@ Returns nothing if outside the range of valid wave vectors.
     end
 end
 
-@inline function index_G_vectors(fft_start::Tuple, fft_stop:: Tuple, fft_lengths::Tuple,
-                                 G::AbstractVector{<:Integer})
-
-    # FFTs store wavevectors as [0 1 2 3 -2 -1] (example for N=5)
-    function G_to_index(length, G)
-        G >= 0 && return 1 + G
-        return 1 + length + G
-    end
-    if all(fft_start .<= G .<= fft_stop)
-        CartesianIndex(Tuple(G_to_index.(fft_lengths, G)))
-    else
-        nothing  # Outside range of valid indices
-    end
-end
-
-function index_G_vectors(basis::PlaneWaveBasis, G::AbstractVector{<:Integer})
+# @inline is necessary here for the inner function to be inlined as well
+@inline function index_G_vectors(basis::PlaneWaveBasis, G::AbstractVector{<:Integer})
     index_G_vectors(basis.fft_size, G)
 end
 

--- a/src/common/cis2pi.jl
+++ b/src/common/cis2pi.jl
@@ -1,14 +1,13 @@
 """Function to compute exp(2π i x)"""
 cis2pi(x) = cispi(2x)
-function cis2pi(x::AbstractFloat)
+function cis2pi(x::T) where {T <: AbstractFloat}
     # Special case when 2x is an integer, as exp(n*π*i) = +- 1. Saves expensive
     # exponential evaluations when called repeatedly
     if isinteger(2x)
-        isodd(2x) ? result = -Complex{typeof(x)}(1, 0) : result = Complex{typeof(x)}(1, 0)
+        return isodd(2x) ? -one(complex(T)) : one(complex(T))
     else
-        result = cispi(2x)
+        return cispi(2x)
     end
-    result
 end
 
 """Function to compute sin(2π x)"""

--- a/src/common/cis2pi.jl
+++ b/src/common/cis2pi.jl
@@ -1,5 +1,15 @@
 """Function to compute exp(2π i x)"""
 cis2pi(x) = cispi(2x)
+function cis2pi(x::AbstractFloat)
+    # Special case when 2x is an integer, as exp(n*π*i) = +- 1. Saves expensive
+    # exponential evaluations when called repeatedly
+    if isinteger(2x)
+        isodd(2x) ? result = -Complex{typeof(x)}(1, 0) : result = Complex{typeof(x)}(1, 0)
+    else
+        result = cispi(2x)
+    end
+    result
+end
 
 """Function to compute sin(2π x)"""
 sin2pi(x) = sinpi(2x)

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -288,22 +288,14 @@ function accumulate_over_symmetries!(ρaccu, ρin, basis::PlaneWaveBasis{T}, sym
         #     ρ ̂_{Sk}(G) = e^{-i G \cdot τ} ̂ρ_k(S^{-1} G)
         invS = Mat3{Int}(inv(symop.S))
         for (ig, G) in enumerate(G_vectors_generator(basis.fft_size))
-            igired = index_G_vectors(basis.fft_size, invS * G)
+            igired = index_G_vectors(basis, invS * G)
             isnothing(igired) && continue
 
             if iszero(symop.τ)
                 @inbounds ρaccu[ig] += ρin[igired]
             else
-                x = -T(2.0*dot(G, symop.τ))
-                # Special case for integers, as exp(n*π*i) = +- 1. Since this is the
-                # most common occurence, lots of expensive cispi() evaluations are saved
-                if isinteger(x)
-                    isodd(x) ? factor = T(-1.0) : factor =  T(1.0)
-                else
-                    factor = cispi(x)
-                end
+                factor = cis2pi(-T(dot(G, symop.τ)))
                 @inbounds ρaccu[ig] += factor * ρin[igired]
-
             end
         end
     end  # symop

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -271,6 +271,9 @@ end
 # Accumulates the symmetrized versions of the density ρin into ρout (in Fourier space).
 # No normalization is performed
 function accumulate_over_symmetries!(ρaccu, ρin, basis::PlaneWaveBasis{T}, symmetries) where {T}
+    fft_start = .- cld.(basis.fft_size .- 1, 2)
+    fft_stop  = fld.(basis.fft_size .- 1, 2)
+    fft_lengths = fft_stop .- fft_start .+ 1
     for symop in symmetries
         # Common special case, where ρin does not need to be processed
         if isone(symop)
@@ -288,7 +291,7 @@ function accumulate_over_symmetries!(ρaccu, ρin, basis::PlaneWaveBasis{T}, sym
         #     ρ ̂_{Sk}(G) = e^{-i G \cdot τ} ̂ρ_k(S^{-1} G)
         invS = Mat3{Int}(inv(symop.S))
         for (ig, G) in enumerate(G_vectors_generator(basis.fft_size))
-            igired = index_G_vectors(basis, invS * G)
+            igired = index_G_vectors(fft_start, fft_stop, fft_lengths, invS * G)
             isnothing(igired) && continue
 
             if iszero(symop.τ)

--- a/test/symmetry_issues.jl
+++ b/test/symmetry_issues.jl
@@ -1,7 +1,7 @@
 # This file collects examples, where we had issues with symmetries (symmetry determination,
 # k-point reduction, etc.) which are now resolved. Should make sure we don't reintroduce bugs.
 
-@testitem "Symmetry issues" begin
+@testitem "Symmetry issues" setup=[TestCases] begin
     using DFTK
     using DFTK: spglib_dataset
     using Unitful
@@ -24,4 +24,51 @@
         @test length(symmetries) == 48
         @test spglib_dataset(system).spacegroup_number == 225
     end
+
+    @testset "Inlining" begin
+        # Test that the index_G_vectors function is properly inlined by comparing timing
+        # with a locally defined function known not to be inlined. Issue initially tackled
+        # in PR https://github.com/JuliaMolSim/DFTK.jl/pull/1025
+        function index_G_vectors_slow(basis, G::AbstractVector{<:Integer})
+            start = .- cld.(basis.fft_size .- 1, 2)
+            stop  = fld.(basis.fft_size .- 1, 2)
+            lengths = stop .- start .+ 1
+
+            # FFTs store wavevectors as [0 1 2 3 -2 -1] (example for N=5)
+            function G_to_index(length, G)
+                G >= 0 && return 1 + G
+                return 1 + length + G
+            end
+            if all(start .<= G .<= stop)
+                CartesianIndex(Tuple(G_to_index.(lengths, G)))
+            else
+                nothing  # Outside range of valid indices
+            end
+        end
+
+        # This is a bare-bone version of the accumulate_over_symmetries() function, only
+        # keeping calls to the index_G_vectors() function for which we test inlining
+        function G_vectors_calls(basis, test_func)
+            for symop in basis.symmetries
+                invS = Mat3{Int}(inv(symop.S))
+                for (ig, G) in enumerate(DFTK.G_vectors_generator(basis.fft_size))
+                    igired = test_func(basis, invS * G)
+                end
+            end
+        end
+
+        silicon = TestCases.silicon
+        Si = ElementPsp(silicon.atnum, load_psp("hgh/lda/si-q4"))
+        atoms = [Si, Si]
+        model = model_DFT(silicon.lattice, atoms, silicon.positions;
+                          functionals=[:lda_x, :lda_c_vwn])
+        Ecut = 32
+        kgrid = [1, 1, 1]
+        basis = PlaneWaveBasis(model; Ecut, kgrid)
+
+        actual_alloc = @allocated G_vectors_calls(basis, DFTK.index_G_vectors)
+        slow_alloc = @allocated G_vectors_calls(basis, index_G_vectors_slow)
+        @test slow_alloc > actual_alloc
+    end
 end
+


### PR DESCRIPTION
In some cases, the `symmetrize_ρ` function becomes a major bottleneck of the calculation (high symmetry, large cutoffs and/or on the GPU). Profiling reveals that ~ half of the time is spent in `index_G_vectors`, and ~ half on `cis2pi`.

This PR drastically reduces the time spent in `index_G_vectors`, by pre-computing the FFT start, end and lengths, which currently takes place every time the function is called (number of symmetries x number of G vectors). As a result, calls to `symmetrize_ρ` are about 40-50% faster.

Note that the time spent in `cis2pi` could also be minimized by pre-computing and storing a 2D array containing the factors for each pair of G vector and symmetry. While this is done in SIRIUS (and probably other PW codes), this creates a lot of noise and complication in the code base.