### PR TITLE
Minor optimization of FFTGrid initialization

### DIFF
--- a/src/fft.jl
+++ b/src/fft.jl
@@ -89,7 +89,8 @@ function FFTGrid(fft_size::Tuple{Int, Int, Int}, unit_cell_volume::T,
 
     VT = value_type(T)
     fac = 1 ./ VT.(fft_size)
-    r_vectors = map(idx -> Vec3{VT}(fac .* (idx.I .- (1, 1, 1))), CartesianIndices(fft_size))
+    r_vectors_cpu = map(idx -> Vec3{VT}(fac .* (idx.I .- (1, 1, 1))), CartesianIndices(fft_size))
+    r_vectors = to_device(arch, r_vectors_cpu)
 
     FFTGrid{T, VT, typeof(Gs), typeof(r_vectors)}(fft_size, opFFT, ipFFT, opBFFT, ipBFFT,
                                                   fft_normalization, ifft_normalization,

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -88,9 +88,8 @@ function FFTGrid(fft_size::Tuple{Int, Int, Int}, unit_cell_volume::T,
     fft_normalization  = sqrt(unit_cell_volume) / length(ipFFT)
 
     VT = value_type(T)
-    r_vectors = [(Vec3{VT}(idx.I) .- (1, 1, 1)) ./ VT.(fft_size)
-                 for idx in CartesianIndices(fft_size)]
-    r_vectors = to_device(arch, r_vectors)
+    fac = 1 ./ VT.(fft_size)
+    r_vectors = map(idx -> Vec3{VT}(fac .* (idx.I .- (1, 1, 1))), CartesianIndices(fft_size))
 
     FFTGrid{T, VT, typeof(Gs), typeof(r_vectors)}(fft_size, opFFT, ipFFT, opBFFT, ipBFFT,
                                                   fft_normalization, ifft_normalization,

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -89,7 +89,9 @@ function FFTGrid(fft_size::Tuple{Int, Int, Int}, unit_cell_volume::T,
 
     VT = value_type(T)
     fac = 1 ./ VT.(fft_size)
-    r_vectors_cpu = map(idx -> Vec3{VT}(fac .* (idx.I .- (1, 1, 1))), CartesianIndices(fft_size))
+    r_vectors_cpu = [Vec3{VT}(fac .* (idx.I .- (1, 1, 1))) 
+                     for idx in CartesianIndices(fft_size)]
+
     r_vectors = to_device(arch, r_vectors_cpu)
 
     FFTGrid{T, VT, typeof(Gs), typeof(r_vectors)}(fft_size, opFFT, ipFFT, opBFFT, ipBFFT,

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -89,9 +89,7 @@ function FFTGrid(fft_size::Tuple{Int, Int, Int}, unit_cell_volume::T,
 
     VT = value_type(T)
     fac = 1 ./ VT.(fft_size)
-    r_vectors_cpu = [Vec3{VT}(fac .* (idx.I .- (1, 1, 1))) 
-                     for idx in CartesianIndices(fft_size)]
-
+    r_vectors_cpu = [Vec3{VT}(fac .* (idx.I .- (1, 1, 1))) for idx in CartesianIndices(fft_size)]
     r_vectors = to_device(arch, r_vectors_cpu)
 
     FFTGrid{T, VT, typeof(Gs), typeof(r_vectors)}(fft_size, opFFT, ipFFT, opBFFT, ipBFFT,


### PR DESCRIPTION
With PR #1056 and #1061, the bottleneck of `PlaneWaveBasis` instantiation becomes the creation of `r_vectors` at `FFTGrid` initialization. For systems with high cutoffs, this is non-negligible.

This PR enables the calculation of the `r_vectors` on the GPU. Additionally, it greatly speeds-up the CPU version by precomputing and recasting the inverse of `fft_size`.