### PR TITLE
Added kweights to gradient and precond. in direct_minimization.jl

### DIFF
--- a/src/scf/direct_minimization.jl
+++ b/src/scf/direct_minimization.jl
@@ -40,7 +40,8 @@ function LinearAlgebra.ldiv!(p, P::DMPreconditioner, d)
     p_unpack = P.unpack(p)
     d_unpack = P.unpack(d)
     for ik = 1:P.Nk
-        ldiv!(p_unpack[ik], P.Pks[ik], ((P.kweights[ik])^-1)*d_unpack[ik])
+        ldiv!(p_unpack[ik], P.Pks[ik], d_unpack[ik])
+        ldiv!(P.kweights[ik], p_unpack[ik])
     end
     p
 end


### PR DESCRIPTION
`direct_minimization.jl` modified as per the meeting last week. This is so the new version can be tested on harder problems by Michael. The script below runs the new direct minimization. 
```julia
using DFTK, AtomsBuilder, PseudoPotentialData, Random
Random.seed!(42)
pseudopotentials = PseudoFamily("dojo.nc.sr.pbesol.v0_4_1.standard.upf")
model = model_DFT(bulk(:Si); functionals=PBEsol(), pseudopotentials)
kg = 5
basis = PlaneWaveBasis(model; Ecut=20, kgrid=[kg, kg, kg])

dir_min_run = direct_minimization(basis; tol = 1e-6)
```
