### PR TITLE
Make SCF runs optionally reproducible by providing a seed

### DIFF
--- a/src/DFTK.jl
+++ b/src/DFTK.jl
@@ -45,6 +45,7 @@ include("common/hankel.jl")
 include("common/hydrogenic.jl")
 include("common/derivatives.jl")
 include("common/linalg.jl")
+include("common/random.jl")
 
 export PspHgh
 export PspUpf

--- a/src/common/random.jl
+++ b/src/common/random.jl
@@ -1,0 +1,28 @@
+"""
+Seeds the task local RNG across all MPI ranks.
+A seed can be provided for reproducibility with previous runs
+(for the same Julia version and Manifest.toml).
+If no seed is provided, a random seed is generated on the master process.
+The returned seed can be used to reproduce the run.
+
+If any subtask is spawned, it will be seeded based on the task local RNG of its parent,
+as explained in the documentation of [TaskLocalRNG](@ref).
+Seeding the task local RNG at the beginning of a computation is thus sufficient.
+"""
+function seed_task_local_rng!(seed::Union{Nothing,Integer}, comm)
+    if mpi_master(comm) && isnothing(seed)
+        # Using negative seeds requires Julia 1.11 and DFTK still supports 1.10
+        seed = rand(UInt64)
+    end
+    seed = MPI.bcast(seed, comm)
+    if mpi_master(comm)
+        Random.seed!(seed)
+        # Generate a different seed for each process
+        local_seeds = rand(typeof(seed), mpi_nprocs(comm))
+        local_seed = MPI.scatter(local_seeds, comm)
+    else
+        local_seed = MPI.scatter(nothing, comm)
+    end
+    Random.seed!(local_seed)
+    seed
+end

--- a/src/scf/self_consistent_field.jl
+++ b/src/scf/self_consistent_field.jl
@@ -146,6 +146,7 @@ Overview of parameters:
     fermialg::AbstractFermiAlgorithm=default_fermialg(basis.model),
     callback=ScfDefaultCallback(; show_damping=false),
     compute_consistent_energies=true,
+    seed=nothing,
     response=ResponseOptions(),  # Dummy here, only for AD
 ) where {T}
     if !isnothing(ψ)
@@ -153,6 +154,7 @@ Overview of parameters:
     end
     start_ns = time_ns()
     timeout_date = Dates.now() + maxtime
+    seed = seed_task_local_rng!(seed, MPI.COMM_WORLD)
 
     # We do density mixing in the real representation
     # TODO support other mixing types
@@ -226,7 +228,7 @@ Overview of parameters:
     scfres = (; ham, basis, energies, converged, nbandsalg.occupation_threshold,
                 ρ=ρout, τ, α=damping, eigenvalues, occupation, εF, info.n_bands_converge,
                 info.n_iter, info.n_matvec, ψ, info.diagonalization, stage=:finalize,
-                info.history_Δρ, info.history_Etot, info.timedout, mixing,
+                info.history_Δρ, info.history_Etot, info.timedout, mixing, seed,
                 runtime_ns=time_ns() - start_ns, algorithm="SCF")
     callback(scfres)
     scfres

--- a/test/reproducibility.jl
+++ b/test/reproducibility.jl
@@ -1,0 +1,20 @@
+@testitem "Reproducibility of seeded SCF runs" setup=[TestCases] begin
+using DFTK
+silicon = TestCases.silicon
+
+model = model_DFT(silicon.lattice, silicon.atoms, silicon.positions; functionals=LDA())
+Ecut = 15
+kgrid = [2, 2, 2]
+
+basis = PlaneWaveBasis(model; Ecut, kgrid)
+scfres1 = self_consistent_field(basis; tol=1e-7)
+
+# Use seed from scfres1 for reproducibility
+scfres2 = self_consistent_field(basis; tol=1e-7, scfres1.seed)
+
+# Should be exactly equal if the computation is reproducible, no need for epsilons.
+@assert scfres1.history_Etot == scfres2.history_Etot
+@assert scfres1.history_Δρ == scfres2.history_Δρ
+@assert scfres1.ψ == scfres2.ψ
+@assert scfres1.ρ == scfres2.ρ
+end


### PR DESCRIPTION
We had a discussion wrt. randomness before, and the conclusion was that we should keep DFTK random by default but allow passing a seed for reproducibility[^1]. It seems that the best way to achieve this in Julia is to seed the `TaskLocalRNG` since any subtask will be seeded from it automatically. This takes care of the multithreading aspect and makes the required changes minimal.

Additionally, the scfres now contains a seed that can be used to reproduce the run[^1].

If this is satisfactory @mfherbst I am happy to implement the same approach for the other solvers (direct minimization etc) as well. For tests, it should be sufficient to just seed the task local RNG before each test; I haven't looked into it yet though.

[^1]: Assuming the exact same Julia and packages versions.