### PR TITLE
Symmetrize forces in DFTKCalculator

### DIFF
--- a/ext/DFTKGeometryOptimizationExt.jl
+++ b/ext/DFTKGeometryOptimizationExt.jl
@@ -48,6 +48,14 @@ function GO.minimize_energy!(system, calc::DFTKCalculator, solver;
         params = DFTK.DFTKParameters(; calc.params.model_kwargs,
                                        calc.params.basis_kwargs,
                                        scf_kwargs)
+
+        # TODO: The derivatives_keep_model_symmetry=true is a bit of a hack here.
+        #       Ideally it should not be the responsibility of the calculator to return
+        #       forces that keep the symmetry of the model, i.e. the symmetry of the
+        #       structure to be optimized, but instead it should be the job of the optimiser
+        #       to choose a representation of the structure, which keeps the symmetry
+        #       OR to explicitly symmetrise the positions in each step to ensure the
+        #       user-selected symmetries are kept.
         calc = DFTKCalculator(params, calc.st;
                               enforce_convergence=false,
                               derivatives_keep_model_symmetry=true)

--- a/ext/DFTKGeometryOptimizationExt.jl
+++ b/ext/DFTKGeometryOptimizationExt.jl
@@ -48,7 +48,9 @@ function GO.minimize_energy!(system, calc::DFTKCalculator, solver;
         params = DFTK.DFTKParameters(; calc.params.model_kwargs,
                                        calc.params.basis_kwargs,
                                        scf_kwargs)
-        calc = DFTKCalculator(params, calc.st; enforce_convergence=false)
+        calc = DFTKCalculator(params, calc.st;
+                              enforce_convergence=false,
+                              derivatives_keep_model_symmetry=true)
     end
 
     callback_dftk = function (optim_state, geoopt_state)

--- a/src/external/DFTKCalculator.jl
+++ b/src/external/DFTKCalculator.jl
@@ -18,16 +18,20 @@ struct DFTKCalculator{T}
     #
     # Calculator counters
     # TODO The Ref thingies feel a little wrong, somehow this should be part of the
-    #      state, but this may make it hard to keep track during geometry optimisation
+    #      state, but this may make it hard to keep track during geometry optimization
     #      or similar. In any case don't rely on this for now, it may disappear.
     counter_n_iter::Ref{Int}
     counter_matvec::Ref{Int}
     #
     # Calculator parameters
     enforce_convergence::Bool  # If true, throws an error exception on non-convergence
+    derivatives_keep_model_symmetry::Bool # Enforces forces are always symmetric with respect
+                               # to the structure, see docs of `compute_forces` for details
 
-    function DFTKCalculator(params::DFTKParameters, st=nothing; enforce_convergence=true)
-        new{Nothing}(params, st, Ref(0), Ref(0), enforce_convergence)
+    function DFTKCalculator(params::DFTKParameters, st=nothing;
+                            enforce_convergence=true, derivatives_keep_model_symmetry=false)
+        new{Nothing}(params, st, Ref(0), Ref(0),
+                     enforce_convergence, derivatives_keep_model_symmetry)
     end
 end
 AtomsCalculators.energy_unit(::DFTKCalculator) = u"hartree"
@@ -59,9 +63,18 @@ By default the calculator preserves the symmetries that are stored inside the
 `st` (the basis is re-built, but symmetries are fixed and not re-computed).
 
 Calculator-specific keyword arguments are:
-- `verbose`: If true, the SCF iterations are printed.
-- `enforce_convergence`: If false, the calculator does not error out
+- `verbose::Bool` (default: `true`): If true, the SCF iterations are printed.
+- `enforce_convergence::Bool` (default: `true`): If false, the calculator does not error out
   in case of a non-converging SCF.
+- `derivatives_keep_model_symmetry::Bool` (default: `false`): If the parameters chosen for
+  the discretization is not able to represent all symmetries of the structure one can either
+  have (i) energy derivatives be consistent with the energy within the discretization used
+  for the computation (ii) or have these derivatives agree with the physical model.
+  See [`compute_forces`](@ref) for more details. By default we do (i), but setting this
+  to true switches to (ii), which can be useful for geometry optimizations, for example.
+  Using a `DFTKCalculator` in combination with
+  [GeometryOptimization.jl](https://github.com/JuliaMolSim/GeometryOptimization.jl)
+  automatically switches to (ii).
 
 ## Example
 ```julia-repl
@@ -90,7 +103,9 @@ end
 # TODO Do something with parameters ?
 AtomsCalculators.get_state(calc::DFTKCalculator) = calc.st
 function AtomsCalculators.set_state!(calc::DFTKCalculator, st)
-    DFTKCalculator(calc.params, st; calc.enforce_convergence)
+    DFTKCalculator(calc.params, st;
+                   calc.enforce_convergence,
+                   calc.derivatives_keep_model_symmetry)
 end
 
 
@@ -144,6 +159,13 @@ function compute_scf(system::AbstractSystem, calc::DFTKCalculator, ::Nothing)
     compute_scf(system, calc, (; ))
 end
 
+function compute_calculator_force(calc::DFTKCalculator, scfres)
+    if calc.derivatives_keep_model_symmetry
+        return _compute_forces_cart_symmetrised(scfres; scfres.basis.model.symmetries)
+    else
+        return compute_forces_cart(scfres)
+    end
+end
 
 @generate_interface function AtomsCalculators.calculate(::AtomsCalculators.Energy,
         system::AbstractSystem, calc::DFTKCalculator, ps=nothing, st=nothing; kwargs...)
@@ -151,21 +173,10 @@ end
     (; energy=scfres.energies.total * u"hartree", state=scfres)
 end
 
-# Compute the Cartesian forces, symmetrized according to the model's symmetries.
-# This ensure that the symmetries are preserved throughout a geometry optimization
-# even if the forces are not perfectly symmetric due to numerical noise.
-# TODO: maybe compute_forces should always symmetrize (with basis or model symmetries?)
-function _computed_symmetrized_forces(scfres)
-    model = scfres.basis.model
-    forces_red = compute_forces(scfres)
-    forces_red = symmetrize_forces(model, forces_red; model.symmetries)
-    covector_red_to_cart.(model, forces_red)
-end
-
 @generate_interface function AtomsCalculators.calculate(::AtomsCalculators.Forces,
         system::AbstractSystem, calc::DFTKCalculator, ps=nothing, st=nothing; kwargs...)
     scfres = compute_scf(system, calc, st)
-    (; forces=_computed_symmetrized_forces(scfres) * u"hartree/bohr",
+    (; forces=compute_calculator_force(calc, scfres) * u"hartree/bohr",
        energy=scfres.energies.total * u"hartree",
        state=scfres)
 end
@@ -184,5 +195,5 @@ end
 
 function AtomsCalculators.energy_forces_virial(system, calc::DFTKCalculator; kwargs...)
     res = AtomsCalculators.calculate(AtomsCalculators.Virial(), system, calc; kwargs...)
-    (; forces=_computed_symmetrized_forces(res.state) * u"hartree/bohr", res...)
+    (; forces=compute_calculator_force(calc, res.state) * u"hartree/bohr", res...)
 end

--- a/src/external/DFTKCalculator.jl
+++ b/src/external/DFTKCalculator.jl
@@ -112,7 +112,6 @@ end
 function compute_scf(system::AbstractSystem, calc::DFTKCalculator, oldstate)
     # We re-use the symmetries from the oldstate to avoid issues if system
     # happens to be more symmetric than the structure used to make the oldstate.
-    # To not lose the symmetries we also symmetrize the forces (see below).
     symmetries = haskey(oldstate, :basis) ? oldstate.basis.model.symmetries : true
     model = model_DFT(system; symmetries, calc.params.model_kwargs...)
 
@@ -160,6 +159,10 @@ function compute_scf(system::AbstractSystem, calc::DFTKCalculator, ::Nothing)
 end
 
 function compute_calculator_force(calc::DFTKCalculator, scfres)
+    # By default forces are only symmetric with respect to the basis (discretised problem),
+    # but not with respect to the model (original physical problem); see the compute_forces
+    # docs for details; for geometry optimisations we need the latter, thus we may explicitly
+    # symmetrise if the flag calc.derivatives_keep_model_symmetry is set.
     if calc.derivatives_keep_model_symmetry
         return _compute_forces_cart_symmetrised(scfres; scfres.basis.model.symmetries)
     else

--- a/src/external/DFTKCalculator.jl
+++ b/src/external/DFTKCalculator.jl
@@ -97,6 +97,7 @@ end
 function compute_scf(system::AbstractSystem, calc::DFTKCalculator, oldstate)
     # We re-use the symmetries from the oldstate to avoid issues if system
     # happens to be more symmetric than the structure used to make the oldstate.
+    # To not lose the symmetries we also symmetrize the forces (see below).
     symmetries = haskey(oldstate, :basis) ? oldstate.basis.model.symmetries : true
     model = model_DFT(system; symmetries, calc.params.model_kwargs...)
 
@@ -150,10 +151,21 @@ end
     (; energy=scfres.energies.total * u"hartree", state=scfres)
 end
 
+# Compute the Cartesian forces, symmetrized according to the model's symmetries.
+# This ensure that the symmetries are preserved throughout a geometry optimization
+# even if the forces are not perfectly symmetric due to numerical noise.
+# TODO: maybe compute_forces should always symmetrize (with basis or model symmetries?)
+function _computed_symmetrized_forces(scfres)
+    model = scfres.basis.model
+    forces_red = compute_forces(scfres)
+    forces_red = symmetrize_forces(model, forces_red; model.symmetries)
+    covector_red_to_cart.(model, forces_red)
+end
+
 @generate_interface function AtomsCalculators.calculate(::AtomsCalculators.Forces,
         system::AbstractSystem, calc::DFTKCalculator, ps=nothing, st=nothing; kwargs...)
     scfres = compute_scf(system, calc, st)
-    (; forces=compute_forces_cart(scfres) * u"hartree/bohr",
+    (; forces=_computed_symmetrized_forces(scfres) * u"hartree/bohr",
        energy=scfres.energies.total * u"hartree",
        state=scfres)
 end
@@ -172,5 +184,5 @@ end
 
 function AtomsCalculators.energy_forces_virial(system, calc::DFTKCalculator; kwargs...)
     res = AtomsCalculators.calculate(AtomsCalculators.Virial(), system, calc; kwargs...)
-    (; forces=compute_forces_cart(res.state) * u"hartree/bohr", res...)
+    (; forces=_computed_symmetrized_forces(res.state) * u"hartree/bohr", res...)
 end

--- a/src/external/DFTKCalculator.jl
+++ b/src/external/DFTKCalculator.jl
@@ -158,15 +158,27 @@ function compute_scf(system::AbstractSystem, calc::DFTKCalculator, ::Nothing)
     compute_scf(system, calc, (; ))
 end
 
-function compute_calculator_force(calc::DFTKCalculator, scfres)
-    # By default forces are only symmetric with respect to the basis (discretised problem),
+function compute_calculator_forces(calc::DFTKCalculator, scfres)
+    # By default forces are only symmetric with respect to the basis (discretized problem),
     # but not with respect to the model (original physical problem); see the compute_forces
     # docs for details; for geometry optimisations we need the latter, thus we may explicitly
     # symmetrise if the flag calc.derivatives_keep_model_symmetry is set.
     if calc.derivatives_keep_model_symmetry
-        return _compute_forces_cart_symmetrised(scfres; scfres.basis.model.symmetries)
+        return _compute_forces_cart_symmetrized(scfres; scfres.basis.model.symmetries)
     else
         return compute_forces_cart(scfres)
+    end
+end
+
+function compute_calculator_stresses(calc::DFTKCalculator, scfres)
+    # By default stresses are only symmetric with respect to the basis (discretized problem),
+    # but not with respect to the model (original physical problem); see the compute_stresses_cart
+    # docs for details; for geometry optimisations we need the latter, thus we may explicitly
+    # symmetrise if the flag calc.derivatives_keep_model_symmetry is set.
+    if calc.derivatives_keep_model_symmetry
+        return _compute_stresses_cart_symmetrized(scfres; scfres.basis.model.symmetries)
+    else
+        return compute_stresses_cart(scfres)
     end
 end
 
@@ -179,7 +191,7 @@ end
 @generate_interface function AtomsCalculators.calculate(::AtomsCalculators.Forces,
         system::AbstractSystem, calc::DFTKCalculator, ps=nothing, st=nothing; kwargs...)
     scfres = compute_scf(system, calc, st)
-    (; forces=compute_calculator_force(calc, scfres) * u"hartree/bohr",
+    (; forces=compute_calculator_forces(calc, scfres) * u"hartree/bohr",
        energy=scfres.energies.total * u"hartree",
        state=scfres)
 end
@@ -188,7 +200,7 @@ end
         system::AbstractSystem, calc::DFTKCalculator, ps=nothing, st=nothing; kwargs...)
     scfres  = compute_scf(system, calc, st)
     Ω = scfres.basis.model.unit_cell_volume
-    virial = (-Ω * compute_stresses_cart(scfres)) * u"hartree"
+    virial = (-Ω * compute_calculator_stresses(calc, scfres)) * u"hartree"
     (; virial, energy=scfres.energies.total * u"hartree", state=scfres)
 end
 
@@ -198,5 +210,5 @@ end
 
 function AtomsCalculators.energy_forces_virial(system, calc::DFTKCalculator; kwargs...)
     res = AtomsCalculators.calculate(AtomsCalculators.Virial(), system, calc; kwargs...)
-    (; forces=compute_calculator_force(calc, res.state) * u"hartree/bohr", res...)
+    (; forces=compute_calculator_forces(calc, res.state) * u"hartree/bohr", res...)
 end

--- a/src/postprocess/forces.jl
+++ b/src/postprocess/forces.jl
@@ -4,6 +4,21 @@ Compute the forces of an obtained SCF solution. Returns the forces wrt. the frac
 lattice vectors. To get Cartesian forces use [`compute_forces_cart`](@ref).
 Returns a list of lists of forces (as SVector{3}) in the same order as the `atoms`
 and `positions` in the underlying [`Model`](@ref).
+
+!!! info "Forces are not always symmetric with respect to the physical structure"
+    We ensure that the returned forces are the derivatve of the obtained DFT
+    energy with respect to positions within the discretisation encoded in
+    the [`PlaneWaveBases`](@ref). Note, that as a result we are unable to make sure
+    that forces always keep the symmetries of the physical structure, simply because
+    the discretised problem (encoded in the `basis`) may be unable to represent numerically
+    all physical symmetries, i.e. `basis.symmetries` may be only a subset
+    of `model.symmetries`.
+
+    For some use cases (e.g. geometry optimisations) it may be important to ensure
+    that one keeps only force compoments that keep the symmetries of the stucture.
+    in this case one an manually call `symmetrize_forces(forces_reduced; model.symmetries)`
+    on the `forces_reduced` returned from this function to project out those force
+    directions not keeping the symmetries of the phyiscal model.
 """
 @timing function compute_forces(basis::PlaneWaveBasis{T}, ψ, occupation; kwargs...) where {T}
     # no explicit symmetrization is performed here, it is the
@@ -18,6 +33,13 @@ Compute the Cartesian forces of an obtained SCF solution in Hartree / Bohr.
 Returns a list of lists of forces
 `[[force for atom in positions] for (element, positions) in atoms]`
 which has the same structure as the `atoms` object passed to the underlying [`Model`](@ref).
+
+!!! info "Forces are not always symmetric with respect to the physical structure"
+    We ensure that the returned forces are the derivative of the obtained DFT
+    energy with respect to positions within the discretisation encoded in
+    the [`PlaneWaveBases`](@ref). As a result forces may not always be symmetric
+    with respect to the physical structure. For more details, see the documentation
+    of [`compute_forces`](@ref).
 """
 function compute_forces_cart(basis::PlaneWaveBasis, ψ, occupation; kwargs...)
     forces_reduced = compute_forces(basis, ψ, occupation; kwargs...)
@@ -29,4 +51,13 @@ function compute_forces(scfres)
 end
 function compute_forces_cart(scfres)
     compute_forces_cart(scfres.basis, scfres.ψ, scfres.occupation; scfres.ρ, scfres.τ)
+end
+
+# Internal function used to not only compute a force, but also symmetrise with respect
+# to a custom set of symmetries. Currently only used in the DFTK calculator; if it becomes
+# broadly useful, we should perhaps promote this to a proper API function.
+function _compute_forces_cart_symmetrised(scfres; symmetries)
+    forces_reduced = compute_forces(scfres)
+    forces_reduced = symmetrize_forces(scfres.basis.model, forces_reduced; symmetries)
+    covector_red_to_cart.(scfres.basis.model, forces_reduced)
 end

--- a/src/postprocess/forces.jl
+++ b/src/postprocess/forces.jl
@@ -8,7 +8,7 @@ and `positions` in the underlying [`Model`](@ref).
 !!! info "Forces are not always symmetric with respect to the physical structure"
     We ensure that the returned forces are the derivatve of the obtained DFT
     energy with respect to positions *within the discretisation* encoded in
-    the [`PlaneWaveBases`](@ref). Note, that as a result we are unable to make sure
+    the [`PlaneWaveBasis`](@ref). Note, that as a result we are unable to make sure
     that forces always keep the symmetries of the physical structure, simply because
     the discretised problem (encoded in the `basis`) may be unable to represent numerically
     all physical symmetries, i.e. `basis.symmetries` may be only a subset
@@ -37,7 +37,7 @@ which has the same structure as the `atoms` object passed to the underlying [`Mo
 !!! info "Forces are not always symmetric with respect to the physical structure"
     We ensure that the returned forces are the derivative of the obtained DFT
     energy with respect to positions within the discretisation encoded in
-    the [`PlaneWaveBases`](@ref). As a result forces may not always be symmetric
+    the [`PlaneWaveBasis`](@ref). As a result forces may not always be symmetric
     with respect to the physical structure. For more details, see the documentation
     of [`compute_forces`](@ref).
 """

--- a/src/postprocess/forces.jl
+++ b/src/postprocess/forces.jl
@@ -7,7 +7,7 @@ and `positions` in the underlying [`Model`](@ref).
 
 !!! info "Forces are not always symmetric with respect to the physical structure"
     We ensure that the returned forces are the derivatve of the obtained DFT
-    energy with respect to positions within the discretisation encoded in
+    energy with respect to positions *within the discretisation* encoded in
     the [`PlaneWaveBases`](@ref). Note, that as a result we are unable to make sure
     that forces always keep the symmetries of the physical structure, simply because
     the discretised problem (encoded in the `basis`) may be unable to represent numerically
@@ -56,7 +56,7 @@ end
 # Internal function used to not only compute a force, but also symmetrise with respect
 # to a custom set of symmetries. Currently only used in the DFTK calculator; if it becomes
 # broadly useful, we should perhaps promote this to a proper API function.
-function _compute_forces_cart_symmetrised(scfres; symmetries)
+function _compute_forces_cart_symmetrized(scfres; symmetries)
     forces_reduced = compute_forces(scfres)
     forces_reduced = symmetrize_forces(scfres.basis.model, forces_reduced; symmetries)
     covector_red_to_cart.(scfres.basis.model, forces_reduced)

--- a/src/postprocess/stresses.jl
+++ b/src/postprocess/stresses.jl
@@ -17,7 +17,7 @@ for details. In Voigt notation one would use the vector
 !!! info "Stresses are not always symmetric with respect to the physical structure"
     We ensure that the returned stresses are the derivatve of the obtained DFT
     energy with respect to the lattice *within the discretisation* encoded in
-    the [`PlaneWaveBases`](@ref). Note, that as a result we are unable to make sure
+    the [`PlaneWaveBasis`](@ref). Note, that as a result we are unable to make sure
     that stresses always keep the symmetries of the physical structure, simply because
     the discretised problem (encoded in the `basis`) may be unable to represent numerically
     all physical symmetries, i.e. `basis.symmetries` may be only a subset

--- a/src/postprocess/stresses.jl
+++ b/src/postprocess/stresses.jl
@@ -13,6 +13,8 @@ where ``ϵ`` is the strain tensor.
 See [O. Nielsen, R. Martin Phys. Rev. B. **32**, 3792 (1985)](https://doi.org/10.1103/PhysRevB.32.3792)
 for details. In Voigt notation one would use the vector
 ``[σ_{xx} σ_{yy} σ_{zz} σ_{zy} σ_{zx} σ_{yx}]``.
+
+Stresses are symmetrised with respect to the basis symmetries (`basis.symmetries`).
 """
 @timing function compute_stresses_cart(scfres)
     # compute the Hellmann-Feynman energy (with fixed ψ/occ/ρ)

--- a/src/postprocess/stresses.jl
+++ b/src/postprocess/stresses.jl
@@ -14,7 +14,16 @@ See [O. Nielsen, R. Martin Phys. Rev. B. **32**, 3792 (1985)](https://doi.org/10
 for details. In Voigt notation one would use the vector
 ``[σ_{xx} σ_{yy} σ_{zz} σ_{zy} σ_{zx} σ_{yx}]``.
 
-Stresses are symmetrised with respect to the basis symmetries (`basis.symmetries`).
+!!! info "Stresses are not always symmetric with respect to the physical structure"
+    We ensure that the returned stresses are the derivatve of the obtained DFT
+    energy with respect to the lattice *within the discretisation* encoded in
+    the [`PlaneWaveBases`](@ref). Note, that as a result we are unable to make sure
+    that stresses always keep the symmetries of the physical structure, simply because
+    the discretised problem (encoded in the `basis`) may be unable to represent numerically
+    all physical symmetries, i.e. `basis.symmetries` may be only a subset
+    of `model.symmetries`. Use `symmetrize_stresses(basis, stresses; basis.model.symmetries)`
+    to explicitly make sure that the `stresses` returned by this function keep the symmetry
+    of the physical model. See also the discussion in [`compute_forces`](@ref).
 """
 @timing function compute_stresses_cart(scfres)
     # compute the Hellmann-Feynman energy (with fixed ψ/occ/ρ)
@@ -65,4 +74,13 @@ function full_strain_to_voigt(ε::AbstractVector{T}) where {T}
              ε[3, 2] + ε[2, 3],
              ε[3, 1] + ε[1, 3],
              ε[1, 2] + ε[2, 1]]
+end
+
+
+# Internal function used to not only compute stresses, but also symmetrise with respect
+# to a custom set of symmetries. Currently only used in the DFTK calculator; if it becomes
+# broadly useful, we should perhaps promote this to a proper API function.
+function _compute_stresses_cart_symmetrized(scfres; symmetries)
+    stresses = compute_stresses_cart(scfres)
+    symmetrize_stresses(scfres.basis, stresses; symmetries)
 end

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -369,8 +369,8 @@ function symmetrize_stresses(model::Model, stresses; symmetries)
     stresses_symmetrized /= length(symmetries)
     stresses_symmetrized
 end
-function symmetrize_stresses(basis::PlaneWaveBasis, stresses)
-    symmetrize_stresses(basis.model, stresses; basis.symmetries)
+function symmetrize_stresses(basis::PlaneWaveBasis, stresses; symmetries=basis.symmetries)
+    symmetrize_stresses(basis.model, stresses; symmetries)
 end
 
 """
@@ -460,7 +460,7 @@ function unfold_bz(basis::PlaneWaveBasis)
     if length(basis.symmetries) == 1
         return basis
     else
-        # TODO This can be optimised much better by avoiding the recomputation
+        # TODO This can be optimized much better by avoiding the recomputation
         #      of the terms wherever possible.
         use_symmetry_for_kpoint_reduction = false
         return PlaneWaveBasis(basis.model, basis.Ecut, basis.fft_size,
@@ -494,7 +494,7 @@ function unfold_array(basis_irred, basis_unfolded, data, is_ψ)
         error("Brillouin zone symmetry unfolding not supported with MPI yet")
     end
     if basis_irred.n_irreducible_kpoints < mpi_nprocs(basis_irred.comm_kpts)
-        # Note: if this routine is ever generalised for MPI,
+        # Note: if this routine is ever generalized for MPI,
         # need special care for potentially duplicated KP
         error("Brillouin zone symmetry unfolding not supported with duplicated k-points")
     end


### PR DESCRIPTION
This fix makes for example BaTiO3 geometry optimization converge! Without it, the symmetries get lost at some point in the optimization step.