### PR TITLE
Minor optimization of nonlocal term

### DIFF
--- a/src/terms/nonlocal.jl
+++ b/src/terms/nonlocal.jl
@@ -73,7 +73,8 @@ end
             G_plus_k_cart = to_cpu(Gplusk_vectors_cart(basis, kpt))
             G_plus_k = Gplusk_vectors(basis, kpt)
             occupationk = to_cpu(occupation[ik])
-            form_factors = to_device(basis.architecture, build_projector_form_factors(element.psp, G_plus_k_cart))
+            form_factors = to_device(basis.architecture,
+                                     build_projector_form_factors(element.psp, G_plus_k_cart))
 
             # Pre-allocation of large arrays
             δHψk = similar(ψ[ik])

--- a/src/terms/nonlocal.jl
+++ b/src/terms/nonlocal.jl
@@ -76,12 +76,13 @@ end
             form_factors = to_device(basis.architecture,
                                      build_projector_form_factors(element.psp, G_plus_k_cart))
 
-            # Pre-allocation of large arrays
-            δHψk = similar(ψ[ik])
-            P = similar(form_factors)
-            dPdR = similar(form_factors)
-            structure_factors = similar(form_factors, length(G_plus_k))
+            # Pre-allocation of large arrays (Noticable performance improvements on
+            # CPU and GPU here)
+            δHψk  = similar(ψ[ik])
+            P     = similar(form_factors)
+            dPdR  = similar(form_factors)
             twoπp = similar(form_factors, length(G_plus_k))
+            structure_factors = similar(form_factors, length(G_plus_k))
             
             for idx in group
                 r = model.positions[idx]

--- a/src/terms/operators.jl
+++ b/src/terms/operators.jl
@@ -108,7 +108,7 @@ struct NonlocalOperator{T <: Real, PT, DT} <: RealFourierOperator
     D::DT
 end
 function apply!(Hψ, op::NonlocalOperator, ψ)
-    Hψ.fourier .+= op.P * (op.D * (op.P' * ψ.fourier))
+    mul!(Hψ.fourier, op.P, (op.D * (op.P' * ψ.fourier)), 1, 1)
 end
 Matrix(op::NonlocalOperator) = op.P * op.D * op.P'
 


### PR DESCRIPTION
When using the built-in DFTK.timer as a rough profiler, it appears that the `nonlocal` term involves a lot more memory allocations than any other term in the Hamiltonian. This is particularly obvious for the H*psi product in LOBPCG and the forces.

This PR minimizes these memory allocations. A minor speed-up of ~10% can be observed on the H*psi product, and a larger speedup of up to 50% on the forces (on a handful of test cases). 