### PR TITLE
Drop ChainRulesCore dependency

### DIFF
--- a/src/DFTK.jl
+++ b/src/DFTK.jl
@@ -11,7 +11,6 @@ using ForwardDiff
 using AbstractFFTs
 using GPUArraysCore
 using Random
-using ChainRulesCore
 using PrecompileTools
 
 @template (FUNCTIONS, METHODS, MACROS) = 

--- a/src/terms/xc.jl
+++ b/src/terms/xc.jl
@@ -493,10 +493,7 @@ function add_kernel_gradient_correction!(δV, terms, density, perturbation, cros
 end
 
 function mergesum(nt1::NamedTuple{An}, nt2::NamedTuple{Bn}) where {An, Bn}
-    all_keys = nothing
-    ChainRulesCore.@ignore_derivatives begin
-        all_keys = (union(An, Bn)..., )
-    end
+    all_keys = (union(An, Bn)..., )
     values = map(all_keys) do key
         if haskey(nt1, key)
             nt1[key] .+ get(nt2, key, false)


### PR DESCRIPTION
This removes ChainRulesCore as a dependency, as it is not used for anything at the current stage.