### PR TITLE
Fix flaky iron_LDA test by tightening SCF tolerance in density

### DIFF
--- a/test/iron_lda.jl
+++ b/test/iron_lda.jl
@@ -49,5 +49,5 @@ end
 
 
 @testitem "Iron LDA (Float64)" tags=[:minimal] setup=[RunSCF, TestCases, IronLDA] begin
-    IronLDA.run_iron_lda(Float64; test_tol=5e-6, scf_ene_tol=1e-11)
+    IronLDA.run_iron_lda(Float64; test_tol=5e-6, scf_dens_tol=1e-7)
 end


### PR DESCRIPTION
I think I found the issue why iron_LDA is flaky: We used the total energy convergence of 1e-11 but that does not guarantee the eigenvalues to be converged to sqrt(1e-11). The order is right (since SCF eigenvalues error is linear in density error) but still uncontrolled (hence the stochastic CI failures). I switched now to explicitly enforce SCF density convergence.