### PR TITLE
Use multithreading for PSP evaluations

### DIFF
--- a/src/common/threading.jl
+++ b/src/common/threading.jl
@@ -86,3 +86,25 @@ function parallel_loop_over_range(fun, range, storages)
 
     return storages
 end
+
+function parallel_map(f, T, src::AbstractVector)
+    dest = similar(src, T)
+    parallel_map!(f, dest, src)
+end
+
+function parallel_map!(f, dest::AbstractVector, src::AbstractVector)
+    @assert axes(dest) == axes(src)
+    nthreads = get_DFTK_threads()
+    chunk_length = cld(length(dest), nthreads)
+
+    if nthreads <= 1
+        map!(f, dest, src)
+    else
+        @sync for chunk in Iterators.partition(eachindex(dest), chunk_length)
+            Threads.@spawn let
+                @views map!(f, dest[chunk], src[chunk])
+            end
+        end
+    end
+    dest
+end

--- a/src/pseudo/PspUpf.jl
+++ b/src/pseudo/PspUpf.jl
@@ -200,7 +200,7 @@ function eval_psp_projector_fourier(psp::PspUpf, i, l, ps::AbstractVector{T}) wh
     ircut_proj = min(psp.ircut, length(psp.r2_projs[l+1][i]))
     rgrid = to_device(arch, @view psp.rgrid[1:ircut_proj])
     r2_proj = to_device(arch, @view psp.r2_projs[l+1][i][1:ircut_proj])
-    map(ps) do p
+    parallel_map(promote_type(eltype(rgrid), T), ps) do p
         # GPU kernels with dynamic function calls do not compile,
         # hence the pre-determined explicit integration function
         hankel(quadrature, rgrid, r2_proj, l, p)
@@ -255,7 +255,7 @@ function eval_psp_local_fourier(psp::PspUpf, ps::AbstractVector{T}) where {T<:Re
     rgrid = to_device(arch, @view psp.rgrid[1:psp.ircut])
     vloc  = to_device(arch, @view psp.vloc[1:psp.ircut])
     Zion = psp.Zion
-    map(ps) do p
+    parallel_map(promote_type(eltype(rgrid), T), ps) do p
         # GPU kernels with dynamic function calls do not compile,
         # hence the pre-determined explicit integration function
         _eval_psp_local_fourier(quadrature, rgrid, vloc, Zion, p)
@@ -288,7 +288,7 @@ function eval_psp_core_density_fourier(psp::PspUpf, ps::AbstractVector{T}) where
     arch = architecture(ps)
     rgrid = to_device(arch, @view psp.rgrid[1:psp.ircut])
     r2_ρcore = to_device(arch, @view psp.r2_ρcore[1:psp.ircut])
-    map(ps) do p
+    parallel_map(promote_type(eltype(rgrid), T), ps) do p
         # GPU kernels with dynamic function calls do not compile,
         # hence the pre-determined explicit integration function
         hankel(quadrature, rgrid, r2_ρcore, 0, p)


### PR DESCRIPTION
Same pattern as the GPU support, but on the CPU: use a parallel map! for the Hankel transform evaluations. Should mostly fix #1326.

Needs benchmarking still. Thoughts on the approach?