### PR TITLE
Fix GPU runs

### DIFF
--- a/src/eigen/diag.jl
+++ b/src/eigen/diag.jl
@@ -54,6 +54,8 @@ function diagonalize_all_kblocks(eigensolver, ham::Hamiltonian, nev_per_kpoint::
     # Transform results into a nicer datastructure
     # TODO It feels inconsistent to put λ onto the CPU here but none of the other objects.
     #      Better have this handled by the caller of diagonalize_all_kblocks.
+    #      Note further that lobpcg_hyper by default puts the eigenvalues
+    #      on the CPU ... even if the next line is removed.
     (; λ=[to_cpu(real.(res.λ)) for res in results],  # Always get onto the CPU
      X=[res.X for res in results],
      residual_norms=[res.residual_norms for res in results],

--- a/src/eigen/diag_lobpcg_hyper.jl
+++ b/src/eigen/diag_lobpcg_hyper.jl
@@ -1,5 +1,7 @@
 include("lobpcg_hyper_impl.jl")
 
+# Note that this function will return λ on the CPU,
+# but X and the history on the device (for GPU runs)
 function lobpcg_hyper(A, X0; maxiter=100, prec=nothing,
                       tol=20size(A, 2)*eps(real(eltype(A))),
                       largest=false, n_conv_check=nothing, kwargs...)

--- a/src/eigen/lobpcg_hyper_impl.jl
+++ b/src/eigen/lobpcg_hyper_impl.jl
@@ -311,7 +311,7 @@ end
 end
 
 function final_retval(X, AX, BX, λ, resid_history, niter, n_matvec)
-    λ_host = oftype(ones(eltype(λ), 1), λ) # Copy to CPU for element-wise access
+    λ_host = oftype(ones(eltype(λ), 1), λ)  # Copy to CPU for element-wise access
     if !issorted(λ_host)
         p = sortperm(λ_host)
         λ_host = λ_host[p]
@@ -331,6 +331,8 @@ end
 ### R is then recomputed, and orthonormalized explicitly wrt BX and BP
 ### We reuse applications of A/B when it is safe to do so, ie only with orthogonal transformations
 
+# Note that this function will return λ on the CPU,
+# but X and the history on the device (for GPU runs)
 @timing function LOBPCG(A, X, B=I, precon=I, tol=1e-10, maxiter=100;
                         miniter=1, ortho_tol=2eps(real(eltype(X))),
                         n_conv_check=nothing, display_progress=false)

--- a/src/eigen/lobpcg_hyper_impl.jl
+++ b/src/eigen/lobpcg_hyper_impl.jl
@@ -310,17 +310,17 @@ end
     X
 end
 
-
 function final_retval(X, AX, BX, λ, resid_history, niter, n_matvec)
-    if !issorted(λ)
-        p = sortperm(λ)
-        λ = λ[p]
+    λ_host = oftype(ones(eltype(λ), 1), λ) # Copy to CPU for element-wise access
+    if !issorted(λ_host)
+        p = sortperm(λ_host)
+        λ = λ_host[p]
         X  = X[:, p]
         AX = AX[:, p]
         BX = BX[:, p]
         resid_history = resid_history[p, :]
     end
-    (; λ=λ, X, AX, BX,
+    (; λ=λ_host, X, AX, BX,
      residual_norms=resid_history[:, niter+1],
      residual_history=resid_history[:, 1:niter+1], n_matvec)
 end

--- a/src/eigen/lobpcg_hyper_impl.jl
+++ b/src/eigen/lobpcg_hyper_impl.jl
@@ -314,7 +314,7 @@ function final_retval(X, AX, BX, λ, resid_history, niter, n_matvec)
     λ_host = oftype(ones(eltype(λ), 1), λ) # Copy to CPU for element-wise access
     if !issorted(λ_host)
         p = sortperm(λ_host)
-        λ = λ_host[p]
+        λ_host = λ_host[p]
         X  = X[:, p]
         AX = AX[:, p]
         BX = BX[:, p]


### PR DESCRIPTION
PR #980 breaks GPU runs by doing element-wise access on GPU arrays. This fixes it by copying the offending array to the host first.