### PR TITLE
Remove Hermitian norm dispatch

### DIFF
--- a/src/gpu/gpu_arrays.jl
+++ b/src/gpu/gpu_arrays.jl
@@ -5,13 +5,6 @@ using Preferences
 # https://github.com/JuliaGPU/CUDA.jl/issues/1565
 LinearAlgebra.dot(x::AbstractGPUArray, D::Diagonal, y::AbstractGPUArray) = x' * (D * y)
 
-# Norm of Hermitian matrices. See https://github.com/JuliaGPU/AMDGPU.jl/issues/843 for AMDGPU,
-# and https://github.com/JuliaGPU/CUDA.jl/issues/2965 for CUDA.
-function LinearAlgebra.norm(A::Hermitian{T, <:AbstractGPUArray}) where {T}
-    upper_triangle = sum(abs2, triu(parent(A)))
-    diago = sum(abs2, diag(parent(A)))
-    sqrt(2upper_triangle - diago)
-end
 
 # Make sure that there is a CPU fallback for AbstractGPUArrays (e.g. for Duals)
 


### PR DESCRIPTION
GPUArrays v11.5.4 introduces a `norm` function for generic `AbstractGPUArrays`, which also works for Hermitian matrices. As a result, the current workaround `norm` becomes ambiguous, and the calculation crashes when it is called.

The simplest fix is to remove the workaround. However, since DFTK does not explicitly depend on GPUArrays (but only GPUArraysCore), we cannot restrict the compatibility in `Project.toml`. I think it is ok, and we can safely assume the latest GPUArrays version is used.