### PR TITLE
Threading defaults

### DIFF
--- a/src/DFTK.jl
+++ b/src/DFTK.jl
@@ -299,6 +299,9 @@ end
 function __init__()
     # Reset timer; otherwise the starting time is the time of precompilation
     reset_timer!(timer)
+
+    # nthreads() is 1 at precompile time, so apply the thread defaults at load
+    setup_threading(; verbose=false)
 end
 
 end # module DFTK

--- a/src/common/threading.jl
+++ b/src/common/threading.jl
@@ -3,17 +3,17 @@ using LinearAlgebra
 using MPI
 
 """
-Setup the number of threads used by DFTK's own threading (`n_DFTK`), by BLAS (`n_blas`) 
+Setup the number of threads used by DFTK's own threading (`n_DFTK`), by BLAS (`n_blas`)
 and by FFTW (`n_fft`). This is independent from the number of Julia threads (`Threads.nthreads()`).
 DFTK and FFTW threading are upper bounded by `Threads.nthreads()`, but not BLAS,
 which uses its own threading system.
-By default, use 1 FFT thread, and `Threads.nthreads()` BLAS and DFTK threads.
+By default, use `Threads.nthreads()` DFTK threads and a single FFT and BLAS thread.
 """
-function setup_threading(; n_fft=1, n_blas=Threads.nthreads(), n_DFTK=Threads.nthreads())
+function setup_threading(; n_fft=1, n_blas=1, n_DFTK=Threads.nthreads(), verbose=true)
     set_DFTK_threads!(n_DFTK)
     FFTW.set_num_threads(n_fft)
     BLAS.set_num_threads(n_blas)
-    mpi_master(MPI.COMM_WORLD) && @info "Threading setup: " Threads.nthreads() n_DFTK n_fft n_blas
+    verbose && mpi_master(MPI.COMM_WORLD) && @info "Threading setup: " Threads.nthreads() n_DFTK n_fft n_blas
 end
 
 """

--- a/src/terms/xc.jl
+++ b/src/terms/xc.jl
@@ -370,8 +370,9 @@ function LibxcDensities(basis::PlaneWaveBasis{T}, max_derivative::Integer, ρ, �
         ∇ρ_real = similar(ρ_real,   n_spin, basis.fft_size..., 3)
         σ_real  = similar(ρ_real, n_spin_σ, basis.fft_size...)
 
+        Gs_cart = G_vectors_cart(basis)
         for α = 1:3
-            iGα = map(G -> im * G[α], G_vectors_cart(basis))
+            iGα = map(G -> im * G[α], Gs_cart)
             for σ = 1:n_spin
                 ∇ρ_real[σ, :, :, :, α] .= irfft(basis, iGα .* @view ρ_fourier[σ, :, :, :])
             end
@@ -553,9 +554,10 @@ components in real space when called with the arguments 1 to 3.
 The divergence is also returned as a real-space array.
 """
 function divergence_real(operand, basis)
+    Gs_cart = G_vectors_cart(basis)
     gradsum = sum(1:3) do α
         operand_α = fft(basis, operand(α))
-        map(G_vectors_cart(basis), operand_α) do G, operand_αG
+        map(Gs_cart, operand_α) do G, operand_αG
             im * G[α] * operand_αG  # ∇_α * operand_α
         end
     end


### PR DESCRIPTION
There was a gotcha I wasn't aware of, which meant that threading was turned off by default. Also set nblas to 1 to avoid overthreading. Also a drive by optimization 