### PR TITLE
Symmetrize densities via precomputed symmetry stars

### DIFF
--- a/src/PlaneWaveBasis.jl
+++ b/src/PlaneWaveBasis.jl
@@ -83,6 +83,8 @@ struct PlaneWaveBasis{T,
     ## Symmetry operations that leave the discretized model (k and r grids) invariant.
     # Subset of model.symmetries.
     symmetries::Vector{SymOp{VT}}
+    # Symmetry-equivalent G-vector stars, used to speed up symmetrization of ρ
+    symmetry_stars::Vector{SymmetryStar{VT}}
     # Whether the symmetry operations leave the rgrid invariant
     # If this is true, the symmetries are a property of the complete discretized model.
     # Therefore, all quantities should be symmetric to machine precision
@@ -240,6 +242,10 @@ function PlaneWaveBasis(model::Model{T}, Ecut::Real, fft_size::Tuple{Int, Int, I
 
     dvol  = model.unit_cell_volume ./ prod(fft_size)
     terms = Vector{Any}(undef, length(model.term_types))  # Dummy terms array, filled below
+    
+    # precompute stars (only used by the CPU symmetrization of grid-preserving symmetries)
+    symmetry_stars = (architecture isa CPU && symmetries_respect_rgrid) ?
+                     compute_symmetry_stars(fft_size, symmetries) : SymmetryStar{value_type(T)}[]
 
     basis = PlaneWaveBasis{T, value_type(T), Arch, typeof(fft_grid),
                            typeof(kpoints[1].G_vectors)}(
@@ -249,7 +255,7 @@ function PlaneWaveBasis(model::Model{T}, Ecut::Real, fft_size::Tuple{Int, Int, I
         kpoints, kweights, kgrid,
         kcoords_global, kweights_global, n_irreducible_kpoints,
         comm_kpts, krange_thisproc, krange_allprocs, krange_thisproc_allspin,
-        architecture, symmetries, symmetries_respect_rgrid,
+        architecture, symmetries, symmetry_stars, symmetries_respect_rgrid,
         use_symmetries_for_kpoint_reduction, terms)
 
     # Instantiate the terms with the basis

--- a/src/SymOp.jl
+++ b/src/SymOp.jl
@@ -116,14 +116,14 @@ end
 
 # A star is the orbit {G = S·G₀ : S in the group} of a representative G-vector G₀ on the FFT
 # grid. The symmetrized density is constant over a star up to a phase, ρ_sym(S·G₀) =
-# e^{-i (S·G₀)·τ_S} ρ_sym(G₀), so `accumulate_over_symmetries!` gathers ρ_sym(G₀) once and
-# scatters it across the orbit. (Defined here, before PlaneWaveBasis, as it is a basis field.)
+# e^{-i (S·G₀)·τ_S} ρ_sym(G₀), so `accumulate_over_symmetries!` gathers ρstar = ρ_sym(G₀) once and
+# scatters it across the orbit.
 struct SymmetryStar{T}
     # gather: ρstar = Σ_isym θ·ρ[iG] with (iG, θ) = sources[isym]
     sources::Vector{Pair{Int, Complex{T}}}
     # scatter: ρsym[iG] = θ·ρstar for (iG, θ) in members
     members::Vector{Pair{Int, Complex{T}}}
-    # G₀ is not stored: it is the sources/members entry of the trivial symmetry.
+    # G₀ is not stored: it is the sources/members entry with trivial symmetry.
 end
 
 # Discover the stars by scanning the grid: each grid point not already in a star seeds a new one

--- a/src/SymOp.jl
+++ b/src/SymOp.jl
@@ -37,16 +37,17 @@ struct SymOp{T <: Real}
     # (Uu)(G) = e^{-i G τ} u(S^-1 G) in reciprocal space
     S::Mat3{Int}
     τ::Vec3{T}
+    invS::Mat3{Int}  # = inv(S), integer since det S = 1
 end
 function SymOp(W, w::AbstractVector{T}) where {T}
     w = mod.(w, 1)
     S = W'
     τ = -W \ w
-    SymOp{T}(W, w, S, τ)
+    SymOp{T}(W, w, S, τ, Mat3{Int}(inv(S)))
 end
 
 function Base.convert(::Type{SymOp{T}}, S::SymOp{U}) where {U <: Real, T <: Real}
-    SymOp{T}(S.W, T.(S.w), S.S, T.(S.τ))
+    SymOp{T}(S.W, T.(S.w), S.S, T.(S.τ), S.invS)
 end
 
 Base.:(==)(op1::SymOp, op2::SymOp) = op1.W == op2.W && op1.w == op2.w
@@ -111,4 +112,45 @@ function complete_symop_group(symops; maxiter=10, kwargs...)
         append!(completed_group, to_add)
     end
     DFTK.check_group(completed_group) # returns the completed group
+end
+
+# A star is the orbit {G = S·G₀ : S in the group} of a representative G-vector G₀ on the FFT
+# grid. The symmetrized density is constant over a star up to a phase, ρ_sym(S·G₀) =
+# e^{-i (S·G₀)·τ_S} ρ_sym(G₀), so `accumulate_over_symmetries!` gathers ρ_sym(G₀) once and
+# scatters it across the orbit. (Defined here, before PlaneWaveBasis, as it is a basis field.)
+struct SymmetryStar{T}
+    # gather: ρstar = Σ_isym θ·ρ[iG] with (iG, θ) = sources[isym]
+    sources::Vector{Pair{Int, Complex{T}}}
+    # scatter: ρsym[iG] = θ·ρstar for (iG, θ) in members
+    members::Vector{Pair{Int, Complex{T}}}
+    # G₀ is not stored: it is the sources/members entry of the trivial symmetry.
+end
+
+# Discover the stars by scanning the grid: each grid point not already in a star seeds a new one
+# as its representative G₀, and its whole orbit is marked `visited` -- so the scan produces one
+# star per orbit, not one per grid point.
+function compute_symmetry_stars(fft_size, symmetries::AbstractVector{<:SymOp{T}}) where {T}
+    Gs         = G_vectors(fft_size)
+    linear_ind = LinearIndices(fft_size)
+    visited    = falses(length(Gs))
+    stars      = SymmetryStar{T}[]
+    for lin in eachindex(Gs)
+        visited[lin] && continue
+        G = Gs[lin]
+        sources = Pair{Int, Complex{T}}[]
+        for symop in symmetries
+            idx = index_G_vectors(fft_size, symop.invS * G)
+            isnothing(idx) || push!(sources, linear_ind[idx] => cis2pi(-T(dot(G, symop.τ))))
+        end
+        members = Pair{Int, Complex{T}}[]
+        for symop in symmetries
+            SG  = symop.S * G
+            idx = index_G_vectors(fft_size, SG)
+            (isnothing(idx) || visited[linear_ind[idx]]) && continue
+            visited[linear_ind[idx]] = true
+            push!(members, linear_ind[idx] => cis2pi(-T(dot(SG, symop.τ))))
+        end
+        push!(stars, SymmetryStar(sources, members))
+    end
+    stars
 end

--- a/src/SymOp.jl
+++ b/src/SymOp.jl
@@ -115,9 +115,14 @@ function complete_symop_group(symops; maxiter=10, kwargs...)
 end
 
 # A star is the orbit {G = S·G₀ : S in the group} of a representative G-vector G₀ on the FFT
-# grid. The symmetrized density is constant over a star up to a phase, ρ_sym(S·G₀) =
-# e^{-i (S·G₀)·τ_S} ρ_sym(G₀), so `accumulate_over_symmetries!` gathers ρstar = ρ_sym(G₀) once and
-# scatters it across the orbit.
+# grid. This is used to speed up the symmetrization
+# ρ_sym(G) = Σ_S e^{-i G·τ} ρ(S⁻¹G)
+# The symmetrized density is constant over a star up to a phase, ρ_sym(S·G₀) =
+# e^{-i (S·G₀)·τ_S} ρ_sym(G₀), so, to symmetrize a density, gather ρstar = ρ_sym(G₀) once and
+# scatter it across the orbit.
+# This is faster than the naive sum because, for a generic star, the
+# naive sum is O(members^2) while the optimized algorithm is
+# O(members)
 struct SymmetryStar{T}
     # gather: ρstar = Σ_isym θ·ρ[iG] with (iG, θ) = sources[isym]
     sources::Vector{Pair{Int, Complex{T}}}

--- a/src/SymOp.jl
+++ b/src/SymOp.jl
@@ -145,15 +145,16 @@ function compute_symmetry_stars(fft_size, symmetries::AbstractVector{<:SymOp{T}}
         sources = Pair{Int, Complex{T}}[]
         for symop in symmetries
             idx = index_G_vectors(fft_size, symop.invS * G)
-            isnothing(idx) || push!(sources, linear_ind[idx] => cis2pi(-T(dot(G, symop.τ))))
+            isnothing(idx) && error("Symmetry stars should not be used when the grid doesn't preserve symmetries")
+            push!(sources, linear_ind[idx] => cis2pi(-dot(G, symop.τ)))
         end
         members = Pair{Int, Complex{T}}[]
         for symop in symmetries
             SG  = symop.S * G
             idx = index_G_vectors(fft_size, SG)
-            (isnothing(idx) || visited[linear_ind[idx]]) && continue
+            visited[linear_ind[idx]] && continue
             visited[linear_ind[idx]] = true
-            push!(members, linear_ind[idx] => cis2pi(-T(dot(SG, symop.τ))))
+            push!(members, linear_ind[idx] => cis2pi(-dot(SG, symop.τ)))
         end
         push!(stars, SymmetryStar(sources, members))
     end

--- a/src/SymOp.jl
+++ b/src/SymOp.jl
@@ -145,14 +145,13 @@ function compute_symmetry_stars(fft_size, symmetries::AbstractVector{<:SymOp{T}}
         sources = Pair{Int, Complex{T}}[]
         for symop in symmetries
             idx = index_G_vectors(fft_size, symop.invS * G)
-            isnothing(idx) && error("Symmetry stars should not be used when the grid doesn't preserve symmetries")
-            push!(sources, linear_ind[idx] => cis2pi(-dot(G, symop.τ)))
+            isnothing(idx) || push!(sources, linear_ind[idx] => cis2pi(-dot(G, symop.τ)))
         end
         members = Pair{Int, Complex{T}}[]
         for symop in symmetries
             SG  = symop.S * G
             idx = index_G_vectors(fft_size, SG)
-            visited[linear_ind[idx]] && continue
+            (isnothing(idx) || visited[linear_ind[idx]]) && continue
             visited[linear_ind[idx]] = true
             push!(members, linear_ind[idx] => cis2pi(-dot(SG, symop.τ)))
         end

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -255,7 +255,7 @@ function apply_symop(symop::SymOp, basis, kpoint, ψk::AbstractVecOrMat)
     #      u_{Sk}(x) = u_{k}(S^{-1} (x - τ))
     # their Fourier transform is related as
     #      ̂u_{Sk}(G) = e^{-i G \cdot τ} ̂u_k(S^{-1} G)
-    invS = Mat3{Int}(inv(S))
+    invS = symop.invS
     Gs_full = [G + kshift for G in G_vectors(basis, Skpoint)]
     ψSk = zero(ψk)
     for iband = 1:size(ψk, 2)
@@ -269,47 +269,42 @@ function apply_symop(symop::SymOp, basis, kpoint, ψk::AbstractVecOrMat)
     Skpoint, ψSk
 end
 
-"""
-Apply a symmetry operation to a density.
-"""
-function apply_symop(symop::SymOp, basis, ρin; kwargs...)
-    isone(symop) && return ρin
-    symmetrize_ρ(basis, ρin; symmetries=[symop], kwargs...)
+# Accumulate the symmetrized density Σ_S e^{-i G·τ} ρ(S⁻¹G) into ρaccu, picking the algorithm.
+# The precomputed stars speed up the serial CPU traversal; the GPU (already parallel) and
+# non-basis symmetries use the direct `map!`. Stars are exact only when the symmetries permute
+# the grid, hence the `symmetries_respect_rgrid` guard.
+function accumulate_over_symmetries!(ρaccu, ρin, basis, symmetries)
+    if basis.architecture isa CPU && symmetries === basis.symmetries && basis.symmetries_respect_rgrid
+        _accumulate_over_symmetries_stars!(ρaccu, ρin, basis.symmetry_stars)
+    else
+        _accumulate_over_symmetries_direct!(ρaccu, ρin, basis, symmetries)
+    end
 end
 
-# Accumulates the symmetrized versions of the density ρin into ρaccu (in Fourier space).
-# No normalization is performed. This function is optimized for CPU and GPU.
-function accumulate_over_symmetries!(ρaccu, ρin, basis::PlaneWaveBasis{T}, symmetries) where {T}
-    # For each G vector and symmetry S:
-    # Transform ρin -> to the partial density at S * k.
-    #
-    # Since the eigenfunctions of the Hamiltonian at k and Sk satisfy
-    #      u_{Sk}(x) = u_{k}(S^{-1} (x - τ))
-    # with Fourier transform
-    #      ̂u_{Sk}(G) = e^{-i G \cdot τ} ̂u_k(S^{-1} G)
-    # equivalently
-    #     ρ ̂_{Sk}(G) = e^{-i G \cdot τ} ̂ρ_k(S^{-1} G) 
-    if all(isone, symmetries)
-        ρaccu .= ρin
-        return ρaccu
+function _accumulate_over_symmetries_stars!(ρaccu, ρin, stars::Vector{<:SymmetryStar})
+    for star in stars
+        ρstar = sum(phase * ρin[idx] for (idx, phase) in star.sources;
+                    init=zero(eltype(ρaccu)))
+        for (idx, phase) in star.members
+            ρaccu[idx] = ρstar * phase
+        end
     end
+    ρaccu
+end
 
+# Direct evaluation of ρ_sym(G) = Σ_S e^{-i G·τ} ρ(S⁻¹G) at every G, in a single `map!`.
+function _accumulate_over_symmetries_direct!(ρaccu, ρin, basis::PlaneWaveBasis{T}, symmetries) where {T}
+    all(isone, symmetries) && return ρaccu .= ρin
     Gs = reshape(G_vectors(basis), size(ρaccu))
     fft_size = basis.fft_size
-
-    # Need to transfer  symmetry data to the GPU as isbit data
-    symm_invS = to_device(basis.architecture, [Mat3{Int}(inv(symop.S)) for symop in symmetries])
-    symm_τ = to_device(basis.architecture, [symop.τ for symop in symmetries])
-    n_symm = length(symmetries)
-
-    # Looping over symmetries inside of map! on G vectors allow for a single GPU kernel launch
+    symm_invS = to_device(basis.architecture, [symop.invS for symop in symmetries])
+    symm_τ    = to_device(basis.architecture, [symop.τ for symop in symmetries])
+    n_symm    = length(symmetries)
     map!(ρaccu, Gs) do G
         acc = zero(complex(T))
-        # Explicit loop over indices because AMDGPU does not support zip() in map!
-        for i_symm in 1:n_symm
-            invS = symm_invS[i_symm]
-            τ = symm_τ[i_symm]
-            idx = index_G_vectors(fft_size, invS * G)
+        for i_symm in 1:n_symm  # explicit indices: AMDGPU does not support zip() in map!
+            τ   = symm_τ[i_symm]
+            idx = index_G_vectors(fft_size, symm_invS[i_symm] * G)
             acc += isnothing(idx) ? zero(complex(T)) :
                         iszero(τ) ? ρin[idx] : cis2pi(-T(dot(G, τ))) * ρin[idx]
         end
@@ -321,7 +316,9 @@ end
 # Low-pass filters ρ (in Fourier) so that symmetry operations acting on it stay in the grid
 # This function is optimized for CPU and GPU.
 function lowpass_for_symmetry!(ρ::AbstractArray, basis; symmetries=basis.symmetries)
-    all(isone, symmetries) && return ρ
+    # Symmetries that permute the grid never map a G-vector out of it, so nothing is filtered.
+    (all(isone, symmetries) ||
+     (symmetries === basis.symmetries && basis.symmetries_respect_rgrid)) && return ρ
 
     Gs = reshape(G_vectors(basis), size(ρ))
     fft_size = basis.fft_size
@@ -348,8 +345,8 @@ Symmetrize a density by applying all the basis (by default) symmetries and formi
     ρin_fourier  = fft(basis, ρ)
     ρout_fourier = zero(ρin_fourier)
     for σ = 1:size(ρ, 4)
-        accumulate_over_symmetries!(ρout_fourier[:, :, :, σ],
-                                    ρin_fourier[:, :, :, σ], basis, symmetries)
+        accumulate_over_symmetries!(ρout_fourier[:, :, :, σ], ρin_fourier[:, :, :, σ],
+                                    basis, symmetries)
         do_lowpass && lowpass_for_symmetry!(ρout_fourier[:, :, :, σ], basis; symmetries)
     end
     inv_fft = T <: Real ? irfft : ifft

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -269,11 +269,11 @@ function apply_symop(symop::SymOp, basis, kpoint, ψk::AbstractVecOrMat)
     Skpoint, ψSk
 end
 
-# Accumulate the symmetrized density Σ_S e^{-i G·τ} ρ(S⁻¹G) into ρaccu, picking the algorithm.
-# The precomputed stars speed up the serial CPU traversal; the GPU (already parallel) and
-# non-basis symmetries use the direct `map!`. Stars are exact only when the symmetries permute
-# the grid, hence the `symmetries_respect_rgrid` guard.
+# Accumulate the symmetrized density Σ_S e^{-i G·τ} ρ(S⁻¹G) into ρaccu
 function accumulate_over_symmetries!(ρaccu, ρin, basis, symmetries)
+    # The precomputed stars speed up the serial CPU traversal; the GPU (already parallel) and
+    # non-basis symmetries use the direct `map!`. Stars are exact only when the symmetries permute
+    # the grid, hence the `symmetries_respect_rgrid` guard.
     if basis.architecture isa CPU && symmetries === basis.symmetries && basis.symmetries_respect_rgrid
         _accumulate_over_symmetries_stars!(ρaccu, ρin, basis.symmetry_stars)
     else
@@ -314,7 +314,6 @@ function _accumulate_over_symmetries_direct!(ρaccu, ρin, basis::PlaneWaveBasis
 end
 
 # Low-pass filters ρ (in Fourier) so that symmetry operations acting on it stay in the grid
-# This function is optimized for CPU and GPU.
 function lowpass_for_symmetry!(ρ::AbstractArray, basis; symmetries=basis.symmetries)
     # Symmetries that permute the grid never map a G-vector out of it, so nothing is filtered.
     (all(isone, symmetries) ||

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -281,17 +281,6 @@ function accumulate_over_symmetries!(ρaccu, ρin, basis, symmetries)
     end
 end
 
-function _accumulate_over_symmetries_stars!(ρaccu, ρin, stars::Vector{<:SymmetryStar})
-    for star in stars
-        ρstar = sum(phase * ρin[idx] for (idx, phase) in star.sources;
-                    init=zero(eltype(ρaccu)))
-        for (idx, phase) in star.members
-            ρaccu[idx] = ρstar * phase
-        end
-    end
-    ρaccu
-end
-
 # Direct evaluation of ρ_sym(G) = Σ_S e^{-i G·τ} ρ(S⁻¹G) at every G, in a single `map!`.
 function _accumulate_over_symmetries_direct!(ρaccu, ρin, basis::PlaneWaveBasis{T}, symmetries) where {T}
     all(isone, symmetries) && return ρaccu .= ρin
@@ -313,11 +302,26 @@ function _accumulate_over_symmetries_direct!(ρaccu, ρin, basis::PlaneWaveBasis
     ρaccu
 end
 
+# See SymmetryStar for a description of the algorithm
+function _accumulate_over_symmetries_stars!(ρaccu, ρin, stars::Vector{<:SymmetryStar})
+    for star in stars
+        # gather: compute ρstar = ρ(G0)
+        ρstar = sum(phase * ρin[idx] for (idx, phase) in star.sources;
+                    init=zero(eltype(ρaccu)))
+        for (idx, phase) in star.members
+            # scatter ρ(G0) to all the star
+            ρaccu[idx] = ρstar * phase
+        end
+    end
+    ρaccu
+end
+
 # Low-pass filters ρ (in Fourier) so that symmetry operations acting on it stay in the grid
 function lowpass_for_symmetry!(ρ::AbstractArray, basis; symmetries=basis.symmetries)
     # Symmetries that permute the grid never map a G-vector out of it, so nothing is filtered.
-    (all(isone, symmetries) ||
-     (symmetries === basis.symmetries && basis.symmetries_respect_rgrid)) && return ρ
+    if (symmetries === basis.symmetries && basis.symmetries_respect_rgrid) || all(isone, symmetries)
+        return ρ
+    end
 
     Gs = reshape(G_vectors(basis), size(ρ))
     fft_size = basis.fft_size

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -271,10 +271,8 @@ end
 
 # Accumulate the symmetrized density Σ_S e^{-i G·τ} ρ(S⁻¹G) into ρaccu
 function accumulate_over_symmetries!(ρaccu, ρin, basis, symmetries)
-    # The precomputed stars speed up the serial CPU traversal; the GPU (already parallel) and
-    # non-basis symmetries use the direct `map!`. Stars are exact only when the symmetries permute
-    # the grid, hence the `symmetries_respect_rgrid` guard.
-    if basis.architecture isa CPU && symmetries === basis.symmetries && basis.symmetries_respect_rgrid
+    # Use the faster stars algorithm when available and precomputed (see basis constructor)
+    if symmetries === basis.symmetries && !isempty(basis.symmetry_stars)
         _accumulate_over_symmetries_stars!(ρaccu, ρin, basis.symmetry_stars)
     else
         _accumulate_over_symmetries_direct!(ρaccu, ρin, basis, symmetries)
@@ -295,7 +293,7 @@ function _accumulate_over_symmetries_direct!(ρaccu, ρin, basis::PlaneWaveBasis
             τ   = symm_τ[i_symm]
             idx = index_G_vectors(fft_size, symm_invS[i_symm] * G)
             acc += isnothing(idx) ? zero(complex(T)) :
-                        iszero(τ) ? ρin[idx] : cis2pi(-T(dot(G, τ))) * ρin[idx]
+                        iszero(τ) ? ρin[idx] : cis2pi(-dot(G, τ)) * ρin[idx]
         end
         acc
     end

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -316,10 +316,7 @@ end
 
 # Low-pass filters ρ (in Fourier) so that symmetry operations acting on it stay in the grid
 function lowpass_for_symmetry!(ρ::AbstractArray, basis; symmetries=basis.symmetries)
-    # Symmetries that permute the grid never map a G-vector out of it, so nothing is filtered.
-    if (symmetries === basis.symmetries && basis.symmetries_respect_rgrid) || all(isone, symmetries)
-        return ρ
-    end
+    all(isone, symmetries) && return ρ
 
     Gs = reshape(G_vectors(basis), size(ρ))
     fft_size = basis.fft_size

--- a/test/symmetry_issues.jl
+++ b/test/symmetry_issues.jl
@@ -35,7 +35,7 @@
         # keeping calls to the index_G_vectors() function for which we test inlining
         function G_vectors_calls(basis)
             for symop in basis.symmetries
-                invS = Mat3{Int}(inv(symop.S))
+                invS = symop.invS
                 for (ig, G) in enumerate(DFTK.G_vectors_generator(basis.fft_size))
                     igired = DFTK.index_G_vectors(basis, invS * G)
                 end

--- a/test/symmetry_stars.jl
+++ b/test/symmetry_stars.jl
@@ -1,0 +1,32 @@
+@testitem "Density symmetrization via stars" tags=[:minimal] setup=[TestCases] begin
+    using DFTK
+    using DFTK: _accumulate_over_symmetries_stars!, _accumulate_over_symmetries_direct!,
+                index_G_vectors, cis2pi, Mat3, G_vectors
+    using LinearAlgebra
+    silicon = TestCases.silicon
+
+    model = model_DFT(silicon.lattice, silicon.atoms, silicon.positions; functionals=LDA())
+    basis = PlaneWaveBasis(model; Ecut=15, kgrid=[2, 2, 2])
+    symmetries = basis.symmetries
+    @test length(symmetries) > 1  # otherwise the test is vacuous
+
+    # Reference: ρ_sym(G) = Σ_S e^{-2πi G·τ} ρ(S⁻¹G), evaluated directly at every G.
+    fft_size = basis.fft_size
+    Gs  = reshape(G_vectors(fft_size), fft_size)
+    lin = LinearIndices(fft_size)
+    ρ   = rand(ComplexF64, fft_size)
+    ref = zero(ρ)
+    for I in CartesianIndices(Gs), symop in symmetries
+        idx = index_G_vectors(fft_size, symop.invS * Gs[I])
+        isnothing(idx) || (ref[lin[I]] += cis2pi(-dot(Gs[I], symop.τ)) * ρ[lin[idx]])
+    end
+
+    out_stars = zero(ρ)
+    _accumulate_over_symmetries_stars!(out_stars, ρ, basis.symmetry_stars)
+    @test out_stars ≈ ref
+
+    # The direct map! path (used on the GPU and for symmetry subsets) must agree.
+    out_direct = zero(ρ)
+    _accumulate_over_symmetries_direct!(out_direct, ρ, basis, symmetries)
+    @test out_direct ≈ ref
+end

--- a/test/symmetry_stars.jl
+++ b/test/symmetry_stars.jl
@@ -30,3 +30,24 @@
     _accumulate_over_symmetries_direct!(out_direct, ρ, basis, symmetries)
     @test out_direct ≈ ref
 end
+
+@testitem "Density symmetrization is a projector" tags=[:minimal] setup=[TestCases] begin
+    using DFTK
+    using DFTK: symmetrize_ρ
+    using LinearAlgebra
+    silicon = TestCases.silicon
+
+    model = model_DFT(silicon.lattice, silicon.atoms, silicon.positions; functionals=LDA())
+    # An explicit fft_size gives a grid that does not respect the symmetries, which goes
+    # through the direct symmetrization; the default one goes through the stars.
+    for fft_size in (nothing, (25, 25, 25))
+        basis = PlaneWaveBasis(model; Ecut=10, kgrid=[2, 2, 2], fft_size)
+        @test length(basis.symmetries) > 1  # otherwise the test is vacuous
+
+        ρsym = symmetrize_ρ(basis, randn(eltype(basis), basis.fft_size..., 1))
+        @test symmetrize_ρ(basis, ρsym) ≈ ρsym
+        for symop in basis.symmetries
+            @test symmetrize_ρ(basis, ρsym; symmetries=[symop]) ≈ ρsym
+        end
+    end
+end


### PR DESCRIPTION
Fix https://github.com/JuliaMolSim/DFTK.jl/issues/1355. Turns out it's not that hard and a 60x speedup is hard to ignore