### PR TITLE
Fix GPU in nonlocal term

### DIFF
--- a/src/terms/nonlocal.jl
+++ b/src/terms/nonlocal.jl
@@ -18,7 +18,7 @@ function (::AtomicNonlocal)(basis::PlaneWaveBasis{T}) where {T}
     isempty(psp_groups) && return TermNoop()
     ops = map(basis.kpoints) do kpt
         P = build_projection_vectors(basis, kpt, psps, psp_positions)
-        D = build_projection_coefficients(T, psps, psp_positions)
+        D = build_projection_coefficients(basis, psps, psp_positions)
         NonlocalOperator(basis, kpt, P, D)
     end
     TermAtomicNonlocal(ops)
@@ -65,7 +65,8 @@ end
     for group in psp_groups
         element = model.atoms[first(group)]
 
-        D = build_projection_coefficients(T, element.psp)
+        D = to_device(basis.architecture, build_projection_coefficients(T, element.psp))
+
         for (ik, kpt) in enumerate(basis.kpoints)
             # We compute the forces from the irreductible BZ; they are symmetrized later.
             G_plus_k_cart = Gplusk_vectors_cart(basis, kpt)
@@ -104,7 +105,7 @@ end
 # The ordering of the projector indices is (A,l,m,i), where A is running over all
 # atoms, l, m are AM quantum numbers and i is running over all projectors for a
 # given l. The matrix is block-diagonal with non-zeros only if A, l and m agree.
-function build_projection_coefficients(T, psps, psp_positions)
+function build_projection_coefficients(basis::PlaneWaveBasis{T}, psps, psp_positions) where {T}
     # TODO In the current version the proj_coeffs still has a lot of zeros.
     #      One could improve this by storing the blocks as a list or in a
     #      BlockDiagonal data structure
@@ -120,7 +121,7 @@ function build_projection_coefficients(T, psps, psp_positions)
     end
     @assert count == n_proj
 
-    proj_coeffs
+    to_device(basis.architecture, proj_coeffs)
 end
 
 # Builds the projection coefficient matrix for a single atom
@@ -288,7 +289,7 @@ end
 function build_projection_coefficients(basis::PlaneWaveBasis{T}, psp_groups) where {T}
     psps          = [basis.model.atoms[first(group)].psp for group in psp_groups]
     psp_positions = [basis.model.positions[group] for group in psp_groups]
-    to_device(basis.architecture, build_projection_coefficients(T, psps, psp_positions))
+    build_projection_coefficients(basis, psps, psp_positions)
 end
 function build_projection_vectors(basis::PlaneWaveBasis, kpt::Kpoint,
                                   psp_groups::AbstractVector{<: AbstractVector{<: Int}},


### PR DESCRIPTION
#1348 broke the GPU implementation because `D` matrix of the nonlocal term was not copied to the device anymore.

This highlights again the need for a GPU CI, I'll open an issue to discuss this.