### PR TITLE
GPU| reduce bubbles and kernel overhead

### DIFF
--- a/src/densities.jl
+++ b/src/densities.jl
@@ -38,7 +38,6 @@ using an optional `occupation_threshold`. By default all occupation numbers are 
                                           .* (basis.fft_grid.ifft_normalization)^2
                                           .* abs2.(storage.ψnk_real))
 
-        synchronize_device(basis.architecture)
     end
     ρ = sum(getfield.(storages, :ρ))
 
@@ -93,7 +92,6 @@ end
                                                           .* storage.δψnk_real
               .+ δoccupation[ik][n] .* basis.kweights[ik] .* abs2.(storage.ψnk_real))
 
-        synchronize_device(basis.architecture)
     end
     δρ = sum(getfield.(storages, :δρ))
 

--- a/src/terms/Hamiltonian.jl
+++ b/src/terms/Hamiltonian.jl
@@ -168,9 +168,8 @@ end
         end
     end
 
-    @timing "local" begin
-        Hψ .+= H.fourier_op.multiplier .* ψ
-    end
+    # Kinetic term
+    Hψ .+= H.fourier_op.multiplier .* ψ
 
     # Apply the nonlocal operator.
     if !isnothing(H.nonlocal_op)

--- a/src/terms/Hamiltonian.jl
+++ b/src/terms/Hamiltonian.jl
@@ -148,7 +148,7 @@ end
         to = TimerOutput()  # Thread-local timer output
         ψ_real = storage.ψ_reals
 
-        @timeit to "local+kinetic" begin
+        @timeit to "local" begin
             ifft!(ψ_real, H.basis, H.kpoint, ψ[:, iband]; normalize=false)
             ψ_real .*= potential
             fft!(Hψ[:, iband], H.basis, H.kpoint, ψ_real; normalize=false)  # overwrites ψ_real
@@ -168,7 +168,7 @@ end
         end
     end
 
-    @timing "local+kinetic" begin
+    @timing "local" begin
         Hψ .+= H.fourier_op.multiplier .* ψ
     end
 


### PR DESCRIPTION
This PR introduces 2 minor changes when looping over columns of wave functions:

1) There is no need for device synchronization in the loop over the bands of $\Psi$. Each band is treated independently, and there is no risk of race condition. All it does is create bubbles in the GPU execution.

2) Applying `H.fourier_op.multiplier` band by band is not the most efficient on the GPU. There is overhead in launching many small kernels instead of a large one. Moreover, GPU parallelism is better exploited with large arrays.

I did not spot any performance impact on the CPU side. On NVIDIA GPUs, I observe a general speedup of ~10% on the SCF.