### PR TITLE
Fix differentiation of nonlocal projectors at p=0 by switching to solid harmonics

### DIFF
--- a/docs/src/developer/useful_formulas.md
+++ b/docs/src/developer/useful_formulas.md
@@ -28,6 +28,14 @@ of the conventions used in the equations.
   ```
   This also holds true for real spherical harmonics.
 
+  Introducing the solid harmonics ``R_l^m(x) = x^l \, Y_l^m(x/|x|)``
+  this can equivalently be written as
+  ```math
+  \hat f( q) = 4 \pi R_{l}^{m}(q) (-i)^{l}
+  \int_{{\mathbb R}^+} r^2 R(r) \ j_{l}(|q| r) / |q|^l dr,
+  ```
+  which is better behaved for algorithmic differentiation at ``q=0``.
+
 ## Spherical harmonics
 - Plane wave expansion formula
   ```math

--- a/docs/src/developer/useful_formulas.md
+++ b/docs/src/developer/useful_formulas.md
@@ -32,9 +32,11 @@ of the conventions used in the equations.
   this can equivalently be written as
   ```math
   \hat f( q) = 4 \pi R_{l}^{m}(q) (-i)^{l}
-  \int_{{\mathbb R}^+} r^2 R(r) \ j_{l}(|q| r) / |q|^l dr,
+  \int_{{\mathbb R}^+} r^2 R(r) j_{l}(|q| r) / |q|^l dr.
   ```
-  which is better behaved for algorithmic differentiation at ``q=0``.
+  The main advantage of this formulation is that the solid harmonics are
+  simple homogeneous polynomials
+  (which are e.g. well behaved for algorithmic differentiation close to ``q=0``).
 
 ## Spherical harmonics
 - Plane wave expansion formula

--- a/src/common/hankel.jl
+++ b/src/common/hankel.jl
@@ -1,13 +1,17 @@
 @doc raw"""
     hankel(r, r2_f, l, p)
 
-Compute the Hankel transform
+Compute the **regularized** Hankel transform
 ```math
-    H[f] = 4\pi \int_0^\infty r f(r) j_l(p·r) r dr.
+    H[f] = \frac{1}{p^l} ⋅ 4\pi \int_0^\infty r f(r) j_l(p·r) r dr.
 ```
 The integration is performed by simpson quadrature, and the function takes
 as input the radial grid `r`, the precomputed quantity r²f(r) `r2_f`, angular
 momentum / spherical bessel order `l`, and the Hankel coordinate `p`.
+
+The regularization by 1/p^l avoids numerical issues for small p:
+instead of computing the unregularized Hankel transform times a spherical harmonic,
+we can compute the regularized Hankel transform times a solid harmonic.
 """
 function hankel(r::AbstractVector, r2_f::AbstractVector, l::Integer, p::T)::T where {T<:Real}
     quadrature = default_psp_quadrature(r)
@@ -16,7 +20,17 @@ end
 
 function hankel(quadrature, r::AbstractVector, r2_f::AbstractVector, l::Integer, p::T)::T where {T<:Real}
     @assert length(r) == length(r2_f)
-    4T(π) * quadrature(r) do i, ri
+    if abs(p) <= 10 * eps(T)
+        # Use j_l(x) ≈ x^l / (2l+1)!! for small p
+        l == 0 && return 4T(π) * quadrature((i, ri) -> r2_f[i], r)
+        l == 1 && return 4T(π) * quadrature((i, ri) -> r2_f[i] * ri, r) / 3
+        l == 2 && return 4T(π) * quadrature((i, ri) -> r2_f[i] * ri^2, r) / 15
+        l == 3 && return 4T(π) * quadrature((i, ri) -> r2_f[i] * ri^3, r) / 105
+        l == 4 && return 4T(π) * quadrature((i, ri) -> r2_f[i] * ri^4, r) / 945
+        l == 5 && return 4T(π) * quadrature((i, ri) -> r2_f[i] * ri^5, r) / 10395
+        throw(BoundsError()) # specific l not implemented
+    end
+    1/p^l * 4T(π) * quadrature(r) do i, ri
         r2_f[i] * sphericalbesselj_fast(l, p * ri)
     end
 end

--- a/src/common/hankel.jl
+++ b/src/common/hankel.jl
@@ -1,7 +1,7 @@
 @doc raw"""
     hankel(r, r2_f, l, p)
 
-Compute the **regularized** Hankel transform
+Compute the **modified** Hankel transform
 ```math
     H[f] = \frac{1}{p^l} ⋅ 4\pi \int_0^\infty r f(r) j_l(p·r) r dr.
 ```
@@ -9,9 +9,9 @@ The integration is performed by simpson quadrature, and the function takes
 as input the radial grid `r`, the precomputed quantity r²f(r) `r2_f`, angular
 momentum / spherical bessel order `l`, and the Hankel coordinate `p`.
 
-The regularization by 1/p^l avoids numerical issues for small p:
-instead of computing the unregularized Hankel transform times a spherical harmonic,
-we can compute the regularized Hankel transform times a solid harmonic.
+The multiplication by 1/p^l avoids numerical issues for small p:
+instead of computing the usual Hankel transform times a spherical harmonic,
+we can compute the modified Hankel transform times a solid harmonic.
 """
 function hankel(r::AbstractVector, r2_f::AbstractVector, l::Integer, p::T)::T where {T<:Real}
     quadrature = default_psp_quadrature(r)

--- a/src/common/hankel.jl
+++ b/src/common/hankel.jl
@@ -20,8 +20,10 @@ end
 
 function hankel(quadrature, r::AbstractVector, r2_f::AbstractVector, l::Integer, p::T)::T where {T<:Real}
     @assert length(r) == length(r2_f)
+    # TODO: 10*eps is somewhat arbitrary, should find a proper bound
+    #       based on the stability of sphericalbesselj_fast
     if abs(p) <= 10 * eps(T)
-        # Use j_l(x) ≈ x^l / (2l+1)!! for small p
+        # Use j_l(x) ≈ x^l / (2l+1)!! for small x
         l == 0 && return 4T(π) * quadrature((i, ri) -> r2_f[i], r)
         l == 1 && return 4T(π) * quadrature((i, ri) -> r2_f[i] * ri, r) / 3
         l == 2 && return 4T(π) * quadrature((i, ri) -> r2_f[i] * ri^2, r) / 15

--- a/src/common/hankel.jl
+++ b/src/common/hankel.jl
@@ -21,7 +21,9 @@ end
 function hankel(quadrature, r::AbstractVector, r2_f::AbstractVector, l::Integer, p::T)::T where {T<:Real}
     @assert length(r) == length(r2_f)
     # TODO: 10*eps is somewhat arbitrary, should find a proper bound
-    #       based on the stability of sphericalbesselj_fast
+    #       based on the stability of sphericalbesselj_fast. The current
+    #       value is likely too lose and has the wrong scaling in eps().
+    #       In particular the scaling in eps() should depend on `l`.
     if abs(p) <= 10 * eps(T)
         # Use j_l(x) ≈ x^l / (2l+1)!! for small x
         l == 0 && return 4T(π) * quadrature((i, ri) -> r2_f[i], r)

--- a/src/common/spherical_bessels.jl
+++ b/src/common/spherical_bessels.jl
@@ -4,6 +4,8 @@
 Returns the spherical Bessel function of the first kind ``j_l(x)``. Consistent with
 [Wikipedia](https://en.wikipedia.org/wiki/Bessel_function#Spherical_Bessel_functions) and
 with `SpecialFunctions.sphericalbesselj`. Specialized for integer ``0 ≤ l ≤ 5``.
+
+Warning: For small arguments, the current implementation is not numerically stable.
 """
 @fastmath function sphericalbesselj_fast(l::Integer, x::T)::T where {T}
     if l == 0
@@ -13,6 +15,7 @@ with `SpecialFunctions.sphericalbesselj`. Specialized for integer ``0 ≤ l ≤ 
 
     iszero(x) && return zero(T)
 
+    # TODO: fix numerical stability for small x
     l == 1 && return (sin(x) - cos(x) * x) / x^2
     l == 2 && return (sin(x) * (3 - x^2) + cos(x) * (-3x)) / x^3
     l == 3 && return (sin(x) * (15 - 6x^2) + cos(x) * (x^3 - 15x)) / x^4

--- a/src/common/spherical_harmonics.jl
+++ b/src/common/spherical_harmonics.jl
@@ -6,43 +6,57 @@ Returns the ``(l,m)`` real spherical harmonic ``Y_l^m(r)``. Consistent with
 [Wikipedia](https://en.wikipedia.org/wiki/Table_of_spherical_harmonics#Real_spherical_harmonics).
 """
 function ylm_real(l::Integer, m::Integer, rvec::AbstractVector{T}) where {T}
+    if l == 0 && m == 0
+        return sqrt(1 / 4T(π))
+    end
+
+    r = norm(rvec)
+    # Catch cases of numerically very small r
+    if r <= 10 * eps(T)
+        return zero(T)
+    end
+
+    solid_harmonic_real(l, m, rvec / r)
+end
+
+"""
+Returns the ``(l,m)`` real solid harmonic, defined as ``R_l^m(r) = r^l Y_l^m(r)``.
+The solid harmonics are homogeneous polynomials of degree l,
+which makes them cleanly defined and differentiable at the origin,
+unlike the spherical harmonics.
+"""
+function solid_harmonic_real(l::Integer, m::Integer, rvec::AbstractVector{T}) where {T}
     @assert 0 ≤ l
     @assert -l ≤ m ≤ l
     @assert length(rvec) == 3
     x, y, z = rvec
-    r = norm(rvec)
 
     if l == 0  # s
         (m ==  0) && return sqrt(1 / 4T(π))
     end
 
-    # Catch cases of numerically very small r
-    if r <= 10 * eps(eltype(rvec))
-        return zero(T)
-    end
-
     if l == 1  # p
-        (m == -1) && return sqrt(3 / 4T(π)) * y / r
-        (m ==  0) && return sqrt(3 / 4T(π)) * z / r
-        (m ==  1) && return sqrt(3 / 4T(π)) * x / r
+        (m == -1) && return sqrt(3 / 4T(π)) * y
+        (m ==  0) && return sqrt(3 / 4T(π)) * z
+        (m ==  1) && return sqrt(3 / 4T(π)) * x
     end
 
     if l == 2  # d
-        (m == -2) && return sqrt(15 /  4T(π)) * (x / r) * (y / r)
-        (m == -1) && return sqrt(15 /  4T(π)) * (y / r) * (z / r)
-        (m ==  0) && return sqrt( 5 / 16T(π)) * (2z^2 - x^2 - y^2) / r^2
-        (m ==  1) && return sqrt(15 /  4T(π)) * (x / r) * (z / r)
-        (m ==  2) && return sqrt(15 / 16T(π)) * (x^2 - y^2) / r^2
+        (m == -2) && return sqrt(15 /  4T(π)) * x * y
+        (m == -1) && return sqrt(15 /  4T(π)) * y * z
+        (m ==  0) && return sqrt( 5 / 16T(π)) * (2z^2 - x^2 - y^2)
+        (m ==  1) && return sqrt(15 /  4T(π)) * x * z
+        (m ==  2) && return sqrt(15 / 16T(π)) * (x^2 - y^2)
     end
 
     if l == 3  # f
-        (m == -3) && return sqrt( 35 / 32T(π)) * (3x^2 - y^2) * y / r^3
-        (m == -2) && return sqrt(105 /  4T(π)) * x * y * z / r^3
-        (m == -1) && return sqrt( 21 / 32T(π)) * y * (4z^2 - x^2 - y^2) / r^3
-        (m ==  0) && return sqrt(  7 / 16T(π)) * z * (2z^2 - 3x^2 - 3y^2) / r^3
-        (m ==  1) && return sqrt( 21 / 32T(π)) * x * (4z^2 - x^2 - y^2) / r^3
-        (m ==  2) && return sqrt(105 / 16T(π)) * (x^2 - y^2) * z / r^3
-        (m ==  3) && return sqrt( 35 / 32T(π)) * (x^2 - 3y^2) * x / r^3
+        (m == -3) && return sqrt( 35 / 32T(π)) * (3x^2 - y^2) * y
+        (m == -2) && return sqrt(105 /  4T(π)) * x * y * z
+        (m == -1) && return sqrt( 21 / 32T(π)) * y * (4z^2 - x^2 - y^2)
+        (m ==  0) && return sqrt(  7 / 16T(π)) * z * (2z^2 - 3x^2 - 3y^2)
+        (m ==  1) && return sqrt( 21 / 32T(π)) * x * (4z^2 - x^2 - y^2)
+        (m ==  2) && return sqrt(105 / 16T(π)) * (x^2 - y^2) * z
+        (m ==  3) && return sqrt( 35 / 32T(π)) * (x^2 - 3y^2) * x
     end
 
     throw(BoundsError()) # specific (l,m) pair not implemented

--- a/src/common/spherical_harmonics.jl
+++ b/src/common/spherical_harmonics.jl
@@ -22,7 +22,7 @@ end
 """
 Returns the ``(l,m)`` real solid harmonic, defined as ``R_l^m(r) = r^l Y_l^m(r)``.
 The solid harmonics are homogeneous polynomials of degree l,
-which makes them cleanly defined and differentiable at the origin,
+which makes them cleanly defined and smooth at the origin,
 unlike the spherical harmonics.
 """
 function solid_harmonic_real(l::Integer, m::Integer, rvec::AbstractVector{T}) where {T}

--- a/src/common/spherical_harmonics.jl
+++ b/src/common/spherical_harmonics.jl
@@ -24,6 +24,9 @@ Returns the ``(l,m)`` real solid harmonic, defined as ``R_l^m(r) = r^l Y_l^m(r)`
 The solid harmonics are homogeneous polynomials of degree l,
 which makes them cleanly defined and smooth at the origin,
 unlike the spherical harmonics.
+Obtained from the spherical harmonics table on
+[Wikipedia](https://en.wikipedia.org/wiki/Table_of_spherical_harmonics#Real_spherical_harmonics)
+without the division by r^l.
 """
 function solid_harmonic_real(l::Integer, m::Integer, rvec::AbstractVector{T}) where {T}
     @assert 0 ≤ l

--- a/src/pseudo/NormConservingPsp.jl
+++ b/src/pseudo/NormConservingPsp.jl
@@ -49,11 +49,11 @@ eval_psp_projector_real(psp::NormConservingPsp, i, l, r::AbstractVector) =
     eval_psp_projector_fourier(psp, i, l, p)
 
 Evaluate the radial part of the `i`-th projector for angular momentum `l`
-at the reciprocal vector with modulus `p`:
+at the reciprocal vector with modulus `p`, regularized by p^l:
 ```math
 \begin{aligned}
-{\rm proj}(p) &= ∫_{ℝ^3} {\rm proj}_{il}(r) e^{-ip·r} dr \\
-              &= 4π ∫_{ℝ_+} r^2 {\rm proj}_{il}(r) j_l(p·r) dr.
+{\rm proj}(p) &= 1/p^l ∫_{ℝ^3} {\rm proj}_{il}(r) e^{-ip·r} dr \\
+              &= 1/p^l 4π ∫_{ℝ_+} r^2 {\rm proj}_{il}(r) j_l(p·r) dr.
 \end{aligned}
 ```
 """

--- a/src/pseudo/NormConservingPsp.jl
+++ b/src/pseudo/NormConservingPsp.jl
@@ -49,7 +49,7 @@ eval_psp_projector_real(psp::NormConservingPsp, i, l, r::AbstractVector) =
     eval_psp_projector_fourier(psp, i, l, p)
 
 Evaluate the radial part of the `i`-th projector for angular momentum `l`
-at the reciprocal vector with modulus `p`, regularized by p^l:
+at the reciprocal vector with modulus `p`, divided by p^l:
 ```math
 \begin{aligned}
 {\rm proj}(p) &= 1/p^l ∫_{ℝ^3} {\rm proj}_{il}(r) e^{-ip·r} dr \\

--- a/src/pseudo/PspHgh.jl
+++ b/src/pseudo/PspHgh.jl
@@ -135,7 +135,8 @@ function eval_psp_local_real(psp::PspHgh, r::T) where {T <: Real}
 end
 
 
-# [HGH98] (7-15) except they do it with plane waves normalized by 1/sqrt(Ω).
+# [HGH98] (7-15) except they do it with plane waves normalized by 1/sqrt(Ω)
+# and we regularize by 1/p^l.
 function eval_psp_projector_fourier(psp::PspHgh, i, l, p::T) where {T <: Real}
     @assert 0 <= l <= length(psp.rp) - 1
     @assert i > 0
@@ -147,17 +148,17 @@ function eval_psp_projector_fourier(psp::PspHgh, i, l, p::T) where {T <: Real}
     #       The first 8 in equation (8) should not be under the sqrt-sign
     #       This is the right version (as shown in the GTH paper)
     (l == 0 && i == 1) && return common
-    (l == 0 && i == 2) && return common * 2 /  sqrt(T(  15))       * ( 3 -   t^2      )
-    (l == 0 && i == 3) && return common * 4 / 3sqrt(T( 105))       * (15 - 10t^2 + t^4)
+    (l == 0 && i == 2) && return common * 2 /  sqrt(T(  15))        * ( 3 -   t^2      )
+    (l == 0 && i == 3) && return common * 4 / 3sqrt(T( 105))        * (15 - 10t^2 + t^4)
     #
-    (l == 1 && i == 1) && return common * 1 /  sqrt(T(   3)) * t
-    (l == 1 && i == 2) && return common * 2 /  sqrt(T( 105)) * t   * ( 5 -   t^2)
-    (l == 1 && i == 3) && return common * 4 / 3sqrt(T(1155)) * t   * (35 - 14t^2 + t^4)
+    (l == 1 && i == 1) && return common * 1 /  sqrt(T(   3)) * rp
+    (l == 1 && i == 2) && return common * 2 /  sqrt(T( 105)) * rp   * ( 5 -   t^2)
+    (l == 1 && i == 3) && return common * 4 / 3sqrt(T(1155)) * rp   * (35 - 14t^2 + t^4)
     #
-    (l == 2 && i == 1) && return common * 1 /  sqrt(T(  15)) * t^2
-    (l == 2 && i == 2) && return common * 2 / 3sqrt(T( 105)) * t^2 * ( 7 -   t^2)
+    (l == 2 && i == 1) && return common * 1 /  sqrt(T(  15)) * rp^2
+    (l == 2 && i == 2) && return common * 2 / 3sqrt(T( 105)) * rp^2 * ( 7 -   t^2)
     #
-    (l == 3 && i == 1) && return common * 1 /  sqrt(T( 105)) * t^3
+    (l == 3 && i == 1) && return common * 1 /  sqrt(T( 105)) * rp^3
 
     error("Not implemented for l=$l and i=$i")
 end

--- a/src/pseudo/PspHgh.jl
+++ b/src/pseudo/PspHgh.jl
@@ -136,7 +136,7 @@ end
 
 
 # [HGH98] (7-15) except they do it with plane waves normalized by 1/sqrt(Ω)
-# and we regularize by 1/p^l.
+# and we divide by 1/p^l.
 function eval_psp_projector_fourier(psp::PspHgh, i, l, p::T) where {T <: Real}
     @assert 0 <= l <= length(psp.rp) - 1
     @assert i > 0

--- a/src/pseudo/PspUpf.jl
+++ b/src/pseudo/PspUpf.jl
@@ -234,8 +234,8 @@ function _eval_psp_local_fourier(quadrature, rgrid, vloc, Zion, p::T)::T where {
     # ABINIT uses a more 'pure' Coulomb term with the same asymptotic behavior
     # C(r) = -Z/r; H[-Z/r] = -Z/p^2
     p == 0 && return zero(T)  # Compensating charge background
-    I = quadrature(rgrid) do i, r
-         r * (r * vloc[i] - -Zion * erf(r)) * sphericalbesselj_fast(0, p * r)
+    I = 1/p * quadrature(rgrid) do i, r
+         (r * vloc[i] - -Zion * erf(r)) * sin(p * r)
     end
     4T(π) * (I + -Zion / p^2 * exp(-p^2 / T(4)))
 end

--- a/src/pseudo/PspUpf.jl
+++ b/src/pseudo/PspUpf.jl
@@ -234,8 +234,9 @@ function _eval_psp_local_fourier(quadrature, rgrid, vloc, Zion, p::T)::T where {
     # ABINIT uses a more 'pure' Coulomb term with the same asymptotic behavior
     # C(r) = -Z/r; H[-Z/r] = -Z/p^2
     p == 0 && return zero(T)  # Compensating charge background
+    # Equal to \int r (r * vloc[i] - (-Zion) erf(r)) * sin(p*r)/(p*r)
     I = 1/p * quadrature(rgrid) do i, r
-         (r * vloc[i] - -Zion * erf(r)) * sin(p * r)
+         (r * vloc[i] - (-Zion) * erf(r)) * sin(p * r)
     end
     4T(π) * (I + -Zion / p^2 * exp(-p^2 / T(4)))
 end

--- a/src/terms/nonlocal.jl
+++ b/src/terms/nonlocal.jl
@@ -234,7 +234,7 @@ function build_projector_form_factors(psp::NormConservingPsp,
             proj_li[p_indices] .= eval_psp_projector_fourier(psp, i, l, ps)
             for m = -l:l
                 map!(@view(form_factors[:, offset[m + l + 1] + i]), G_indices) do iG
-                    angular = (-im)^l * ylm_real(l, m, G_plus_k[iG])
+                    angular = (-im)^l * solid_harmonic_real(l, m, G_plus_k[iG])
                     proj_li[iG2ifnorm[iG]] * angular
                 end
             end
@@ -245,6 +245,7 @@ end
 
 """
 Build Fourier transform factors of an atomic function centered at 0 for a given l.
+The function is assumed to be regularized by 1/p^l already.
 """
 function build_form_factors(fun::Function, l::Int,
                             G_plus_ks::AbstractVector{<:AbstractVector{Vec3{TT}}}) where {TT}
@@ -272,7 +273,7 @@ function build_form_factors(fun::Function, l::Int,
             radials_p = radials[norm(p)]
             for m = -l:l
                 # see "Fourier transforms of centered functions" in the docs for the formula
-                angular = (-im)^l * ylm_real(l, m, p)
+                angular = (-im)^l * solid_harmonic_real(l, m, p)
                 form_factors_ik[ip, m+l+1] = radials_p * angular
             end
         end

--- a/src/terms/nonlocal.jl
+++ b/src/terms/nonlocal.jl
@@ -245,7 +245,8 @@ end
 
 """
 Build Fourier transform factors of an atomic function centered at 0 for a given l.
-The function is assumed to be regularized by 1/p^l already.
+The function should return a Hankel transform or equivalent,
+with a division by p^l already included.
 """
 function build_form_factors(fun::Function, l::Int,
                             G_plus_ks::AbstractVector{<:AbstractVector{Vec3{TT}}}) where {TT}

--- a/src/workarounds/forwarddiff_rules.jl
+++ b/src/workarounds/forwarddiff_rules.jl
@@ -303,29 +303,23 @@ end
        scfres.seed, scfres.algorithm, scfres.runtime_ns)
 end
 
-function hankel(r::AbstractVector, r2_f::AbstractVector, l::Integer, p::TT) where {TT <: ForwardDiff.Dual}
+function hankel(quadrature, r::AbstractVector, r2_f::AbstractVector, l::Integer, p::TT) where {TT <: ForwardDiff.Dual}
     # This custom rule uses two properties of the hankel transform:
-    #   d H[f] / dp = 4\pi \int_0^∞ r^2 f(r) j_l'(p⋅r)⋅r dr
+    #   d H[f] / dp = 4\pi \int_0^∞ r^2 f(r) [ j_l'(p⋅r)⋅r/p^l - l * j_l(p⋅r)/p^{l+1} ] dr
     # and that
     #   j_l'(x) = l / x * j_l(x) - j_{l+1}(x)
-    # and tries to avoid allocations as much as possible, which hurt in this inner loop.
-    #
-    # One could implement this by custom rules in integration and spherical bessels, but
-    # the tricky bit is to exploit that one needs both the j_l'(p⋅r) and j_l(p⋅r) values
-    # but one does not want to precompute and allocate them into arrays
-    # TODO Investigate custom rules for bessels and integration
+    # giving
+    #   d H[f] / dp = -4\pi \int_0^∞ r^2 f(r) j_{l+1}(p⋅r)⋅r/p^l ] dr
 
     T  = ForwardDiff.valtype(TT)
     pv = ForwardDiff.value(p)
 
-    jl = sphericalbesselj_fast.(l, pv .* r)
-    value = 4T(π) * simpson((i, r) -> r2_f[i] * jl[i], r)
-
+    value = hankel(quadrature, r, r2_f, l, pv)
     if iszero(pv)
         return TT(value, zero(T) * ForwardDiff.partials(p))
     end
-    derivative = 4T(π) * simpson(r) do i, r
-        (r2_f[i] * (l * jl[i] / pv - r * sphericalbesselj_fast(l+1, pv * r)))
+    derivative = -4T(π) / pv^l * quadrature(r) do i, ri
+        r2_f[i] * r[i] * sphericalbesselj_fast(l+1, pv * ri)
     end
     TT(value, derivative * ForwardDiff.partials(p))
 end

--- a/src/workarounds/forwarddiff_rules.jl
+++ b/src/workarounds/forwarddiff_rules.jl
@@ -324,7 +324,7 @@ function hankel(quadrature, r::AbstractVector, r2_f::AbstractVector, l::Integer,
     if iszero(pv)
         return Dual{Tg,V,N}(value, zero(V) * ForwardDiff.partials(p))
     end
-    derivative = -4T(π) / pv^l * quadrature(r) do i, ri
+    derivative = -4V(π) / pv^l * quadrature(r) do i, ri
         r2_f[i] * r[i] * sphericalbesselj_fast(l+1, pv * ri)
     end
     Dual{Tg,V,N}(value, derivative * ForwardDiff.partials(p))

--- a/test/PspHgh.jl
+++ b/test/PspHgh.jl
@@ -68,16 +68,16 @@ end
         11.917710279480355, 10.249557409656868, 0.11180299205602792
     ]
 
-    @test map(p -> eval_psp_projector_fourier(psp, 1, 1, p), pnorms) ≈ [
+    @test map(p -> eval_psp_projector_fourier(psp, 1, 1, p)*p, pnorms) ≈ [
         0.0, 0.3149163627204332, 0.9853983576555614,
         1.667197861646941, 2.8039993470553535, 3.0863036233824626,
     ]
-    @test map(p -> eval_psp_projector_fourier(psp, 2, 1, p), pnorms) ≈ [
+    @test map(p -> eval_psp_projector_fourier(psp, 2, 1, p)*p, pnorms) ≈ [
         0.0, 0.5320561290084422, 1.657814585041487,
         2.778424038171201, 4.517311337690638, 2.7698566262467117,
     ]
 
-    @test map(p -> eval_psp_projector_fourier(psp, 3, 1, p), pnorms) ≈ [
+    @test map(p -> eval_psp_projector_fourier(psp, 3, 1, p)*p, pnorms) ≈ [
          0.0, 0.7482799478933317, 2.321676914155303,
          3.8541542745249706, 6.053770711942623, 1.6078748819430986,
     ]
@@ -109,7 +109,7 @@ end
         psp = load_psp(family, element)
         for l = 0:psp.lmax, i = 1:count_n_proj_radial(psp, l)
             for p in [0.01, 0.1, 0.2, 0.5, 1, 2, 5, 10]
-                reference = quadgk(r -> integrand(psp, i, l, p, r), 0, Inf)[1]
+                reference = 1/p^l * quadgk(r -> integrand(psp, i, l, p, r), 0, Inf)[1]
                 @test reference ≈ eval_psp_projector_fourier(psp, i, l, p) atol=5e-15 rtol=1e-8
             end
         end

--- a/test/PspHgh.jl
+++ b/test/PspHgh.jl
@@ -109,6 +109,7 @@ end
         psp = load_psp(family, element)
         for l = 0:psp.lmax, i = 1:count_n_proj_radial(psp, l)
             for p in [0.01, 0.1, 0.2, 0.5, 1, 2, 5, 10]
+                # DFTK uses a modified Hankel, hence divide by 1/p^l
                 reference = 1/p^l * quadgk(r -> integrand(psp, i, l, p, r), 0, Inf)[1]
                 @test reference ≈ eval_psp_projector_fourier(psp, i, l, p) atol=5e-15 rtol=1e-8
             end

--- a/test/PspUpf.jl
+++ b/test/PspUpf.jl
@@ -163,8 +163,8 @@ end
         for l = 0:psp.lmax, i in count_n_proj_radial(psp, l)
             ir_cut = min(psp.ircut, length(psp.r2_projs[l+1][i]))
             for p in (0.01, 0.1, 0.2, 0.5, 1., 2., 5., 10.)
-                reference = quadgk(r -> integrand(psp, i, l, p, r),
-                                   psp.rgrid[ir_start], psp.rgrid[ir_cut])[1]
+                reference = 1/p^l * quadgk(r -> integrand(psp, i, l, p, r),
+                                           psp.rgrid[ir_start], psp.rgrid[ir_cut])[1]
                 @test reference ≈ eval_psp_projector_fourier(psp, i, l, p) atol=1e-2 rtol=1e-2
             end
         end

--- a/test/PspUpf.jl
+++ b/test/PspUpf.jl
@@ -163,6 +163,7 @@ end
         for l = 0:psp.lmax, i in count_n_proj_radial(psp, l)
             ir_cut = min(psp.ircut, length(psp.r2_projs[l+1][i]))
             for p in (0.01, 0.1, 0.2, 0.5, 1., 2., 5., 10.)
+                # DFTK uses a modified Hankel, hence divide by 1/p^l
                 reference = 1/p^l * quadgk(r -> integrand(psp, i, l, p, r),
                                            psp.rgrid[ir_start], psp.rgrid[ir_cut])[1]
                 @test reference ≈ eval_psp_projector_fourier(psp, i, l, p) atol=1e-2 rtol=1e-2

--- a/test/forwarddiff/generic.jl
+++ b/test/forwarddiff/generic.jl
@@ -63,7 +63,7 @@ end
 
             ff_ad = ForwardDiff.derivative(f, 0.0)
 
-            # High l are sensitive to numerical noise, so we only use AD for l=1,
+            # High l are sensitive to numerical noise, so we only use FD for l=1,
             # and we know that the derivative should be zero for l=0,2,3
             ff_ref = zero(ff_ad)
             if l == 1

--- a/test/forwarddiff/generic.jl
+++ b/test/forwarddiff/generic.jl
@@ -42,3 +42,35 @@ end
         end
     end
 end
+
+@testitem "Derivative of nonlocal projectors at [0,0,0]" #=
+    =#    tags=[:dont_test_mpi, :minimal] setup=[TestCases] begin
+    using DFTK
+    using ForwardDiff
+    using StaticArrays
+    using .TestCases: pd_lda_family
+
+    # has projectors up to l=3
+    psp = load_psp(pd_lda_family[:Hg])
+    projs_by_l = [1:2, 3:8, 9:18, 19:25]
+
+    for l in 0:3, α in 1:3
+        @testset "l = $l, α = $α" begin
+            p = @SVector[0, 0, 0]
+            dp = @SVector[float(i == α) for i in 1:3]
+
+            f(ε) = DFTK.build_projector_form_factors(psp, [p+ε*dp])[projs_by_l[l+1]]
+
+            ff_ad = ForwardDiff.derivative(f, 0.0)
+
+            # High l are sensitive to numerical noise, so we only use AD for l=1,
+            # and we know that the derivative should be zero for l=0,2,3
+            ff_ref = zero(ff_ad)
+            if l == 1
+                h = 1e-4
+                ff_ref .= (-3*f(0.0) + 4*f(h) - f(2h)) / 2h
+            end
+            @test ff_ad ≈ ff_ref rtol=1e-7 atol=1e-10
+        end
+    end
+end


### PR DESCRIPTION
Spherical coordinates at p=0 are awkward, and this causes problems for AD wrt. k at G+k=0 for projectors that have angular momentum l=1: the derivative should not be zero, but our guards against small p make it 0. Additionally, only the product of the Hankel transform and the spherical harmonics is differentiable, but not each of them on their own.

The best fix I could find find (thanks Claude, although all the code is mine) was to move the `1/p^l` from the spherical harmonic to the Hankel transform. This gives a "regularized" Hankel transform (whose derivative is always 0 at p=0) times a solid harmonic. With this trick the derivative is $H(0) \cdot \partial_\alpha R_{lm}(0)$ which is always well-defined! And since $R_{lm}$ is a homogeneous polynomial of degree l this cleanly explains why only projectors at l=1 contribute to the derivative.