### PR TITLE
Change default to ResponseOptions(verbose=true)

### DIFF
--- a/src/scf/self_consistent_field.jl
+++ b/src/scf/self_consistent_field.jl
@@ -44,7 +44,7 @@ end
 # Struct to store some options for forward-diff / reverse-diff response
 # (unused in primal calculations)
 @kwdef struct ResponseOptions
-    verbose = false
+    verbose = true
 end
 
 """


### PR DESCRIPTION
I find myself always manually passing ResponseOptions(verbose=true), whenever I use ForwardDiff for response. Given that the response solver runs similarly long as the SCF itself (or even multiple times in the case of multiple partials), and the SCF is verbose by default, here I propose to make the response verbose by default too.