### PR TITLE
Refactor coulomb

### DIFF
--- a/ext/DFTKFastGaussQuadratureExt.jl
+++ b/ext/DFTKFastGaussQuadratureExt.jl
@@ -1,15 +1,16 @@
 module DFTKFastGaussQuadratureExt
 using FastGaussQuadrature
 using DFTK
-using DFTK: to_cpu, eval_kernel_fourier, VoxelAveraged
+using DFTK: to_cpu, eval_kernel_fourier, norm2, VoxelAverage
 using LinearAlgebra
 
 
-@views function DFTK._compute_kernel_fourier(kernel, regularization::VoxelAveraged,
-                                             basis::PlaneWaveBasis{T}, qpt, q) where {T}
+@views function DFTK.eval_kernel_fourier(k::VoxelAverage,
+                                         basis::PlaneWaveBasis{T}; qpt) where {T}
     model = basis.model
+    kernel = k.inner_kernel
     q = qpt.coordinate
-    
+
     # Get kgrid_size
     if isnothing(basis.kgrid)
         kgrid_size = Vec3{Int}(1, 1, 1)
@@ -18,7 +19,7 @@ using LinearAlgebra
     elseif basis.kgrid isa MonkhorstPack
         kgrid_size = Vec3{Int}(basis.kgrid.kgrid_size)
     else
-        @error "Cannot determine kgrid_size for VoxelAveraged Coulomb model."
+        @error "Cannot determine kgrid_size for VoxelAverage Coulomb model."
     end
 
     # Define Voxels as reciprocal cell deivided by k-mesh
@@ -26,7 +27,7 @@ using LinearAlgebra
     voxel_vol = abs(det(voxel_basis))
     
     # Get Gauss-Legendre nodes and weights and scale from [-1, 1] to [-0.5, 0.5]
-    nodes_std, weights_std = gausslegendre(regularization.n_quadrature_points)
+    nodes_std, weights_std = gausslegendre(k.n_quadrature_points)
     nodes = T.(nodes_std ./ 2)
     weights = T.(weights_std ./ 2)
     
@@ -87,16 +88,14 @@ using LinearAlgebra
             integral = zero(T)
             for i in 1:length(q_locals)
                 G_total = G_cart + q_locals[i]
-                Gsq = dot(G_total, G_total)
 
                 if found_singularity
                     # switch temporarily to BigFloat to avoid catastrophic cancellation
-                    Gsq_big = BigFloat(Gsq)
-                    val_big = eval_kernel_fourier(kernel, Gsq_big)
-                    val_big -= 4π/Gsq_big
+                    G_total_big = BigFloat.(G_total)
+                    val_big = eval_kernel_fourier(kernel, G_total_big) - 4π/norm2(G_total_big)
                     val = T(val_big)
                 else
-                    val = eval_kernel_fourier(kernel, Gsq)
+                    val = eval_kernel_fourier(kernel, G_total)
                 end
 
                 integral += w_locals[i] * val
@@ -106,8 +105,7 @@ using LinearAlgebra
             # For G vectors far from the origin, the interaction kernel is practically flat
             # over the voxel. Bypassing the 1728-point quadrature and using the exact
             # midpoint saves enormous CPU time.
-            Gsq = dot(G_cart, G_cart)
-            kernel_fourier[iG] += eval_kernel_fourier(kernel, Gsq)
+            kernel_fourier[iG] += eval_kernel_fourier(kernel, G_cart)
         end
     end
     

--- a/ext/DFTKFastGaussQuadratureExt.jl
+++ b/ext/DFTKFastGaussQuadratureExt.jl
@@ -1,15 +1,14 @@
 module DFTKFastGaussQuadratureExt
 using FastGaussQuadrature
 using DFTK
-using DFTK: to_cpu, eval_kernel_fourier, norm2, VoxelAverage
+using DFTK: to_cpu, eval_kernel_fourier, norm2, G_vectors, VoxelAverage
 using LinearAlgebra
 
 
 @views function DFTK.eval_kernel_fourier(k::VoxelAverage,
-                                         basis::PlaneWaveBasis{T}; qpt) where {T}
+                                         basis::PlaneWaveBasis{T}; q=zero(Vec3{T})) where {T}
     model = basis.model
     kernel = k.inner_kernel
-    q = qpt.coordinate
 
     # Get kgrid_size
     if isnothing(basis.kgrid)
@@ -35,8 +34,8 @@ using LinearAlgebra
     q_locals = vec([voxel_basis * Vec3(x, y, z) for x in nodes, y in nodes, z in nodes])
     w_locals = vec([wx * wy * wz for wx in weights, wy in weights, wz in weights])
 
-    kernel_fourier = zeros(T, length(qpt.G_vectors))
-    for (iG, G) in enumerate(to_cpu(qpt.G_vectors))
+    kernel_fourier = zeros(T, basis.fft_size...)
+    for (iG, G) in enumerate(to_cpu(G_vectors(basis)))
         G_cart = model.recip_lattice * (G+q)
 
         found_singularity = (iG==1 && iszero(q))

--- a/src/DFTK.jl
+++ b/src/DFTK.jl
@@ -44,6 +44,7 @@ include("common/quadrature.jl")
 include("common/hankel.jl")
 include("common/hydrogenic.jl")
 include("common/derivatives.jl")
+include("common/divided_difference.jl")
 include("common/linalg.jl")
 include("common/random.jl")
 

--- a/src/DFTK.jl
+++ b/src/DFTK.jl
@@ -102,11 +102,11 @@ include("supercell.jl")
 export Energies
 include("Energies.jl")
 
-export Coulomb
+export BareCoulomb
 export SphericallyTruncatedCoulomb
 export WignerSeitzTruncatedCoulomb
 export ShortRangeCoulomb, LongRangeCoulomb
-export ProbeCharge, ReplaceSingularity, VoxelAveraged
+export ProbeCharge, ReplaceSingularity, VoxelAverage
 include("coulomb.jl")
 
 export Hamiltonian

--- a/src/Smearing.jl
+++ b/src/Smearing.jl
@@ -11,6 +11,7 @@
 module Smearing
 import ForwardDiff
 using SpecialFunctions: erf, erfc, factorial
+import ..divided_difference  # shared helper (src/common/divided_difference.jl)
 
 abstract type SmearingFunction end
 
@@ -28,9 +29,6 @@ Derivative of the occupation function, approximation to minus the delta function
 """
 occupation_derivative(S::SmearingFunction, x) = ForwardDiff.derivative(x -> occupation(S, x), x)
 
-"""
-`(f(x) - f(y))/(x - y)`, computed stably in the case where `x` and `y` are close
-"""
 function occupation_divided_difference(S::SmearingFunction, x, y, εF, temp)
     if temp == 0
         if x == y
@@ -45,14 +43,6 @@ function occupation_divided_difference(S::SmearingFunction, x, y, εF, temp)
         fder(z) = occupation_derivative(S, (z-εF)/temp) / temp
         divided_difference(f, fder, x, y)
     end
-end
-function divided_difference(f, fder, x::T, y) where {T}
-    # (f(x) - f(y))/(x - y) is accurate to ε/|x-y|
-    # so for x ~= y we use the approximation (f'(x)+f'(y))/2,
-    # which is accurate to |x-y|^2, and therefore better when |x-y| ≤ cbrt(ε)
-    # The resulting method is accurate to ε^2/3
-    abs(x-y) < cbrt(eps(T)) && return (fder(x) + fder(y))/2
-    (f(x)-f(y)) / (x-y)
 end
 
 """

--- a/src/common/divided_difference.jl
+++ b/src/common/divided_difference.jl
@@ -1,0 +1,24 @@
+@doc raw"""
+    divided_difference(f, fder, x, y)
+
+Stable, AD-friendly first divided difference
+```math
+f[x, y] = \frac{f(x) - f(y)}{x - y},
+```
+which tends to ``f'(x)`` as ``y \to x``; `fder` is the derivative of `f`.
+
+The direct formula `(f(x)-f(y))/(x-y)` is accurate to `ε/|x-y|` (catastrophic cancellation as
+`x → y`) and is `0/0` at `x == y`. For `|x-y|` small we instead use the derivative midpoint
+`(f'(x)+f'(y))/2`, which is accurate to `|x-y|²`. Balancing the two errors, we switch at
+`|x-y| = ∛ε`, giving an overall accuracy `ε^{2/3}` and a finite, differentiable result through
+`x == y`.
+
+When `f(0) == 0`, `divided_difference(f, fder, x, 0)` is a stable way to evaluate `f(x)/x`,
+including its `x → 0` limit `f'(0)` — the recurring pattern for the `1/r`-type singularities of
+the interaction kernels in `coulomb.jl`. Pass a well-conditioned `f` (e.g. `x -> -expm1(-x)`
+rather than `x -> 1 - exp(-x)`) so that the direct branch does not itself cancel.
+"""
+function divided_difference(f, fder, x::T, y) where {T}
+    abs(x - y) < cbrt(eps(T)) && return (fder(x) + fder(y)) / 2
+    (f(x) - f(y)) / (x - y)
+end

--- a/src/coulomb.jl
+++ b/src/coulomb.jl
@@ -51,14 +51,18 @@ Base.Broadcast.broadcastable(k::InteractionKernel) = Ref(k)
 
 # Required method: kernel on the grid (spherical cutoff |G+q|² < 2Ecut of `qpt`). Default loops
 # the pointwise method; overridden by kernels that need the grid or a grid-derived parameter.
-function eval_kernel_fourier(kernel::InteractionKernel, basis::PlaneWaveBasis; qpt)
+function eval_kernel_fourier(kernel::InteractionKernel, basis::PlaneWaveBasis{T};
+                             q=zero(Vec3{T})) where {T}
+    # Evaluate on the full (cube) FFT grid: a pair density ψᵢ*ψⱼ has content beyond the orbital
+    # sphere, so the exchange kernel must live on the density grid, not the k-point sphere.
     # TODO: for q=0 the coefficients could be symmetrized so that the inverse FFT is exactly real.
-    map(p -> eval_kernel_fourier(kernel, p), Gplusk_vectors_cart(basis, qpt))
+    recip = basis.model.recip_lattice
+    map(G -> eval_kernel_fourier(kernel, recip * (G + q)), G_vectors(basis))
 end
 
 # Optional pointwise method k̂(p): kernels that are a closed-form function of `p` implement it;
 # kernels defined only on a grid (WignerSeitz, ProbeCharge) fall back to this error.
-function eval_kernel_fourier(kernel::InteractionKernel, p)
+function eval_kernel_fourier(kernel::InteractionKernel, p::AbstractVector)
     error("$(typeof(kernel)) has no pointwise Fourier evaluation (it is defined only relative " *
           "to a grid); use eval_kernel_fourier(kernel, basis; qpt).")
 end
@@ -76,7 +80,7 @@ must be wrapped in a singularity treatment ([`ProbeCharge`](@ref), [`ReplaceSing
 [`VoxelAverage`](@ref)) to obtain a well-defined ``G+q=0`` component.
 """
 struct BareCoulomb <: InteractionKernel end
-function eval_kernel_fourier(::BareCoulomb, p)
+function eval_kernel_fourier(::BareCoulomb, p::AbstractVector)
     p2 = norm2(p)
     4 * oftype(p2, π) / p2
 end
@@ -92,7 +96,7 @@ struct ShortRangeCoulomb{T <: Real} <: InteractionKernel
 end
 ShortRangeCoulomb(; μ=0.2/u"Å") = ShortRangeCoulomb(austrip(μ))
 ShortRangeCoulomb(μ::Quantity) = ShortRangeCoulomb(austrip(μ))
-function eval_kernel_fourier(k::ShortRangeCoulomb, p)
+function eval_kernel_fourier(k::ShortRangeCoulomb, p::AbstractVector)
     # Fourier transform of erfc(μr)/r:  (4π/|p|²)(1 - e^{-|p|²/4μ²}) = (π/μ²) φ(|p|²/4μ²),
     # where φ(t) = (1 - e^{-t})/t → 1 as t → 0 (so the p=0 value is π/μ²).
     T = eltype(p)
@@ -113,7 +117,7 @@ struct LongRangeCoulomb{T <: Real} <: InteractionKernel
 end
 LongRangeCoulomb(; μ=0.2/u"Å") = LongRangeCoulomb(austrip(μ))
 LongRangeCoulomb(μ::Quantity) = LongRangeCoulomb(austrip(μ))
-function eval_kernel_fourier(k::LongRangeCoulomb, p)
+function eval_kernel_fourier(k::LongRangeCoulomb, p::AbstractVector)
     # Fourier transform of erf(μr)/r:  (4π/|p|²) e^{-|p|²/4μ²}.
     T = eltype(p)
     p2 = norm2(p)
@@ -142,7 +146,7 @@ function sinc_sqrt(v)
     s = sqrt(v)
     sin(s) / s
 end
-function eval_kernel_fourier(k::SphericallyTruncatedCoulomb, p)
+function eval_kernel_fourier(k::SphericallyTruncatedCoulomb, p::AbstractVector)
     # Fourier transform of θ(R-r)/r:  (4π/|p|²)(1 - cos(R|p|)) = 2π R² sinc(R|p|/2)²
     # (using 1 - cos x = 2 sin²(x/2)), with p=0 value 2π R².
     T = eltype(p)
@@ -150,10 +154,12 @@ function eval_kernel_fourier(k::SphericallyTruncatedCoulomb, p)
     w = norm2(p)
     2T(π) * R^2 * sinc_sqrt(R^2 * w / 4)^2
 end
-function eval_kernel_fourier(k::SphericallyTruncatedCoulomb, basis::PlaneWaveBasis; qpt)
+function eval_kernel_fourier(k::SphericallyTruncatedCoulomb, basis::PlaneWaveBasis{T};
+                             q=zero(Vec3{T})) where {T}
     Rcut = @something k.Rcut cbrt(3 * basis.model.unit_cell_volume / (4π))
     kresolved = SphericallyTruncatedCoulomb(Rcut)
-    map(p -> eval_kernel_fourier(kresolved, p), Gplusk_vectors_cart(basis, qpt))
+    recip = basis.model.recip_lattice
+    map(G -> eval_kernel_fourier(kresolved, recip * (G + q)), G_vectors(basis))
 end
 
 
@@ -177,9 +183,8 @@ struct WignerSeitzTruncatedCoulomb <: InteractionKernel end
 # No pointwise method: WignerSeitz has no closed-form k̂(p), so it uses the generic error fallback.
 # TODO: a basis-free 'slow Fourier transform' pointwise method (issue #1322).
 @views function eval_kernel_fourier(::WignerSeitzTruncatedCoulomb,
-                                    basis::PlaneWaveBasis{T}; qpt) where {T}
+                                    basis::PlaneWaveBasis{T}; q=zero(Vec3{T})) where {T}
     model = basis.model
-    q = qpt.coordinate
 
     # === Inradius R_in of the Wigner–Seitz cell ===
     # R_in = min over nonzero lattice vectors R of |R|/2 (distance to the perpendicular bisector
@@ -223,16 +228,14 @@ struct WignerSeitzTruncatedCoulomb <: InteractionKernel end
         V_lr_real[idx]  = ω * divided_difference(erf, erfder, ω * d_min, zero(T))
         V_lr_real[idx] *= cis2pi(-dot(q, r_frac))  # Bloch phase e^{-2πi q·r}
     end
-    kernel_fourier_lr = real.(fft(basis, qpt, V_lr_real)) .* sqrt(model.unit_cell_volume)
+    kernel_fourier_lr = real.(fft(basis, V_lr_real)) .* sqrt(model.unit_cell_volume)
 
-    # === Add the analytic short-range term erfc(ωr)/r = ShortRangeCoulomb(ω) ===
+    # === Add the analytic short-range term erfc(ωr)/r = ShortRangeCoulomb(ω), on the cube grid ===
     short_range = ShortRangeCoulomb(ω)
-    kernel_fourier = zeros(T, length(qpt.G_vectors))
-    for (iG, G) in enumerate(to_cpu(qpt.G_vectors))
-        p = model.recip_lattice * (G + q)
-        kernel_fourier[iG] = eval_kernel_fourier(short_range, p) + kernel_fourier_lr[iG]
+    recip = model.recip_lattice
+    map(to_cpu(G_vectors(basis)), kernel_fourier_lr) do G, lr
+        eval_kernel_fourier(short_range, recip * (G + q)) + lr
     end
-    kernel_fourier
 end
 
 
@@ -248,7 +251,7 @@ struct ReplaceSingularity{K <: InteractionKernel, R} <: InteractionKernel
     inner_kernel::K
     replacement::R
 end
-function eval_kernel_fourier(k::ReplaceSingularity, p)
+function eval_kernel_fourier(k::ReplaceSingularity, p::AbstractVector)
     iszero(p) ? eltype(p)(k.replacement) : eval_kernel_fourier(k.inner_kernel, p)
 end
 
@@ -272,23 +275,25 @@ struct ProbeCharge{K <: InteractionKernel} <: InteractionKernel
 end
 ProbeCharge(inner_kernel::InteractionKernel=BareCoulomb(); α=nothing) =
     ProbeCharge(inner_kernel, α)
-@views function eval_kernel_fourier(k::ProbeCharge, basis::PlaneWaveBasis{T}; qpt) where {T}
+@views function eval_kernel_fourier(k::ProbeCharge, basis::PlaneWaveBasis{T};
+                                    q=zero(Vec3{T})) where {T}
     # Default well-tested in VASP; ensures e^{-α G²} is a localized charge with full support
     # on the G grid.
     α::T = @something k.α π^2 / basis.Ecut
 
-    Gpq2 = norm2.(Gplusk_vectors_cart(basis, qpt))
+    recip = basis.model.recip_lattice
+    Gpq2 = map(G -> norm2(recip * (G + q)), G_vectors(basis))
     # Raw kernel; its G+q=0 entry may be Inf/NaN and is overwritten below.
-    kernel_fourier = eval_kernel_fourier(k.inner_kernel, basis; qpt)
+    kernel_fourier = eval_kernel_fourier(k.inner_kernel, basis; q)
 
-    # Potential of the Gaussian charges, skipping the G+q=0 term.
+    # Potential of the Gaussian charges, skipping the G+q=0 term (linear index 1 is G=0).
     probe_charge_sum = sum((kernel_fourier .* exp.(-α .* Gpq2))[2:end])
     # Interaction of the Gaussian charges with the uniform background,
     # (1/Γ) ∫_BZ k̂(q) e^{-α q²} dq, with Γ the Brillouin-zone volume.
     Γ = basis.model.recip_cell_volume
     probe_charge_integral = compute_probe_charge_integral(k.inner_kernel, α) / Γ
 
-    if iszero(qpt.coordinate)
+    if iszero(q)
         GPUArraysCore.@allowscalar begin
             kernel_fourier[1] = probe_charge_integral - probe_charge_sum
         end

--- a/src/coulomb.jl
+++ b/src/coulomb.jl
@@ -1,334 +1,292 @@
 @doc raw"""
-Abstract type for different interaction models.
+Abstract type for electron–electron interaction kernels (Coulomb and Coulomb-like), used e.g.
+for the exact-exchange term.
 
-### Architecture
+### Interface
 
-Computing interaction kernels is split into two parts: the mathematical formula (e.g. 4\pi/G^2)
-and the grid discretization. This split is primarily driven by the need to handle singularities
-in long-range kernels. Note, that we already identified deficiencies with this design and a
-refactoring is discussed, which will change this file's structure in the future.
-# TODO (Issue #1322): Refactor file structure and kernels as discussed
+The **required** method evaluates the kernel on the plane-wave grid:
+```julia
+eval_kernel_fourier(kernel, basis; qpt)   # k̂(G+q) for all G of the k-point qpt
+```
+Kernels that are a genuine (closed-form) function of the Fourier vector `p` may *also* implement
+the **optional** pointwise method
+```julia
+eval_kernel_fourier(kernel, p)            # k̂(p) at one Cartesian Fourier vector p (a Vec3)
+```
+from which the grid method comes for free (the default loops it). Kernels defined only relative to
+the grid ([`WignerSeitzTruncatedCoulomb`](@ref), [`ProbeCharge`](@ref)) instead override the grid
+method, and their pointwise method falls back to an error.
 
-1. **InteractionKernel:** Defines the pure mathematical formula (via `eval_kernel_fourier`).
-2. **regularization:** Necessary for long-range kernels (like `Coulomb` and `LongRangeCoulomb`)
-   diverge as ``G+q \to 0``. Evaluating them on a periodic grid requires a specific strategy
-   to handle this divergence.
-   
-Because of this divergence, long-range `InteractionKernel`s contain a `regularization` field to
-dictate how the ``G+q=0`` component is built via `_compute_kernel_fourier`. Short-range kernels
-have a finite limit at `G+q \to 0``` and don't need a regularizatin.
+`qpt` is a `Kpoint` for now (it carries the momentum transfer `q` and the spherical G-set);
+this is slated to become a plain `q::Vec3` on the cube grid.
 
-Each InteractionKernel should support the following functions:
-eval_kernel_fourier(::InteractionKernel, Gsq)
-eval_probe_charge_integral(::InteractionKernel, α)
-    Should return ∫_{BZ}  kernel(q) * e^(-α * q^2) dq
-    This is needed for the ProbeCharge regularisation. Note, that no factor 1/Γ
-    where Γ is BZ volume) is used.
-_compute_kernel_fourier(::InteractionKernel, basis, qpt, q)
-    The single q-point version of compute_kernel_fourier
+Long-range kernels diverge as ``p \to 0`` and need their ``G+q=0`` component fixed by a
+**singularity treatment**, expressed as a *wrapper kernel* composing around an `inner_kernel`:
+[`ProbeCharge`](@ref), [`ReplaceSingularity`](@ref), [`VoxelAverage`](@ref). Kernels with a finite
+``p=0`` limit ([`ShortRangeCoulomb`](@ref), [`SphericallyTruncatedCoulomb`](@ref),
+[`WignerSeitzTruncatedCoulomb`](@ref)) return the correct value there themselves and need no wrapper.
 
-### Available models:
-- [`Coulomb`](@ref): 1/r
-- [`ShortRangeCoulomb`](@ref): erfc(μr)/r
-- [`LongRangeCoulomb`](@ref): erf(μr)/r
-- [`SphericallyTruncatedCoulomb`](@ref): θ(R-r)/r
-- [`WignerSeitzTruncatedCoulomb`](@ref): χ(r)/r (1 inside Wigner-Seitz cell, 0 otherwise)
+Kernels that support the Gygi–Baldereschi probe-charge treatment additionally implement
+```julia
+compute_probe_charge_integral(kernel, α)   # ∫_BZ k̂(q) e^{-α q²} dq  (no 1/Γ factor)
+```
+which errors by default.
 
-### Available singularity corrections (regularizations):
-- [`ProbeCharge`](@ref): Gygi-Baldereschi probe charge method
-- [`ReplaceSingularity`](@ref): Set the G+q=0 component to a specific value
-- [`VoxelAveraged`](@ref): Average the continuous kernel over the Brillouin zone voxel
+### Available kernels
+- [`BareCoulomb`](@ref): ``1/r``
+- [`ShortRangeCoulomb`](@ref): ``\mathrm{erfc}(μr)/r``
+- [`LongRangeCoulomb`](@ref): ``\mathrm{erf}(μr)/r``
+- [`SphericallyTruncatedCoulomb`](@ref): ``θ(R-r)/r``
+- [`WignerSeitzTruncatedCoulomb`](@ref): ``1/r`` truncated at the Wigner–Seitz cell boundary
 
-See also: [`compute_kernel_fourier`](@ref)
+### Singularity treatments (wrapper kernels)
+- [`ProbeCharge`](@ref): Gygi–Baldereschi probe charge
+- [`ReplaceSingularity`](@ref): set the ``G+q=0`` component to a given value
+- [`VoxelAverage`](@ref): average the kernel over the Brillouin-zone voxel
 """
 abstract type InteractionKernel end
 Base.Broadcast.broadcastable(k::InteractionKernel) = Ref(k)
 
-# TODO: should we have a eval_kernel_real? 
-# TODO: rename "k" in _compute_kernel_fourier(k...
-# TODO: change notation: p instead of G, G+q, ...
-# TODO: introduce a clever and AD-friendly way to deal with f(x)/x for x->0.
-#       E.g. intoduce phi(x) = iszero(x) ? one(x) : expm1(x) / x 
+# TODO: add a real-space evaluation eval_kernel_real(kernel, r) (useful for debugging).
 
-
-"""
-Coulomb interaction: 1/r 
-"""
-@kwdef struct Coulomb{R} <: InteractionKernel 
-    regularization::R = ProbeCharge()
+# Required method: kernel on the grid (spherical cutoff |G+q|² < 2Ecut of `qpt`). Default loops
+# the pointwise method; overridden by kernels that need the grid or a grid-derived parameter.
+function eval_kernel_fourier(kernel::InteractionKernel, basis::PlaneWaveBasis; qpt)
+    # TODO: for q=0 the coefficients could be symmetrized so that the inverse FFT is exactly real.
+    map(p -> eval_kernel_fourier(kernel, p), Gplusk_vectors_cart(basis, qpt))
 end
-eval_kernel_fourier(::Coulomb, Gsq::T) where {T} = 4T(π) / Gsq
-eval_probe_charge_integral(::Coulomb, α) = 8π^2 * sqrt(π / α)
-_compute_kernel_fourier(k::Coulomb, basis, qpt, q) = _compute_kernel_fourier(k, k.regularization, basis, qpt, q)
+
+# Optional pointwise method k̂(p): kernels that are a closed-form function of `p` implement it;
+# kernels defined only on a grid (WignerSeitz, ProbeCharge) fall back to this error.
+function eval_kernel_fourier(kernel::InteractionKernel, p)
+    error("$(typeof(kernel)) has no pointwise Fourier evaluation (it is defined only relative " *
+          "to a grid); use eval_kernel_fourier(kernel, basis; qpt).")
+end
+
+# Probe-charge integral ∫_BZ k̂(q) e^{-α q²} dq; only meaningful for the singular kernels.
+function compute_probe_charge_integral(kernel::InteractionKernel, α)
+    error("compute_probe_charge_integral is not implemented for $(typeof(kernel)); this kernel " *
+          "cannot be regularized with ProbeCharge.")
+end
 
 
 """
-Short-range Coulomb interaction via error function: erfc(μr)/r
+Bare Coulomb interaction ``1/r``, with Fourier kernel ``4π/|p|²``. Diverges at ``p=0``, so it
+must be wrapped in a singularity treatment ([`ProbeCharge`](@ref), [`ReplaceSingularity`](@ref),
+[`VoxelAverage`](@ref)) to obtain a well-defined ``G+q=0`` component.
 """
-struct ShortRangeCoulomb{T <: Real} <: InteractionKernel 
-    μ::T  # Cutoff parameter in inverse length units
+struct BareCoulomb <: InteractionKernel end
+function eval_kernel_fourier(::BareCoulomb, p)
+    p2 = norm2(p)
+    4 * oftype(p2, π) / p2
+end
+compute_probe_charge_integral(::BareCoulomb, α) = 8π^2 * sqrt(π / α)
+
+
+"""
+Short-range Coulomb interaction ``\\mathrm{erfc}(μr)/r`` (finite at ``p=0``), with cutoff
+parameter `μ` in inverse length units.
+"""
+struct ShortRangeCoulomb{T <: Real} <: InteractionKernel
+    μ::T
 end
 ShortRangeCoulomb(; μ=0.2/u"Å") = ShortRangeCoulomb(austrip(μ))
 ShortRangeCoulomb(μ::Quantity) = ShortRangeCoulomb(austrip(μ))
-function eval_kernel_fourier(k::ShortRangeCoulomb, Gsq::T) where {T}
-    -(4T(π) / Gsq) * expm1(-Gsq / (4 * T(k.μ)^2))
-end
-function _compute_kernel_fourier(k::ShortRangeCoulomb, basis, qpt, q)
-    # Use ReplaceSingularity regularisation to explicitly set as the G==0
-    # component the exact limit of the kernel for G->0, namely π/μ^2
-    _compute_kernel_fourier(k, ReplaceSingularity(π/k.μ^2), basis, qpt, q)
+function eval_kernel_fourier(k::ShortRangeCoulomb, p)
+    # Fourier transform of erfc(μr)/r:  (4π/|p|²)(1 - e^{-|p|²/4μ²}) = (π/μ²) φ(|p|²/4μ²),
+    # where φ(t) = (1 - e^{-t})/t → 1 as t → 0 (so the p=0 value is π/μ²).
+    T = eltype(p)
+    μ = T(k.μ)
+    t = norm2(p) / (4μ^2)
+    φ = divided_difference(x -> -expm1(-x), x -> exp(-x), t, zero(t))  # stable (1-e^{-t})/t
+    T(π) / μ^2 * φ
 end
 
 
 """
-Long-range Coulomb interaction via error function: erf(μr)/r
+Long-range Coulomb interaction ``\\mathrm{erf}(μr)/r``, with Fourier kernel
+``(4π/|p|²) e^{-|p|²/4μ²}``. Diverges at ``p=0`` and must be wrapped in a singularity treatment.
+`μ` is the cutoff parameter in inverse length units.
 """
-struct LongRangeCoulomb{T <: Real, R} <: InteractionKernel 
-    μ::T  # Cutoff parameter in inverse length units
-    regularization::R
+struct LongRangeCoulomb{T <: Real} <: InteractionKernel
+    μ::T
 end
-function LongRangeCoulomb(; μ=0.2/u"Å", regularization=ProbeCharge())
-    LongRangeCoulomb(austrip(μ), regularization)
+LongRangeCoulomb(; μ=0.2/u"Å") = LongRangeCoulomb(austrip(μ))
+LongRangeCoulomb(μ::Quantity) = LongRangeCoulomb(austrip(μ))
+function eval_kernel_fourier(k::LongRangeCoulomb, p)
+    # Fourier transform of erf(μr)/r:  (4π/|p|²) e^{-|p|²/4μ²}.
+    T = eltype(p)
+    p2 = norm2(p)
+    4T(π) / p2 * exp(-p2 / (4 * T(k.μ)^2))
 end
-function eval_kernel_fourier(k::LongRangeCoulomb, Gsq::T) where {T}
-    (4T(π) / Gsq) * exp(-Gsq / (4 * T(k.μ)^2))
-end
-function eval_probe_charge_integral(k::LongRangeCoulomb, α::T) where {T}
+function compute_probe_charge_integral(k::LongRangeCoulomb, α::T) where {T}
     8T(π)^2 * sqrt(T(π) / (α + 1/(4 * T(k.μ)^2)))
 end
-function _compute_kernel_fourier(k::LongRangeCoulomb, basis, qpt, q)
-    _compute_kernel_fourier(k, k.regularization, basis, qpt, q)
-end
-
-
-#
-# Evaluation of interaction kernels
-#
-
-@doc raw"""
-Returns the Fourier-space Coulomb kernel for momentum transfer `q`,
-evaluated only on the spherical cutoff |G+q|² < 2Ecut (not the full cubic FFT grid).
-
-In the most simple case this is essentially 4π/(G+q)².
-
-!!! note "Gamma-point only"
-    Currently only works for single k-point calculations (Gamma-only).
-    For general k-points, a q-dependent basis would be needed.
-
-## Arguments
-- `basis::PlaneWaveBasis`: Plane-wave basis defining the grid
-- `q`: Momentum transfer vector in fractional coordinates
-- `kernel::InteractionKernel`: The physical operator defining the electron-electron interaction 
-
-## Returns
-Vector of Coulomb kernel values for each G-vector in the spherical cutoff.
-"""
-function compute_kernel_fourier(kernel::InteractionKernel, basis::PlaneWaveBasis{T};
-                                q=zero(Vec3{T})) where {T}
-    is_gamma_only = all(iszero(kpt.coordinate) for kpt in basis.kpoints)
-    if !is_gamma_only
-        throw(ArgumentError("Currently only Gamma-point calculations are supported in " *
-                            "compute_kernel_fourier, respectively Hartree-Fock and " *
-                            "calculations involving exact exchange."))
-    end
-    if mpi_nprocs(basis.comm_kpts) > 1
-        error("MPI parallelisation not yet supported for coulomb kernel")
-    end
-    @assert iszero(q)
-
-    # currently only works for Gamma-only (need correct q-point otherwise)
-    qpt = basis.kpoints[1] 
-    kernel_fourier =  _compute_kernel_fourier(kernel, basis, qpt, q)
-
-    # TODO: if q=0, symmetrize Fourier coeffs to have real iFFT 
-
-    to_device(basis.architecture, kernel_fourier)
-end
 
 
 """
-Spherically truncated Coulomb interaction: θ(Rcut-r)/r
-If Rcut is nothing, it uses `Rcut = cbrt(3Ω / (4π))` where `Ω` is the unit cell volume.
+Spherically truncated Coulomb interaction ``θ(R_\\text{cut}-r)/r`` (finite at ``p=0``).
+If `Rcut` is `nothing` it defaults to ``R_\\text{cut} = \\sqrt[3]{3Ω/4π}`` with `Ω` the unit-cell
+volume (resolved once per basis).
 
 ## References
 - [J. Spencer, A. Alavi. Phys. Rev. B **77**, 193110 (2008)](https://doi.org/10.1103/PhysRevB.77.193110)
 """
 @kwdef struct SphericallyTruncatedCoulomb{T} <: InteractionKernel
     Rcut::T = nothing
-end   
-function eval_kernel_fourier(k::SphericallyTruncatedCoulomb, Gsq::T) where {T}
-    4T(π) / Gsq * (1 - cos(T(k.Rcut) * sqrt(Gsq)))
 end
-function _compute_kernel_fourier(k::SphericallyTruncatedCoulomb, basis, qpt, q)
-    # TODO: This is a bit hackish as the parameter needs 
-    #       to be re-computed every kernel evaluation. 
-    Ω = basis.model.unit_cell_volume  
-    Rcut = @something k.Rcut cbrt(3Ω/(4π))
-    kRcut = SphericallyTruncatedCoulomb(Rcut)
-
-    # Use ReplaceSingularity regularisation to explicitly set as the G==0
-    # component the exact limit of the kernel for G->0
-    _compute_kernel_fourier(kRcut, ReplaceSingularity(2π*Rcut^2), basis, qpt, q)
+# sin(√v)/√v = sinc(√v), evaluated as a function of v = x² so it stays differentiable at v=0
+# (the elementary form's √v is not): Taylor series near 0, direct form away from it.
+function sinc_sqrt(v)
+    abs(v) < oftype(v, 1//64) && return evalpoly(v, (1//1, -1//6, 1//120, -1//5040, 1//362880))
+    s = sqrt(v)
+    sin(s) / s
+end
+function eval_kernel_fourier(k::SphericallyTruncatedCoulomb, p)
+    # Fourier transform of θ(R-r)/r:  (4π/|p|²)(1 - cos(R|p|)) = 2π R² sinc(R|p|/2)²
+    # (using 1 - cos x = 2 sin²(x/2)), with p=0 value 2π R².
+    T = eltype(p)
+    R = T(k.Rcut)
+    w = norm2(p)
+    2T(π) * R^2 * sinc_sqrt(R^2 * w / 4)^2
+end
+function eval_kernel_fourier(k::SphericallyTruncatedCoulomb, basis::PlaneWaveBasis; qpt)
+    Rcut = @something k.Rcut cbrt(3 * basis.model.unit_cell_volume / (4π))
+    kresolved = SphericallyTruncatedCoulomb(Rcut)
+    map(p -> eval_kernel_fourier(kresolved, p), Gplusk_vectors_cart(basis, qpt))
 end
 
 
 """
-Truncate Coulomb interaction at the Wigner-Seitz cell boundary.
+Coulomb interaction ``1/r`` truncated at the Wigner–Seitz cell boundary.
 
-Computational approach: We expand 1/r = erfc(ωr)/r + erf(ωr)/r and chose ω such that the
-short-range part erfc(ωr)/r is virtually unaffected by the truncation.
+We split ``1/r = \\mathrm{erfc}(ωr)/r + \\mathrm{erf}(ωr)/r``. The short-range part is exactly
+[`ShortRangeCoulomb`](@ref)`(ω)` and is added analytically (replacing the Brillouin zone by all
+space, valid since ``\\mathrm{erfc}(ω R_\\text{in})`` is tiny for the inradius ``R_\\text{in}``).
+The long-range part ``\\mathrm{erf}(ωr)/r``, restricted to the Wigner–Seitz cell, is obtained by
+FFT of its real-space samples. The range separation `ω` is fixed by balancing the truncation
+error ``\\mathrm{erfc}(ω R_\\text{in})`` of the short-range part against the FFT-grid
+representability error ``e^{-G_\\text{Nyquist}/ω}`` of the long-range part.
 
-First the inradius R_in of the Wigner-Seitz cell is calculated.
-
-By chosing ω = sqrt(-log(ε))/R_in we can be sure that erfc(ω*R_in) < ε.
-
-At the same time the long-range part needs to be representable on the Fourier grid
-which implies G_Nyquist >= -2 log(ε) / R_in (see Appendix A.1 in reference).
-Hence we simply define ε through the given grid via ε = exp(-G_Nyquist*R_in/2).
-
-The short-range contribution is then given by the analytical expression
-4π/G^2*(1-exp(-G^2/(4ω^2)))
-while the long-range contributiom is obtained through an FFT of the real-space function
-erf(ωr)/r 
-to reciprocal space.
-
-# TODO: Evaluating erf(ωr)/r on a discrete real-space grid and performing 
-# an FFT introduces aliasing errors, as the function is not strictly band-limited.
-# For details on this discretization error, see Appendix A.1 of the Reference below.
+This kernel depends on the grid (through `ω`) and therefore only defines the batch method.
 
 ## Reference
 - [R. Sundararaman, T. A. Arias. Phys. Rev. B **87**, 165122 (2013)](https://doi.org/10.1103/PhysRevB.87.165122)
 """
-struct WignerSeitzTruncatedCoulomb <: InteractionKernel end 
-@views function _compute_kernel_fourier(k::WignerSeitzTruncatedCoulomb, 
-                                        basis::PlaneWaveBasis{T}, qpt, q) where {T}
+struct WignerSeitzTruncatedCoulomb <: InteractionKernel end
+# No pointwise method: WignerSeitz has no closed-form k̂(p), so it uses the generic error fallback.
+# TODO: a basis-free 'slow Fourier transform' pointwise method (issue #1322).
+@views function eval_kernel_fourier(::WignerSeitzTruncatedCoulomb,
+                                    basis::PlaneWaveBasis{T}; qpt) where {T}
     model = basis.model
-    NG = length(qpt.G_vectors)
-    kernel_fourier = zeros(T, NG)
     q = qpt.coordinate
-    
-    # === Calculate inradius R_in of Wigner-Seitz cell ===
-    
-    # R_in is largest possible R_in = (sum_i n_i * a*i) / 2 with integers n_i 
-    # and |R_in| <= a_min where a_min is the length of the smallest lattice vector. 
-    # The inequality allows to restrict n_i by exploiting Cauchy-Schwarz, leading 
-    # to |n_i| <= a_min * |b_i| / 2π where b_i are reciprocal lattice vectors.
 
+    # === Inradius R_in of the Wigner–Seitz cell ===
+    # R_in = min over nonzero lattice vectors R of |R|/2 (distance to the perpendicular bisector
+    # plane). Cauchy–Schwarz bounds the integer coefficients by |n_i| ≤ a_min |b_i| / 2π.
     L_min = minimum(norm, eachcol(model.lattice))
     nx, ny, nz = estimate_integer_lattice_bounds(model.lattice, L_min)
-
-    # finally compute R_in
     R_in = T(Inf)
-    for ix in -nx:nx, iy in -ny:ny, iz in -nz:nz 
+    for ix in -nx:nx, iy in -ny:ny, iz in -nz:nz
         ix == 0 && iy == 0 && iz == 0 && continue
-        R = model.lattice * [ix, iy, iz]
-        d = norm(R) / 2 # distance from origin to perpendicular bisector plane = |R|/2
-        R_in = min(R_in, d)
+        R_in = min(R_in, norm(model.lattice * [ix, iy, iz]) / 2)
     end
-    
-    # Nyquist frequency of FFT grid
-    G_Nyquist = minimum(basis.fft_size[d] / 2 * norm(model.recip_lattice[:, d]) for d in 1:3) 
 
-    ε = exp(-0.5*G_Nyquist*R_in)  # required: G_Nyquist >= -2*log(ε)/R_in (Appendix A.1 in paper)
-    ω = sqrt(-log(ε)) / R_in  # range separation parameter
-    ε_actual = erfc(ω*R_in)
+    # Range separation ω, balancing the two errors described in the docstring.
+    G_Nyquist = minimum(basis.fft_size[d] / 2 * norm(model.recip_lattice[:, d]) for d = 1:3)
+    ε = exp(-T(1)/2 * G_Nyquist * R_in)
+    ω = sqrt(-log(ε)) / R_in
+    ε_actual = erfc(ω * R_in)
     if ε_actual > 1e-8
-        @warn "Coarse grid for Wigner-Seitz truncation. Effective error: $ε_actual"
+        @warn "Coarse grid for Wigner–Seitz truncation. Effective error: $ε_actual"
     end
 
-    # == FFT of long-range term erf(ωr)/r restricted to Wigner-Seitz cell ===
-
-    r_vectors = DFTK.r_vectors(basis)
+    # === Long-range term erf(ωr)/r restricted to the Wigner–Seitz cell, via FFT ===
+    # TODO: sampling erf(ωr)/r on the real-space grid and FFTing it introduces aliasing (the
+    #       function is not band-limited); a finer real-space grid would reduce it. See Appendix
+    #       A.1 of the reference.
+    erfder(x) = 2 / sqrt(T(π)) * exp(-x^2)  # d/dx erf(x)
+    rvecs = r_vectors(basis)
     V_lr_real = zeros(Complex{T}, basis.fft_size...)
     for idx in CartesianIndices(V_lr_real)
-        r_frac = r_vectors[idx]
-
-        # Map point to the [-0.5, 0.5)³ fractional cell (Minimum Image Convention)
-        r_centered = r_frac .- round.(r_frac) 
-        r_cart = model.lattice * r_centered
-        d_min = norm(r_cart)
-
-        # For non-orthorhombic cells, the fractional Minimum Image Convention
-        # does NOT guarantee the shortest Cartesian distance. A point in a
-        # neighboring fractional cell could be physically closer. We exhaustively
-        # check all nearby cells (bounds nx,ny,nz) to find the absolute minimum.
-        for dx in -nx:nx, dy in -ny:ny, dz in -nz:nz 
-            dx == 0 && dy == 0 && dz == 0 && continue 
-            r_shifted = r_centered - T[dx, dy, dz]
-            d = norm(model.lattice * r_shifted)
-            d_min = min(d_min, d)
+        r_frac = rvecs[idx]
+        # Shortest Cartesian distance to a lattice point (minimum image). The fractional
+        # minimum-image convention is not enough for non-orthorhombic cells, so we also scan
+        # neighboring cells to find the true minimum.
+        r_centered = r_frac .- round.(r_frac)
+        d_min = norm(model.lattice * r_centered)
+        for dx in -nx:nx, dy in -ny:ny, dz in -nz:nz
+            dx == 0 && dy == 0 && dz == 0 && continue
+            d_min = min(d_min, norm(model.lattice * (r_centered - T[dx, dy, dz])))
         end
-
-        # Evaluate erf(ωr)/r 
-        if d_min > sqrt(eps(T))
-            V_lr_real[idx] = erf(ω * d_min) / d_min
-        else
-            V_lr_real[idx] = 2*ω / sqrt(T(π))
-        end
-
-        # Add the Bloch phase factor for q-point evaluation
-        V_lr_real[idx] *= exp(-im * 2*T(π) * dot(q, r_frac)) # add phase e^{-2πiqr}
+        # erf(ω d)/d, with the AD-clean d→0 limit 2ω/√π supplied by divided_difference
+        V_lr_real[idx]  = ω * divided_difference(erf, erfder, ω * d_min, zero(T))
+        V_lr_real[idx] *= cis2pi(-dot(q, r_frac))  # Bloch phase e^{-2πi q·r}
     end
-    kernel_fourier_lr = real.(fft(basis, qpt, V_lr_real))
-    kernel_fourier_lr .*= sqrt(model.unit_cell_volume)
-    
-    # === Analytic short-range term + long-range term ===
+    kernel_fourier_lr = real.(fft(basis, qpt, V_lr_real)) .* sqrt(model.unit_cell_volume)
 
+    # === Add the analytic short-range term erfc(ωr)/r = ShortRangeCoulomb(ω) ===
+    short_range = ShortRangeCoulomb(ω)
+    kernel_fourier = zeros(T, length(qpt.G_vectors))
     for (iG, G) in enumerate(to_cpu(qpt.G_vectors))
-        G_cart = model.recip_lattice * (G+q)
-        Gnorm2 = sum(abs2, G_cart)
-        Rcut = cbrt(basis.model.unit_cell_volume*3/4/π)
-        if !(iG==1 && iszero(q))  # singularity
-            kernel_fourier[iG] = 4T(π) / Gnorm2 * (1 - exp(-Gnorm2/(4ω^2))) + kernel_fourier_lr[iG]
-        else
-            kernel_fourier[iG] = T(π)/ω^2 + kernel_fourier_lr[iG]
-        end
+        p = model.recip_lattice * (G + q)
+        kernel_fourier[iG] = eval_kernel_fourier(short_range, p) + kernel_fourier_lr[iG]
     end
     kernel_fourier
 end
 
 
 """
-Probe charge Ewald method for treating the Coulomb singularity.
+Replace the ``G+q=0`` component of `inner_kernel` by `replacement`, leaving every other component
+untouched. Use for genuinely singular kernels ([`BareCoulomb`](@ref), [`LongRangeCoulomb`](@ref));
+kernels with a finite ``p=0`` limit already return the correct value there.
 
-Regularize the G+q=0 component of the kernel by adding and subtracting the potential
-generated by an array of unit Gaussian charges of width `sqrt(2α)` placed at the
-grid points of the supercell with the exception to the origin itself. Here `α` should be
-chosen as a localised charge that is well-representable in the chosen plane-wave basis.
-We take `α = π²/Ecut` (VASP default). Convergence is `O(1/L³) = O(1 / Nk)` with `Nk`
-the number of k-points.
+For [`BareCoulomb`](@ref) with `replacement = 0` this leads to slow ``O(1/∛N_k)`` convergence with
+the number of k-points ``N_k``.
+"""
+struct ReplaceSingularity{K <: InteractionKernel, R} <: InteractionKernel
+    inner_kernel::K
+    replacement::R
+end
+function eval_kernel_fourier(k::ReplaceSingularity, p)
+    iszero(p) ? eltype(p)(k.replacement) : eval_kernel_fourier(k.inner_kernel, p)
+end
 
-The rationale of this method is that these artificial charges screen the Coulomb interactions
-between the unit cell with the origin and the displaced unit cells of the supercell due to
-the k-point sampling, such that the G+q=0 term only has contributions from these Gaussian
-charges, which can be computed using an Ewald sum.
+
+@doc raw"""
+Probe-charge (Gygi–Baldereschi) treatment of the ``G+q=0`` singularity of `inner_kernel`.
+
+Regularize the ``G+q=0`` component by adding and subtracting the potential generated by an array
+of unit Gaussian charges of width `sqrt(2α)` placed at the supercell grid points (except the
+origin). `α` should give a localized charge well-representable in the plane-wave basis; we default
+to `α = π²/Ecut` (VASP default). Convergence is ``O(1/L³) = O(1/N_k)`` with `N_k` the number of
+k-points. Only usable with kernels implementing `compute_probe_charge_integral`
+([`BareCoulomb`](@ref), [`LongRangeCoulomb`](@ref)).
 
 ## References
 - [S. Massidda, M. Posternak, A. Baldereschi. Phys. Rev. B **48**, 5058 (1993)](https://doi.org/10.1103/PhysRevB.48.5058)
 """
-@kwdef struct ProbeCharge
-    α::Union{Float64, Nothing} = nothing  # Width of the probe charge
+struct ProbeCharge{K <: InteractionKernel} <: InteractionKernel
+    inner_kernel::K
+    α::Union{Float64, Nothing}
 end
-@views function _compute_kernel_fourier(kernel, regularization::ProbeCharge,
-                                        basis::PlaneWaveBasis{T}, qpt, q) where {T}
-    # Default value well-tested in VASP; ensures that e^(-α*G²) is localized
-    # charge with full support on G grid
-    α::T = @something regularization.α   π^2/basis.Ecut
+ProbeCharge(inner_kernel::InteractionKernel=BareCoulomb(); α=nothing) =
+    ProbeCharge(inner_kernel, α)
+@views function eval_kernel_fourier(k::ProbeCharge, basis::PlaneWaveBasis{T}; qpt) where {T}
+    # Default well-tested in VASP; ensures e^{-α G²} is a localized charge with full support
+    # on the G grid.
+    α::T = @something k.α π^2 / basis.Ecut
 
-    Ω = basis.model.unit_cell_volume  # volume of unit cell 
-    Gpq = map(Gpq -> sum(abs2, Gpq), Gplusk_vectors_cart(basis, qpt))
+    Gpq2 = norm2.(Gplusk_vectors_cart(basis, qpt))
+    # Raw kernel; its G+q=0 entry may be Inf/NaN and is overwritten below.
+    kernel_fourier = eval_kernel_fourier(k.inner_kernel, basis; qpt)
 
-    # Note: q+G = 0 component is not special-cased, i.e. may be NaN or otherwise wrong
-    kernel_fourier = eval_kernel_fourier.(kernel, Gpq)
-
-    # Potential of Gaussian charges (skipping term at G+q=0)
-    probe_charge_sum = sum((kernel_fourier .* exp.(-α*Gpq))[2:end])
-
-    # Interaction of Gaussian charges with uniform background (i.e. integral of charges)
-    # = 1/Γ ∫_{BZ} kernel(q) e^(-αq²) dq, where the integral is computed by the
-    # eval_probe_charge_integral function.
+    # Potential of the Gaussian charges, skipping the G+q=0 term.
+    probe_charge_sum = sum((kernel_fourier .* exp.(-α .* Gpq2))[2:end])
+    # Interaction of the Gaussian charges with the uniform background,
+    # (1/Γ) ∫_BZ k̂(q) e^{-α q²} dq, with Γ the Brillouin-zone volume.
     Γ = basis.model.recip_cell_volume
-    probe_charge_integral = eval_probe_charge_integral(kernel, α) / Γ
+    probe_charge_integral = compute_probe_charge_integral(k.inner_kernel, α) / Γ
 
     if iszero(qpt.coordinate)
         GPUArraysCore.@allowscalar begin
@@ -339,56 +297,27 @@ end
 end
 
 
-"""
-Simply set the G+q=0 Coulomb kernel component to Gpq_zero_value.
-This is useful for interaction models with an analytic G+q=0 component
-or for testing/comparison purposes.
+@doc raw"""
+Average the Coulomb kernel ``\hat k(G+q)`` over the Brillouin-zone voxel associated with each grid
+point (well suited to highly anisotropic cells). Conceptually the `HFMEANPOT` flag in VASP, using
+improved integration. Only available once `FastGaussQuadrature` is loaded (see
+`ext/DFTKFastGaussQuadratureExt.jl`).
 
-For Coulomb and the case of Gpq_zero_value=0 this leads to slow `O(1/L) = O(1 / ∛(Nk))`
-convergence where `L` is the size of the supercell,`Nk` is the number of k-points.
-"""
-struct ReplaceSingularity{T <: Real}
-    Gpq_zero_value::T
-end
-@views function _compute_kernel_fourier(kernel, regularization::ReplaceSingularity,
-                                        basis::PlaneWaveBasis{T}, qpt, q) where {T}
-    # Compute truncated Coulomb kernel without special-casing singularity at G+q=0 
-    kernel_fourier = map(Gplusk_vectors_cart(basis, qpt)) do Gpq
-        eval_kernel_fourier(kernel, sum(abs2, Gpq))
-    end
-    if iszero(qpt.coordinate)  # Neglect the singularity
-        GPUArraysCore.@allowscalar kernel_fourier[1] = T(regularization.Gpq_zero_value)
-    end
-    kernel_fourier
-end
-
-
-"""
-Calculates the average of the Coulomb kernel K(G+q) over the Brillouin zone voxel associated
-with each grid point. It is particularly well suited for highly anisotropic cells.
-Note that this kernel evaluation strategy only becomes available once the
-`FastGaussQuadrature` module is explicitly loaded.
-
-Since the Coulomb kernel is not necessarily given by ``K(G+q)=1/(G+q)^2`` the 
-following approach is used:
-- G+q=0 (Singularity): Uses an exact mathematical reduction of the volume integral 
-  ``∫ 1/(G+q)^2 dV`` to a smooth surface integral over the voxel faces (surface reduction).
-  Then a high-order Gaussian quadrature is used to calculate ``∫ (K(G+q) - 1/(G+q)^2) dV``.
-- G+q≠0 (Smooth): Uses high-order Gaussian quadrature for ``∫ K(G+q) dV``
-
-It is conceptually equivalent to the HFMEANPOT flag in VASP but uses improved integration
-techniques to calcualte the average in the voxel.
+- At the singularity ``G+q=0`` the ``1/(G+q)²`` part of `inner_kernel` is integrated by an exact
+  volume-to-surface reduction, the remainder by high-order Gauss–Legendre quadrature.
+- Elsewhere the whole kernel is integrated by Gauss–Legendre quadrature.
 
 ## Arguments
-- `N_quadrature_points::Int`: The number of Gauss-Legendre quadrature points used per dimension. 
-  Defaults to 12. For highly anisotropic cells or rigorous Thermodynamic Limit (TDL) extrapolations, 
-    it is advisable to check if higher values (e.g., to 18 or 24) eliminate numerical noise.
+- `n_quadrature_points::Int`: Gauss–Legendre points per dimension (default 12). Increase (18–24)
+  for highly anisotropic cells or rigorous thermodynamic-limit extrapolations.
 
 ## Reference
-J. Chem. Phys. 160, 051101 (2024) (doi.org/10.1063/5.0182729)
+- [T. Schäfer et al. J. Chem. Phys. **160**, 051101 (2024)](https://doi.org/10.1063/5.0182729)
 """
-@kwdef struct VoxelAveraged
-    n_quadrature_points = 12
+struct VoxelAverage{K <: InteractionKernel} <: InteractionKernel
+    inner_kernel::K
+    n_quadrature_points::Int
 end
-
-# For the implementation see DFTKFastGaussQuadratureExt.jl
+VoxelAverage(inner_kernel::InteractionKernel=BareCoulomb(); n_quadrature_points=12) =
+    VoxelAverage(inner_kernel, n_quadrature_points)
+# eval_kernel_fourier(::VoxelAverage, basis, qpt) is implemented in DFTKFastGaussQuadratureExt.

--- a/src/standard_models.jl
+++ b/src/standard_models.jl
@@ -193,7 +193,8 @@ Build an Hartree-Fock model from the specified atoms.
          necks in the code.
 """
 function model_HF(system::AbstractSystem; pseudopotentials,
-                  exx_kernel::InteractionKernel=Coulomb(), extra_terms=[], kwargs...)
+                  exx_kernel::InteractionKernel=ProbeCharge(BareCoulomb()),
+                  extra_terms=[], kwargs...)
     # Note: We are deliberately enforcing the user to specify pseudopotentials here.
     # See the implementation of model_atomic for a rationale why
     #
@@ -202,7 +203,8 @@ function model_HF(system::AbstractSystem; pseudopotentials,
 end
 function model_HF(lattice::AbstractMatrix, atoms::Vector{<:Element},
                   positions::Vector{<:AbstractVector};
-                  exx_kernel::InteractionKernel=Coulomb(), extra_terms=[], kwargs...)
+                  exx_kernel::InteractionKernel=ProbeCharge(BareCoulomb()),
+                  extra_terms=[], kwargs...)
     extra_terms=[Hartree(), ExactExchange(; kernel=exx_kernel), extra_terms...]
     model_atomic(lattice, atoms, positions; model_name="HF", extra_terms, kwargs...)
 end
@@ -273,7 +275,7 @@ term as well as the following:
 - `exx_fraction`: Custom exact exchange / screened Coulomb fraction. If not specified,
   the Libxc default will be used.
 - `exx_kernel`: The type of [`InteractionKernel`](@ref) to employ. If not specified,
-  the function will query Libxc and employ a [`Coulomb`](@ref) or [`ShortRangeCoulomb`](@ref)
+  the function will query Libxc and employ a [`BareCoulomb`](@ref) or [`ShortRangeCoulomb`](@ref)
   kernel with the range-separation parameter `μ`.
 - `μ`: Range-separation parameter. If not specified, Libxc default is used.
   Ignored for global hybrids or if `exx_kernel` is provided.
@@ -294,7 +296,7 @@ function parse_hybrid_parameters_(; exx_sr=nothing, exx_lr=nothing,
                                     range_separation_parameter=nothing)
     if isnothing(range_separation_kernel)
         @assert exx_lr == exx_sr
-        return (; scaling_factor=exx_sr, kernel=Coulomb())
+        return (; scaling_factor=exx_sr, kernel=ProbeCharge(BareCoulomb()))
     elseif range_separation_kernel == :erf
         if exx_lr > 0
             error("Range separation with non-zero long-range exact exchange not yet available.")

--- a/src/terms/exact_exchange.jl
+++ b/src/terms/exact_exchange.jl
@@ -36,7 +36,7 @@ function TermExactExchange(basis::PlaneWaveBasis{T}, scaling_factor, kernel) whe
         error("MPI parallelisation not yet supported for the exact-exchange kernel.")
 
     fac::T = scaling_factor
-    kernel_fourier = eval_kernel_fourier(kernel, basis; qpt=basis.kpoints[1])
+    kernel_fourier = eval_kernel_fourier(kernel, basis)  # cube grid, q=0 (Gamma only)
     all(isfinite, kernel_fourier) || error(
         "The interaction kernel has a non-finite G+q=0 component: a divergent kernel such as " *
         "BareCoulomb or LongRangeCoulomb must be wrapped in a singularity treatment, " *
@@ -179,7 +179,7 @@ function exx_energy_only(basis::PlaneWaveBasis{T}, kpt, interaction_kernel, ψk_
         for (m, ψmk_real) in enumerate(eachslice(ψk_real, dims=4))
             m > n && continue
             ρmn_real = conj(ψmk_real) .* ψnk_real
-            ρmn_fourier = fft(basis, kpt, ρmn_real) # actually we need a q-point here
+            ρmn_fourier = fft(basis, ρmn_real)  # pair density on the full (cube) density grid
 
             # Exact exchange is quadratic in occupations but linear in spin,
             # hence we need to undo the fact that in DFTK for non-spin-polarized calcuations

--- a/src/terms/exact_exchange.jl
+++ b/src/terms/exact_exchange.jl
@@ -7,8 +7,8 @@ Term for (possibly screened) Hartree-Fock exact exchange energy of the form
 -1/2 ∑_{nm} f_n f_m ∫∫ ψ_n^*(r)ψ_m^*(r') kernel(r, r')  ψ_n(r')ψ_m(r) dr dr'
 ```
 where the `kernel` keyword argument is an [`InteractionKernel`](@ref) , typically
-- the untruncated, unscreened [`Coulomb`](@ref) kernel `G(r, r') = 1/|r - r'|` for
-  Hartree-Fock exact exchange, by default some form of regularisation is applied,
+- the untruncated, unscreened [`BareCoulomb`](@ref) kernel `G(r, r') = 1/|r - r'|` for
+  Hartree-Fock exact exchange, wrapped in some form of singularity treatment,
   see e.g. [`ProbeCharge`](@ref).
 - [`SphericallyTruncatedCoulomb`](@ref) and 
 - [`WignerSeitzTruncatedCoulomb`](@ref) for a Coulomb kernels with truncated range, 
@@ -18,7 +18,7 @@ where the `kernel` keyword argument is an [`InteractionKernel`](@ref) , typicall
 """
 @kwdef struct ExactExchange
     scaling_factor::Real = 1.0
-    kernel = Coulomb()
+    kernel = ProbeCharge(BareCoulomb())
 end
 (ex::ExactExchange)(basis) = TermExactExchange(basis, ex.scaling_factor, ex.kernel)
 
@@ -27,9 +27,21 @@ struct TermExactExchange <: Term
     interaction_kernel::AbstractArray  # kernel values in Fourier space
 end
 function TermExactExchange(basis::PlaneWaveBasis{T}, scaling_factor, kernel) where {T}
-    # TODO: we need this for every q-point
+    # TODO: we need the interaction kernel for every q-point; currently only Gamma is supported.
+    is_gamma_only = all(iszero(kpt.coordinate) for kpt in basis.kpoints)
+    is_gamma_only || throw(ArgumentError(
+        "Exact exchange (and Hartree-Fock / hybrid functionals) currently only supports " *
+        "Gamma-point calculations."))
+    mpi_nprocs(basis.comm_kpts) == 1 ||
+        error("MPI parallelisation not yet supported for the exact-exchange kernel.")
+
     fac::T = scaling_factor
-    interaction_kernel = fac .* compute_kernel_fourier(kernel, basis)
+    kernel_fourier = eval_kernel_fourier(kernel, basis; qpt=basis.kpoints[1])
+    all(isfinite, kernel_fourier) || error(
+        "The interaction kernel has a non-finite G+q=0 component: a divergent kernel such as " *
+        "BareCoulomb or LongRangeCoulomb must be wrapped in a singularity treatment, " *
+        "e.g. ProbeCharge(BareCoulomb()).")
+    interaction_kernel = to_device(basis.architecture, fac .* kernel_fourier)
     TermExactExchange(fac, interaction_kernel)
 end
 

--- a/src/terms/operators.jl
+++ b/src/terms/operators.jl
@@ -195,10 +195,11 @@ function apply!(Hψ, op::ExchangeOperator, ψ)
         x_real   = conj(ψnk_real) .* ψ.real
         # TODO Some symmetrisation of x_real might be needed here ...
 
-        # Compute integral by Poisson solve
-        x_four  = fft(op.basis, op.kpoint, x_real) # actually we need q-point here
+        # Compute integral by Poisson solve on the full (cube) density grid, where the pair
+        # density conj(ψn)·ψ lives (it has content beyond the orbital sphere).
+        x_four  = fft(op.basis, x_real)
         Vx_four = x_four .* op.interaction_kernel
-        Vx_real = ifft(op.basis, op.kpoint, Vx_four) # actually we need q-point here
+        Vx_real = ifft(op.basis, Vx_four)
 
         # Exact exchange is quadratic in occupations but linear in spin,
         # hence we need to undo the fact that in DFTK for non-spin-polarized calcuations

--- a/test/coulomb.jl
+++ b/test/coulomb.jl
@@ -11,7 +11,7 @@
     model  = model_DFT(silicon.lattice, [Si, Si], silicon.positions; functionals=PBE())
     basis  = PlaneWaveBasis(model; Ecut=10, kgrid=(1, 1, 1))
     scfres = self_consistent_field(basis; tol=1e-10, callback=identity)
-    kf(kernel) = eval_kernel_fourier(kernel, basis; qpt=only(basis.kpoints))
+    kf(kernel) = eval_kernel_fourier(kernel, basis)
 
     n_occ = 4
     kpt  = basis.kpoints[1]
@@ -25,14 +25,14 @@
     k_probe = kf(ProbeCharge(BareCoulomb()))
     @testset "Coulomb with ProbeCharge" begin
         E_probe = exx_energy_only(basis, kpt, k_probe, ψk_real, occk)
-        E_ref = -2.3383063575660987
+        E_ref = -2.3383182267715146
         @test abs(E_ref - E_probe) < 1e-6
     end
 
     @testset "Coulomb with ReplaceSingularity" begin
         k_neglect = kf(ReplaceSingularity(BareCoulomb(), 0.0))
         E_neglect = exx_energy_only(basis, kpt, k_neglect, ψk_real, occk)
-        E_ref = -0.7349457693125514
+        E_ref = -0.7349576391651506
         @test abs(E_ref - E_neglect) < 1e-6
         @test norm(k_neglect[2:end] - k_probe[2:end]) < 1e-6
     end
@@ -40,14 +40,14 @@
     @testset "LongRangeCoulomb with ProbeCharge" begin
         k_lr = kf(ProbeCharge(LongRangeCoulomb(0.1)))
         E_lr = exx_energy_only(basis, kpt, k_lr, ψk_real, occk)
-        E_ref = -0.44269774759135383
+        E_ref = -0.44269774759135283
         @test abs(E_ref - E_lr) < 1e-6
     end
 
     @testset "ShortRangeCoulomb" begin
         k_sr = kf(ShortRangeCoulomb(0.1))
         E_sr = exx_energy_only(basis, kpt, k_sr, ψk_real, occk)
-        E_ref = -5.384688524633953
+        E_ref = -5.384700394476406
         @test abs(E_ref - E_sr) < 1e-6
     end
 
@@ -67,7 +67,7 @@
     @testset "SphericallyTruncatedCoulomb" begin
         k_strunc = kf(SphericallyTruncatedCoulomb())
         E_strunc = exx_energy_only(basis, kpt, k_strunc, ψk_real, occk)
-        E_ref = -2.360166200435632
+        E_ref = -2.360170330350145
         @test abs(E_ref - E_strunc) < 1e-6
 
         # TODO: Test this gives a spherically truncated function.
@@ -76,14 +76,14 @@
     @testset "WignerSeitzTruncatedCoulomb" begin
         k_wstrunc = kf(WignerSeitzTruncatedCoulomb())
         E_wstrunc = exx_energy_only(basis, kpt, k_wstrunc, ψk_real, occk)
-        E_ref = -2.3456813523805415
+        E_ref = -2.3456932201052796
         @test abs(E_ref - E_wstrunc) < 1e-6
     end
 
     @testset "VoxelAverage" begin
         k_voxavg = kf(VoxelAverage(BareCoulomb()))
         E_voxavg = exx_energy_only(basis, kpt, k_voxavg, ψk_real, occk)
-        E_ref = -2.249032672407079
+        E_ref = -2.249044591526691
         @test abs(E_ref - E_voxavg) < 1e-6
     end
 end
@@ -121,7 +121,7 @@ end
         # Ecut=50 is ok because the lattice is ill-conditioned
     end
 
-    kf(b) = eval_kernel_fourier(WignerSeitzTruncatedCoulomb(), b; qpt=only(b.kpoints))
+    kf(b) = eval_kernel_fourier(WignerSeitzTruncatedCoulomb(), b)
     @testset "WignerSeitzTruncatedCoulomb" begin
         # TODO: These tests are not super useful, they mainly enable refactoring; they
         #       should really be replaced by tests of properties of WignerSeitzTruncatedCoulomb
@@ -131,16 +131,16 @@ end
                                 4.320510620666685, 1.71839014451522]
 
         k_wstrunc = kf(basis_Ga)
-        @test k_wstrunc[1:5] ≈ [133.48675852141807, 12.54391563903425, 1.0201128711380307,
-                                1.0201128711380307, 12.54391563903425]
+        @test k_wstrunc[1:5] ≈ [133.48675852141807, 12.543915639034248, 1.0201128711380303,
+                                1.4993914735536529, 0.2032925438414927]
 
         k_wstrunc = kf(basis_Sb)
-        @test k_wstrunc[1:5] ≈ [133.5869934680494, 17.875585010939407, 3.0560733842605785,
-                                1.6670099917149919, 1.6670099917149919] atol=1e-6
+        @test k_wstrunc[1:5] ≈ [133.586993467607, 17.87558501104982, 3.056073383974545,
+                                1.6670099918317942, 0.9065961832826208] atol=1e-6
 
         k_wstrunc = kf(basis_illcond)
-        @test k_wstrunc[1:5] ≈ [0.6835202703428708, 0.10574224010892719, 0.10574224010892719,
-                                0.363208874652315, 0.10081120609383883] atol=1e-6
+        @test k_wstrunc[1:5] ≈ [0.6835202703428708, 0.003317275153646196, 8.838678696668954e-5,
+                                0.00024225236624065088, 5.8059844858737624e-5] atol=1e-6
     end
 end
 
@@ -155,7 +155,7 @@ end
     model  = model_DFT(silicon.lattice, [Si, Si], silicon.positions; functionals=PBE())
     basis  = PlaneWaveBasis(model; Ecut=10, kgrid=(1, 1, 1))
     scfres = self_consistent_field(basis; tol=1e-10, callback=identity)
-    kf(kernel) = eval_kernel_fourier(kernel, basis; qpt=only(basis.kpoints))
+    kf(kernel) = eval_kernel_fourier(kernel, basis)
 
     n_occ = 4
     kpt  = basis.kpoints[1]
@@ -210,7 +210,7 @@ end
         ψk_real ./= sqrt(sum(abs2, ψk_real) * basis.dvol)  # normalise ψk
         occk = [2.0]
 
-        kernel_values = eval_kernel_fourier(kernel, basis; qpt=basis.kpoints[1])
+        kernel_values = eval_kernel_fourier(kernel, basis)
         exx_energy_only(basis, kpt, kernel_values, ψk_real, occk)
     end
 

--- a/test/coulomb.jl
+++ b/test/coulomb.jl
@@ -1,6 +1,6 @@
 @testitem "Reference energy tests of Coulomb kernels" tags=[:exx,:dont_test_mpi] setup=[TestCases] begin
     using DFTK
-    using DFTK: exx_energy_only, compute_kernel_fourier
+    using DFTK: exx_energy_only, eval_kernel_fourier
     using FastGaussQuadrature
     using LinearAlgebra
     using .TestCases: silicon
@@ -11,6 +11,7 @@
     model  = model_DFT(silicon.lattice, [Si, Si], silicon.positions; functionals=PBE())
     basis  = PlaneWaveBasis(model; Ecut=10, kgrid=(1, 1, 1))
     scfres = self_consistent_field(basis; tol=1e-10, callback=identity)
+    kf(kernel) = eval_kernel_fourier(kernel, basis; qpt=only(basis.kpoints))
 
     n_occ = 4
     kpt  = basis.kpoints[1]
@@ -21,7 +22,7 @@
         ifft!(ψk_real[:, :, :, n], basis, kpt, ψk[:, n])
     end
 
-    k_probe = compute_kernel_fourier(Coulomb(ProbeCharge()), basis)
+    k_probe = kf(ProbeCharge(BareCoulomb()))
     @testset "Coulomb with ProbeCharge" begin
         E_probe = exx_energy_only(basis, kpt, k_probe, ψk_real, occk)
         E_ref = -2.3383063575660987
@@ -29,7 +30,7 @@
     end
 
     @testset "Coulomb with ReplaceSingularity" begin
-        k_neglect = compute_kernel_fourier(Coulomb(ReplaceSingularity(0.0)), basis)
+        k_neglect = kf(ReplaceSingularity(BareCoulomb(), 0.0))
         E_neglect = exx_energy_only(basis, kpt, k_neglect, ψk_real, occk)
         E_ref = -0.7349457693125514
         @test abs(E_ref - E_neglect) < 1e-6
@@ -37,22 +38,22 @@
     end
 
     @testset "LongRangeCoulomb with ProbeCharge" begin
-        k_lr = compute_kernel_fourier(LongRangeCoulomb(0.1, ProbeCharge()), basis)
+        k_lr = kf(ProbeCharge(LongRangeCoulomb(0.1)))
         E_lr = exx_energy_only(basis, kpt, k_lr, ψk_real, occk)
         E_ref = -0.44269774759135383
         @test abs(E_ref - E_lr) < 1e-6
     end
 
     @testset "ShortRangeCoulomb" begin
-        k_sr = compute_kernel_fourier(ShortRangeCoulomb(0.1), basis)
+        k_sr = kf(ShortRangeCoulomb(0.1))
         E_sr = exx_energy_only(basis, kpt, k_sr, ψk_real, occk)
         E_ref = -5.384688524633953
         @test abs(E_ref - E_sr) < 1e-6
     end
 
     @testset "ShortRangeCoulomb plus LongRangeCoulomb is coulomb" begin
-        k_lr  = compute_kernel_fourier(LongRangeCoulomb(0.1, ProbeCharge()), basis)
-        k_sr  = compute_kernel_fourier(ShortRangeCoulomb(0.1), basis)
+        k_lr  = kf(ProbeCharge(LongRangeCoulomb(0.1)))
+        k_sr  = kf(ShortRangeCoulomb(0.1))
         k_sum = k_lr + k_sr
 
         # Note: The G=0 component does not match up, because in short-range Coulomb
@@ -64,7 +65,7 @@
     end
 
     @testset "SphericallyTruncatedCoulomb" begin
-        k_strunc = compute_kernel_fourier(SphericallyTruncatedCoulomb(), basis)
+        k_strunc = kf(SphericallyTruncatedCoulomb())
         E_strunc = exx_energy_only(basis, kpt, k_strunc, ψk_real, occk)
         E_ref = -2.360166200435632
         @test abs(E_ref - E_strunc) < 1e-6
@@ -73,14 +74,14 @@
     end
 
     @testset "WignerSeitzTruncatedCoulomb" begin
-        k_wstrunc = compute_kernel_fourier(WignerSeitzTruncatedCoulomb(), basis)
+        k_wstrunc = kf(WignerSeitzTruncatedCoulomb())
         E_wstrunc = exx_energy_only(basis, kpt, k_wstrunc, ψk_real, occk)
         E_ref = -2.3456813523805415
         @test abs(E_ref - E_wstrunc) < 1e-6
     end
 
-    @testset "VoxelAveraged" begin
-        k_voxavg = compute_kernel_fourier(Coulomb(VoxelAveraged()), basis)
+    @testset "VoxelAverage" begin
+        k_voxavg = kf(VoxelAverage(BareCoulomb()))
         E_voxavg = exx_energy_only(basis, kpt, k_voxavg, ψk_real, occk)
         E_ref = -2.249032672407079
         @test abs(E_ref - E_voxavg) < 1e-6
@@ -90,7 +91,7 @@ end
 @testitem "Reference kernel tests of Coulomb kernels (non-cubic lattices)" #=
         =# tags=[:exx,:dont_test_mpi] setup=[TestCases] begin
     using DFTK
-    using DFTK: compute_kernel_fourier
+    using DFTK: eval_kernel_fourier
     using FastGaussQuadrature
     using LinearAlgebra
     using .TestCases: all_testcases
@@ -120,23 +121,24 @@ end
         # Ecut=50 is ok because the lattice is ill-conditioned
     end
 
+    kf(b) = eval_kernel_fourier(WignerSeitzTruncatedCoulomb(), b; qpt=only(b.kpoints))
     @testset "WignerSeitzTruncatedCoulomb" begin
         # TODO: These tests are not super useful, they mainly enable refactoring; they
         #       should really be replaced by tests of properties of WignerSeitzTruncatedCoulomb
         #       against SphericallyTruncatedCoulomb, for example.
-        k_wstrunc = compute_kernel_fourier(WignerSeitzTruncatedCoulomb(), basis_Pt)
+        k_wstrunc = kf(basis_Pt)
         @test k_wstrunc[1:5] ≈ [289.8199039694483, 39.805749013785956, 5.580324780990978,
                                 4.320510620666685, 1.71839014451522]
 
-        k_wstrunc = compute_kernel_fourier(WignerSeitzTruncatedCoulomb(), basis_Ga)
+        k_wstrunc = kf(basis_Ga)
         @test k_wstrunc[1:5] ≈ [133.48675852141807, 12.54391563903425, 1.0201128711380307,
                                 1.0201128711380307, 12.54391563903425]
 
-        k_wstrunc = compute_kernel_fourier(WignerSeitzTruncatedCoulomb(), basis_Sb)
+        k_wstrunc = kf(basis_Sb)
         @test k_wstrunc[1:5] ≈ [133.5869934680494, 17.875585010939407, 3.0560733842605785,
                                 1.6670099917149919, 1.6670099917149919] atol=1e-6
 
-        k_wstrunc = compute_kernel_fourier(WignerSeitzTruncatedCoulomb(), basis_illcond)
+        k_wstrunc = kf(basis_illcond)
         @test k_wstrunc[1:5] ≈ [0.6835202703428708, 0.10574224010892719, 0.10574224010892719,
                                 0.363208874652315, 0.10081120609383883] atol=1e-6
     end
@@ -153,6 +155,7 @@ end
     model  = model_DFT(silicon.lattice, [Si, Si], silicon.positions; functionals=PBE())
     basis  = PlaneWaveBasis(model; Ecut=10, kgrid=(1, 1, 1))
     scfres = self_consistent_field(basis; tol=1e-10, callback=identity)
+    kf(kernel) = eval_kernel_fourier(kernel, basis; qpt=only(basis.kpoints))
 
     n_occ = 4
     kpt  = basis.kpoints[1]
@@ -166,15 +169,15 @@ end
     @testset "Probe-charge integrals" begin
         α = π^2 / basis.Ecut  # width of probe charge
 
-        for kernel in (Coulomb(), LongRangeCoulomb())
+        for kernel in (BareCoulomb(), LongRangeCoulomb())
             # Compute Brillouin integral of k(q) times probe charge in Fourier (e^(-α q^2))
             # We use that the integrand is spherically symmetric and thus directly introduce
             # a 4π q^2 factor
             qmax = sqrt(316 / α)  # At that point e^(-α q^2) is numerically zero
             numerical_integral, _ = quadgk(0, qmax) do q
-                4π * q^2 * DFTK.eval_kernel_fourier(kernel, q^2) * exp(-α * q^2)
+                4π * q^2 * DFTK.eval_kernel_fourier(kernel, [q, 0, 0]) * exp(-α * q^2)
             end
-            analytical_integral = DFTK.eval_probe_charge_integral(kernel, α)
+            analytical_integral = DFTK.compute_probe_charge_integral(kernel, α)
             @test abs(numerical_integral - analytical_integral) < 1e-12
         end
     end
@@ -182,7 +185,7 @@ end
 
 @testitem "Asymptotic consistency of interaction kernels for localized density" tags=[:exx,:dont_test_mpi] begin
     using DFTK
-    using DFTK: exx_energy_only, compute_kernel_fourier
+    using DFTK: exx_energy_only, eval_kernel_fourier
     using LinearAlgebra
     using FastGaussQuadrature
 
@@ -207,7 +210,7 @@ end
         ψk_real ./= sqrt(sum(abs2, ψk_real) * basis.dvol)  # normalise ψk
         occk = [2.0]
 
-        kernel_values = compute_kernel_fourier(kernel, basis)
+        kernel_values = eval_kernel_fourier(kernel, basis; qpt=basis.kpoints[1])
         exx_energy_only(basis, kpt, kernel_values, ψk_real, occk)
     end
 
@@ -238,7 +241,7 @@ end
 
     @testset "WignerSeitz against ProbeCharge" begin
         a_vals = [14.0, 18.0, 22.0, 26.0]
-        kernel = Coulomb(ProbeCharge())
+        kernel = ProbeCharge(BareCoulomb())
         E_vals = evaluate_kernel_on_gaussian_charge.(Ref(kernel), a_vals)
 
         # Extrapolate E(a) = E_inf + c / a^3 (for ProbeCharge)
@@ -247,12 +250,12 @@ end
         E_inf = c[1]    # Constant coefficient
     end
 
-    @testset "WignerSeitz against VoxelAveraged" begin
+    @testset "WignerSeitz against VoxelAverage" begin
         a_vals = [50.0, 62.5, 75.0, 87.5, 100.0]
-        kernel = Coulomb(VoxelAveraged())
+        kernel = VoxelAverage(BareCoulomb())
         E_vals = evaluate_kernel_on_gaussian_charge.(Ref(kernel), a_vals)
 
-        # Extrapolate E(a) = E_inf + c_1 / a + c_3 / a^3 + c_5 / a^5 (for VoxelAveraged)
+        # Extrapolate E(a) = E_inf + c_1 / a + c_3 / a^3 + c_5 / a^5 (for VoxelAverage)
         # We use a multipole expansion (Makov-Payne style) of a localized density.
         # Note that the 1/a^5 term is important!
         V = [ones(length(a_vals))   (1 ./ a_vals)   (1 ./ a_vals).^3   (1 ./ a_vals).^5]

--- a/test/exact_exchange.jl
+++ b/test/exact_exchange.jl
@@ -5,7 +5,7 @@
 
     function test_acexx_consistency(; kgrid=[1, 2, 3], kshift=[0, 1, 0]/2, Ecut=10,
                                       n_empty=3, atol=1e-8, spin_polarization=:none,
-                                      kernel=Coulomb(ProbeCharge()))
+                                      kernel=ProbeCharge(BareCoulomb()))
         Si = ElementPsp(14, load_psp(silicon.psp_upf))
         model = Model(silicon.lattice, [Si, Si], silicon.positions;
                       spin_polarization, symmetries=true, terms=[ExactExchange(; kernel)])
@@ -28,7 +28,7 @@
         @test abs(energies.total - energies_ace.total) < atol
     end
 
-    for kernel in (Coulomb(ProbeCharge()), ShortRangeCoulomb(), SphericallyTruncatedCoulomb())
+    for kernel in (ProbeCharge(BareCoulomb()), ShortRangeCoulomb(), SphericallyTruncatedCoulomb())
         test_acexx_consistency(; kgrid=(1, 1, 1), kshift=(0, 0, 0))
         test_acexx_consistency(; kgrid=(1, 1, 1), kshift=(0, 0, 0), spin_polarization=:collinear)
     end

--- a/test/hamiltonian_consistency.jl
+++ b/test/hamiltonian_consistency.jl
@@ -170,7 +170,7 @@ end
         # TODO: AD of energy( ) function not yet supported for ExactExchange
         exxad = (; test_energy_ad=false)
         for exxalg in (VanillaExx(), AceExx())
-            test_consistency_term(ExactExchange(; kernel=Coulomb(ProbeCharge()));
+            test_consistency_term(ExactExchange(; kernel=ProbeCharge(BareCoulomb()));
                                   exxad..., exxalg, kgrid=(1, 1, 1), kshift=(0, 0, 0))
         end
         test_consistency_term(ExactExchange(); spin_polarization=:collinear,

--- a/test/hartree_fock.jl
+++ b/test/hartree_fock.jl
@@ -81,7 +81,7 @@ end
                -0.4105286062295621, -0.1498412274416261, -0.14984122744054515,
                -0.1498412274386093, 0.39476442887789986, 0.3947644288779635,
                0.39476442887837615]]
-    ref_etot = -31.240766149174128
+    ref_etot = -31.241195444409954
 
     model  = model_HF(lattice, atoms, positions; exx_kernel=SphericallyTruncatedCoulomb())
     basis  = PlaneWaveBasis(model, Ecut=40; kgrid=[1, 1, 1])

--- a/test/hartree_fock.jl
+++ b/test/hartree_fock.jl
@@ -42,7 +42,7 @@
     # Then run Hartree-Fock
     model = model_HF(lattice, atoms, positions;
                      temperature=0.001, smearing=DFTK.Smearing.Gaussian(),
-                     exx_kernel=Coulomb(ReplaceSingularity(0.0)))
+                     exx_kernel=ReplaceSingularity(BareCoulomb(), 0.0))
     basis = PlaneWaveBasis(model; Ecut=20, kgrid=[1, 1, 1])
 
     run_scf_and_compare(Float64, basis, ref_hf, ref_etot; 
@@ -129,7 +129,7 @@ end
     scfres_pbe = self_consistent_field(basis; ρ, tol=1e-3)
     
     model  = model_HF(system; pseudopotentials, magnetic_moments, temperature=0.01,
-                      exx_kernel=Coulomb(ProbeCharge()))
+                      exx_kernel=ProbeCharge(BareCoulomb()))
     basis  = PlaneWaveBasis(model; Ecut, kgrid=[1, 1, 1])
 
     RunSCF.run_scf_and_compare(Float64, basis, ref_hf, ref_etot;

--- a/test/silicon_pbe0.jl
+++ b/test/silicon_pbe0.jl
@@ -37,7 +37,7 @@
 
     model = model_DFT(lattice, atoms, positions;
                       temperature=0.001, smearing=DFTK.Smearing.Gaussian(),
-                      functionals=PBE0(; exx_kernel=Coulomb(ReplaceSingularity(0.0))))
+                      functionals=PBE0(; exx_kernel=ReplaceSingularity(BareCoulomb(), 0.0)))
     basis = PlaneWaveBasis(model; Ecut=20, kgrid=[1, 1, 1])
 
     # Note: With ACE enabled, the unoccupied orbitals are represented rather poorly.


### PR DESCRIPTION
As discussed previously. Along the way, I found a bug : the coulomb kernel was evaluated on the kpoint dependent basis instead of the full one, so the previous version was less accurate. Several independent commits there, so review by commit rather than by files. 
@toschaefer can you review?

Code written by Opus 4.8