### PR TITLE
Hgh Cleanup

### DIFF
--- a/examples/pseudopotentials.jl
+++ b/examples/pseudopotentials.jl
@@ -6,7 +6,7 @@
 #
 # Currently, DFTK supports norm-conserving (NC) PSPs in
 # separable (Kleinman-Bylander) form. Two file formats can currently
-# be read and used: analytical Hartwigsen-Goedecker-Hutter (HGH) PSPs
+# be read and used: analytical Goedecker-Teter-Hutter (GTH) PSPs
 # and numeric Unified Pseudopotential Format (UPF) PSPs.
 #
 # In brief, the pseudopotential approach replaces the all-electron
@@ -19,7 +19,7 @@
 # computational efficiency.
 #
 # Different PSP generation codes produce various file formats which contain the
-# same general quantities required for pesudopotential evaluation. HGH PSPs
+# same general quantities required for pesudopotential evaluation. GTH PSPs
 # are constructed from a fixed functional form based on Gaussians, and the files
 # simply tablulate various coefficients fitted for a given element. UPF PSPs
 # take a more flexible approach where the functional form used to generate the
@@ -27,7 +27,7 @@
 # in the file. The UPF file format is documented
 # [on the Quantum Espresso Website](http://pseudopotentials.quantum-espresso.org/home/unified-pseudopotential-format).
 #
-# In this example, we will compare the convergence of an analytical HGH PSP with
+# In this example, we will compare the convergence of an analytical GTH PSP with
 # a modern numeric norm-conserving PSP in UPF format from
 # [PseudoDojo](http://www.pseudo-dojo.org/).
 # Then, we will compare the bandstructure at the converged parameters calculated
@@ -58,9 +58,9 @@ family_upf = PseudoFamily("dojo.nc.sr.lda.v0_4_1.standard.upf");
 # An alternative to a `PseudoFamily` object is in all cases a plain
 # `Dict` to map from atomic symbols to the employed pseudopotential file.
 # For demonstration purposes we employ this
-# in combination with the HGH-type pseudopotentials:
-family_hgh = PseudoFamily("cp2k.nc.sr.lda.v0_1.semicore.gth")
-pseudopotentials_hgh = Dict(:Si => family_hgh[:Si])
+# in combination with the GTH-type pseudopotentials:
+family_gth = PseudoFamily("cp2k.nc.sr.lda.v0_1.semicore.gth")
+pseudopotentials_gth = Dict(:Si => family_gth[:Si])
 
 # First, we'll take a look at the energy cutoff convergence of these two pseudopotentials.
 # For both pseudos, a reference energy is calculated with a cutoff of 140 Hartree, and
@@ -71,8 +71,8 @@ pseudopotentials_hgh = Dict(:Si => family_hgh[:Si])
 #md # ```
 #nb # <img src="https://docs.dftk.org/stable/assets/si_pseudos_ecut_convergence.png" width=600 height=400 />
 
-# The converged cutoffs are 26 Ha and 18 Ha for the HGH
-# and UPF pseudos respectively. We see that the HGH pseudopotential
+# The converged cutoffs are 26 Ha and 18 Ha for the GTH
+# and UPF pseudos respectively. We see that the GTH pseudopotential
 # is much *harder*, i.e. it requires a higher energy cutoff, than the UPF PSP. In general,
 # numeric pseudopotentials tend to be softer than analytical pseudos because of the
 # flexibility of sampling arbitrary functions on a grid.
@@ -90,7 +90,7 @@ pseudometa(family_upf, :Si)
 # Here, we see that multiple recommended cutoffs are made available in the metadata.
 
 # Next, to see that the different pseudopotentials give reasonably similar results,
-# we'll look at the bandstructures calculated using the HGH and UPF PSPs. Even though
+# we'll look at the bandstructures calculated using the GTH and UPF PSPs. Even though
 # the converged cutoffs are higher, we perform these calculations with a cutoff of
 # 12 Ha for both PSPs.
 
@@ -108,12 +108,12 @@ end;
 
 # The SCF and bandstructure calculations can then be performed using the two PSPs,
 # where we notice in particular the difference in total energies.
-result_hgh = run_bands(pseudopotentials_hgh)
-result_hgh.scfres.energies
+result_gth = run_bands(pseudopotentials_gth)
+result_gth.scfres.energies
 #-
 result_upf = run_bands(family_upf)
 result_upf.scfres.energies
 
 # But while total energies are not physical and thus allowed to differ,
 # the bands (as an example for a physical quantity) are very similar for both pseudos:
-plot(result_hgh.bandplot, result_upf.bandplot, titles=["HGH" "UPF"], size=(800, 400))
+plot(result_gth.bandplot, result_upf.bandplot, titles=["GTH" "UPF"], size=(800, 400))

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -121,7 +121,7 @@ function Model(lattice::AbstractMatrix{T},
     else  # fixed number of electrons
         n_electrons < 0 && error("n_electrons should be non-negative.")
         if !disable_electrostatics_check && n_electrons_from_atoms(atoms) != n_electrons
-            error("Support for non-neutral cells is experimental and likely broken.")
+            error("Support for non-neutral cells is experimental and likely broken!!!")
         end
     end
 

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -121,7 +121,7 @@ function Model(lattice::AbstractMatrix{T},
     else  # fixed number of electrons
         n_electrons < 0 && error("n_electrons should be non-negative.")
         if !disable_electrostatics_check && n_electrons_from_atoms(atoms) != n_electrons
-            error("Support for non-neutral cells is experimental and likely broken!!!")
+            error("Support for non-neutral cells is experimental and likely broken.")
         end
     end
 

--- a/src/pseudo/PspUpf.jl
+++ b/src/pseudo/PspUpf.jl
@@ -98,8 +98,8 @@ function PspUpf(path; identifier=path, rcut=nothing)
     # rβ [Ry Bohr^{-1/2}]  h [Ry^{-1}]
     # rβ [Bohr^{-1/2}]     h [Ry]
     # The quantity that's used in calculations is β h β, so the units don't practically
-    # matter. However, HGH pseudos in UPF format use the first units, so we assume them
-    # to facilitate comparison of the intermediate quantities with analytical HGH.
+    # matter. However, GTH pseudos in UPF format use the first units, so we assume them
+    # to facilitate comparison of the intermediate quantities with analytical GTH.
 
     r2_projs = map(0:lmax) do l
         betas_l = filter(beta -> beta["angular_momentum"] == l, pseudo["beta_projectors"])


### PR DESCRIPTION
First of probably a few iterations for #1064 
I mostly changed basic things, some naming and such, and some references to hgh vs gth pseudopotentials. The next step in my mind would be to make a duplicate file of `src/pseudo/PspHgh.jl` called PspGth with all the same functionality, and update load_psp.jl accordingly, rerouting most loading through that. Then just putting warnings throughout PspHgh so if anyone is loading .hgh files (like from the data folder) there is a warning.
In the whole I'm still unfamiliar with both github and the process of deprecation, so let me know if theres stuff I should be doing, best practices I'm missing, and also advice on if these next steps are pertinent right now, or if they're even reasonable thought processes.