### PR TITLE
Add hubbard_n to the 'gdensity'

### DIFF
--- a/src/densities.jl
+++ b/src/densities.jl
@@ -177,29 +177,8 @@ end
 #
 # Generalised density representation
 #
-# Many DFT functionals rely on the Hoffmann-Ostenhoff inequality τW(ρ) ≤ τ, i.e. that the
-# von Weizsäcker kinetic energy density is strictly a lower bound to the kinetic energy density.
-# This is satisfied if ρ and τ are built from the same orbitals, but may not be true if we
-# take (convex) combinations of the vector (ρ, τ). This is why we represent the packed
-# density as (ρ, τ_excess) where τ_excess = τ - τW(ρ).
-#
-# TODO: When we do the state refactor we should think how to deal with this;
-#       - Probably a ComponentArray or some form of custom struct is reasonable here
-#       - Do we want to compute the τW implicitly in here ? It's not a very cheap operation
-#         (i.e. not order-1) so that may be unexpected for such an operation. On the other
-#         hand we will probably not get around to have some form of additional computation
-#         that happens upon the construction of these "densities".
-pack_gdensity(basis::PlaneWaveBasis, ρ::AbstractArray, τ::Nothing) = ρ
-pack_gdensity(basis, ρ::AbstractArray, τ::AbstractArray) = cat(ρ, τ; dims=Val(4))
-function split_gdensity(basis::PlaneWaveBasis, x::AbstractArray{T, 4}) where {T}
-    # TODO: This breaks when non-collinear spin is implemented
-    n_spin = basis.model.n_spin_components
-    @assert size(x, 4) == n_spin || size(x, 4) == 2n_spin
-    if size(x, 4) == 2n_spin
-        ρ = @view x[:, :, :,        1:n_spin]
-        τ = @view x[:, :, :, n_spin+1:end   ]
-        (ρ, τ)
-    else
-        (x, nothing)
-    end
-end
+# The generalised density groups the density-like ρ, τ and hubbard_n.
+# For now a named tuple; a custom struct / ComponentArray could be considered.
+pack_gdensity(basis::PlaneWaveBasis, ρ::AbstractArray, τ=nothing, hubbard_n=nothing) =
+    (; ρ, τ, hubbard_n)
+split_gdensity(basis::PlaneWaveBasis, D::NamedTuple) = (D.ρ, D.τ, D.hubbard_n)

--- a/src/scf/mixing.jl
+++ b/src/scf/mixing.jl
@@ -23,12 +23,12 @@ function mix_potential(args...; kwargs...)
 end
 
 
-# Mixing in the generalised density (essentially an adapted tuple of ρ and τ;
-# see pack_gdensity in densities.jl): For now just fall back to ρ-only mixing
+# Mixing in the generalised density (see pack_gdensity in densities.jl):
+# For now just fall back to ρ-only mixing
 function mix_gdensity(mixing, basis, ΔD; kwargs...)
-    Δρ, Δτ  = split_gdensity(basis, ΔD)
+    Δρ, Δτ, Δhubbard_n = split_gdensity(basis, ΔD)
     Pinv_Δρ = mix_density(mixing, basis, Δρ; kwargs...)
-    pack_gdensity(basis, Pinv_Δρ, Δτ)
+    pack_gdensity(basis, Pinv_Δρ, Δτ, Δhubbard_n)
 end
 
 

--- a/src/scf/scf_solvers.jl
+++ b/src/scf/scf_solvers.jl
@@ -25,7 +25,7 @@ or applying some kind of mixing, see the other keyword arguments of
 """
 struct ScfDampingSolver <: ScfSolver end
 function (scf::ScfDampingSolver)(f, x0, info0; maxiter, damping)
-    β = convert(eltype(x0), damping)
+    β = convert(eltype(x0.ρ), damping)
     x = x0
     info = info0
     for _ = 1:maxiter
@@ -33,7 +33,13 @@ function (scf::ScfDampingSolver)(f, x0, info0; maxiter, damping)
         if info.converged || info.timedout
             break
         end
-        x = @. β * fx + (1 - β) * x
+        ρ,  τ,  hubbard_n  = split_gdensity(info.basis, x)
+        fρ, fτ, fhubbard_n = split_gdensity(info.basis, fx)
+        ρ = @. β * fρ + (1 - β) * ρ
+        τ = isnothing(τ) ? nothing : @. β * fτ + (1 - β) * τ
+        hubbard_n = isnothing(hubbard_n) ? nothing : (
+                    @. β * fhubbard_n + (1 - β) * hubbard_n)
+        x = pack_gdensity(info.basis, ρ, τ, hubbard_n)
     end
     (; fixpoint=x, info)
 end
@@ -74,10 +80,10 @@ function ScfAndersonDensitySolver(; m_start::Integer=1, kwargs...)
 end
 # For the show function, see below
 function (scf::ScfAndersonDensitySolver)(f, x0, info0; maxiter, damping)
-    T = eltype(x0)
+    T = eltype(x0.ρ)
     β = convert(T, damping)
     x = x0
-    ρ, _ = split_gdensity(info0.basis, x0)
+    ρ, _, _ = split_gdensity(info0.basis, x0)
     info = info0
     acceleration = AndersonAcceleration(; scf.anderson_kwargs...)
     for i = 1:maxiter
@@ -86,17 +92,17 @@ function (scf::ScfAndersonDensitySolver)(f, x0, info0; maxiter, damping)
             break
         end
 
-        fρ, fτ = split_gdensity(info.basis, fx)
+        fρ, fτ, fhubbard_n = split_gdensity(info.basis, fx)
         if i < scf.m_start
             @debug "Skipping Anderson acceleration in iteration $i"
             ρ = @. ρ + β * (fρ - ρ)
         else
             @debug "Using Anderson acceleration in iteration $i"
-            # Damp ρ and send it to anderson; τ is just patched through without any changes
+            # Damp ρ and send it to anderson; τ and hubbard_n are patched through unchanged
             residual_ρ = fρ - ρ
             ρ = acceleration(ρ, β, residual_ρ)
         end
-        x = pack_gdensity(info.basis, ρ, fτ)
+        x = pack_gdensity(info.basis, ρ, fτ, fhubbard_n)
     end
     (; fixpoint=x, info)
 end
@@ -126,7 +132,7 @@ function ScfAndersonSolver(; representation=TauVwScaled(), m_start::Integer=1, k
     ScfAndersonSolver(representation, m_start, kwargs)
 end
 function (scf::ScfAndersonSolver)(f, x0, info0; maxiter, damping)
-    T = eltype(x0)
+    T = eltype(x0.ρ)
     β = convert(T, damping)
     x = x0
     info = info0
@@ -137,38 +143,43 @@ function (scf::ScfAndersonSolver)(f, x0, info0; maxiter, damping)
             break
         end
 
-        x  = to_representation!(scf.representation, info.basis,  x)
-        fx = to_representation!(scf.representation, info.basis, fx)
+        ρτ = to_representation(scf.representation, info.basis, x.ρ, x.τ)
+        fρτ = to_representation(scf.representation, info.basis, fx.ρ, fx.τ)
         if i < scf.m_start
             @debug "Skipping Anderson acceleration in iteration $i"
-            x = @. x + β * (fx - x)
+            @. ρτ = ρτ + β * (fρτ - ρτ)
         else
             @debug "Using Anderson acceleration in iteration $i"
-            # Damp ρ and send it to anderson; τ is just patched through without any changes
-            residual = fx - x
-            x = acceleration(x, β, residual)
+            residual = fρτ - ρτ
+            ρτ = acceleration(ρτ, β, residual)
         end
-        x = from_representation!(scf.representation, info.basis, x)
+        ρ, τ = from_representation(scf.representation, info.basis, ρτ)
+        x = pack_gdensity(info.basis, ρ, τ, fx.hubbard_n)
     end
     (; fixpoint=x, info)
 end
 
 struct TauVwScaled; end
-function to_representation!(::TauVwScaled, basis, x)
-    inv_τUEG(τ::AbstractArray) = (10/3 * (3π^2)^(-2/3) * max.(0, τ)) .^ (3/5)
-    ρ, τ = split_gdensity(basis, x)
+function to_representation(::TauVwScaled, basis, ρ, τ)
     if !isnothing(τ)
-        τ .= inv_τUEG(τ .- von_weizsaecker_kinetic_energy_density(basis, ρ))
+        inv_τUEG(τ::AbstractArray) = (10/3 * (3π^2)^(-2/3) * max.(0, τ)) .^ (3/5)
+        τ_repr = inv_τUEG(τ .- von_weizsaecker_kinetic_energy_density(basis, ρ))
+        cat(ρ, τ_repr; dims=Val(4))
+    else
+        ρ
     end
-    x
 end
-function from_representation!(::TauVwScaled, basis, x)
-    τUEG(ρ::AbstractArray) =  3/10 * (3π^2)^(2/3)  * max.(0, ρ)  .^ (5/3)
-    ρ, τ = split_gdensity(basis, x)
-    if !isnothing(τ)
-        τ .= τUEG(τ) .+ von_weizsaecker_kinetic_energy_density(basis, ρ)
+function from_representation(::TauVwScaled, basis, repr)
+    n_spin = basis.model.n_spin_components
+    if size(repr, 4) == 2n_spin
+        τUEG(ρ::AbstractArray) =  3/10 * (3π^2)^(2/3)  * max.(0, ρ)  .^ (5/3)
+        ρ = repr[:, :, :, 1:n_spin]
+        τ = repr[:, :, :, n_spin+1:end]
+        τ .= τUEG(τ) .+ von_weizsaecker_kinetic_energy_density(basis, ρ)
+        (ρ, τ)
+    else
+        (repr, nothing)
     end
-    x
 end
 
 function Base.show(io::IO, scf::Union{ScfAndersonSolver,ScfAndersonDensitySolver})

--- a/src/scf/self_consistent_field.jl
+++ b/src/scf/self_consistent_field.jl
@@ -123,9 +123,16 @@ function next_density(ham::Hamiltonian,
         τ = nothing
     end
 
-    (; ψ=eigres.X, eigenvalues=eigres.λ, occupation, εF, ρ, τ, diagonalization=eigres,
-     n_bands_converge, nbandsalg.occupation_threshold,
-     n_matvec=mpi_sum(eigres.n_matvec, ham.basis.comm_kpts))
+    ihubbard = findfirst(t -> t isa TermHubbard, ham.basis.terms)
+    if !isnothing(ihubbard)
+        hubbard_n = compute_hubbard_n(ham.basis.terms[ihubbard], ham.basis, eigres.X, occupation)
+    else
+        hubbard_n = nothing
+    end
+
+    (; ψ=eigres.X, eigenvalues=eigres.λ, occupation, εF, ρ, τ, hubbard_n,
+       diagonalization=eigres, n_bands_converge, nbandsalg.occupation_threshold,
+       n_matvec=mpi_sum(eigres.n_matvec, ham.basis.comm_kpts))
 end
 
 
@@ -198,34 +205,25 @@ Overview of parameters:
     # linear combinations (such as mixing or Anderson); see split_gdensity and pack_gdensity in
     # densities.jl for details.
     function fixpoint_map(Din, info)
-        (; ψ, occupation, eigenvalues, εF, n_iter, converged, timedout, hubbard_n) = info
+        (; ψ, occupation, eigenvalues, εF, n_iter, converged, timedout) = info
         n_iter += 1
-        (ρin, τin) = split_gdensity(basis, Din)
+        ρin, τin, hubbard_nin = split_gdensity(basis, Din)
 
         # Note that ρin is not the density of ψ, and the eigenvalues
         # are not the self-consistent ones, which makes this energy non-variational
         energies, ham = energy_hamiltonian(basis, ψ, occupation;
-                                           exxalg, ρ=ρin, τ=τin, hubbard_n, eigenvalues, εF, 
-                                           nbandsalg.occupation_threshold)
+                                           exxalg, ρ=ρin, τ=τin, hubbard_n=hubbard_nin,
+                                           eigenvalues, εF, nbandsalg.occupation_threshold)
 
         # Diagonalize `ham` to get the new state
         nextstate = next_density(ham, nbandsalg, fermialg; eigensolver, ψ, eigenvalues,
                                  occupation, miniter=1,
                                  tol=determine_diagtol(diagtolalg, info))
-        (; ψ, eigenvalues, occupation, εF, ρ, τ) = nextstate
-        D = pack_gdensity(basis, ρ, τ)
-
-        # TODO: Dirty hack. This should be solved more generally and hubbard should be on
-        #       the same footing as τ and ρ as part of the generalised density;
-        #       see discussion in https://github.com/JuliaMolSim/DFTK.jl/issues/1065
-        ihubbard = findfirst(t -> t isa TermHubbard, basis.terms)
-        if !isnothing(ihubbard)
-            hubbard_n = compute_hubbard_n(basis.terms[ihubbard], basis, ψ, occupation)
-        end
+        (; ψ, eigenvalues, occupation, εF, ρ, τ, hubbard_n) = nextstate
 
         # Update info with results gathered so far
-        info_next = (; ham, basis, ρin, τin, converged, stage=:iterate, algorithm="SCF",
-                       hubbard_n, α=damping, n_iter, nbandsalg.occupation_threshold,
+        info_next = (; ham, basis, ρin, τin, hubbard_nin, converged, stage=:iterate,
+                       algorithm="SCF", α=damping, n_iter, nbandsalg.occupation_threshold,
                        seed, runtime_ns=time_ns() - start_ns, nextstate...,
                        diagonalization=[nextstate.diagonalization])
 
@@ -236,8 +234,16 @@ Overview of parameters:
                                   nbandsalg.occupation_threshold)
         end
 
-        ΔD = D - Din
-        Δρ, Δτ = split_gdensity(basis, ΔD)
+        # Residual of the generalised density. Only ρ and τ are mixed/accelerated, so the
+        # residual only needs their differences; hubbard_n is patched through, so it is passed
+        # along as its new value rather than as an increment (see below).
+        Δρ = ρ - ρin
+        Δτ = isnothing(τ) ? nothing : τ - τin
+        if isnothing(hubbard_nin) && !isnothing(hubbard_n)
+            hubbard_nin = zero(hubbard_n)
+        end
+        Δhubbard_n = isnothing(hubbard_n) ? nothing : hubbard_n - hubbard_nin
+        ΔD = pack_gdensity(basis, Δρ, Δτ, Δhubbard_n)
         history_Etot = vcat(info.history_Etot, energies.total)
         history_Δρ   = vcat(info.history_Δρ, norm(Δρ) * sqrt(basis.dvol))
         history_Δτ   = vcat(info.history_Δτ, isnothing(Δτ) ? zero(eltype(Δρ))
@@ -245,8 +251,13 @@ Overview of parameters:
         info_next = merge(info_next, (; energies, history_Etot, history_Δρ, history_Δτ,
                                         n_matvec=info.n_matvec + nextstate.n_matvec))
 
-        # Mix generalised density (i.e. both ρ and τ)
-        Dnext = Din + mix_gdensity(mixing, basis, ΔD; info_next...)
+        # Mix generalised density
+        mixed = mix_gdensity(mixing, basis, ΔD; info_next...)
+        Pinv_Δρ, Pinv_Δτ, Pinv_Δhubbard_n = split_gdensity(basis, mixed)
+        ρnext = ρin + Pinv_Δρ
+        τnext = isnothing(τin) ? nothing : τin + Pinv_Δτ
+        hubbard_nnext = isnothing(hubbard_nin) ? nothing : hubbard_nin + Pinv_Δhubbard_n
+        Dnext = pack_gdensity(basis, ρnext, τnext, hubbard_nnext)
 
         converged = mpi_bcast(n_iter ≥ miniter && is_converged(info_next), basis.comm_kpts)
         timedout  = mpi_bcast(Dates.now() ≥ timeout_date,                  basis.comm_kpts)
@@ -265,7 +276,8 @@ Overview of parameters:
                    history_Etot=T[], history_Δρ=T[], history_Δτ=T[])
 
     # Convergence is flagged by is_converged inside the fixpoint_map.
-    _, info = solver(fixpoint_map, pack_gdensity(basis, ρ, τ), info_init; maxiter, damping)
+    _, info = solver(fixpoint_map, pack_gdensity(basis, ρ, τ, hubbard_n), info_init;
+                     maxiter, damping)
 
     # We do not use the return value of solver but rather the one that got updated by fixpoint_map
     # ψ is consistent with ρ, so we return that. We also perform a last energy computation

--- a/src/scf/self_consistent_field.jl
+++ b/src/scf/self_consistent_field.jl
@@ -16,7 +16,8 @@ function kwargs_scf_checkpoints(basis::AbstractBasis;
                                 diagtolalg::AdaptiveDiagtol=AdaptiveDiagtol(),
                                 ρ=guess_density(basis),
                                 τ=guess_kinetic_energy_density(basis, ρ),
-                                hubbard_n=nothing, ψ=nothing, occupation=nothing,
+                                hubbard_n=guess_hubbard_n(basis),
+                                ψ=nothing, occupation=nothing,
                                 save_ψ=false, kwargs...)
     if isfile(filename)
         # Disable strict checking, since we can live with only the density data
@@ -172,7 +173,7 @@ Overview of parameters:
     basis::PlaneWaveBasis{T};
     ρ=guess_density(basis),
     τ=guess_kinetic_energy_density(basis, ρ),
-    hubbard_n=nothing,
+    hubbard_n=guess_hubbard_n(basis),
     ψ=nothing,
     occupation=nothing,
     eigenvalues=nothing,
@@ -239,9 +240,6 @@ Overview of parameters:
         # along as its new value rather than as an increment (see below).
         Δρ = ρ - ρin
         Δτ = isnothing(τ) ? nothing : τ - τin
-        if isnothing(hubbard_nin) && !isnothing(hubbard_n)
-            hubbard_nin = zero(hubbard_n)
-        end
         Δhubbard_n = isnothing(hubbard_n) ? nothing : hubbard_n - hubbard_nin
         ΔD = pack_gdensity(basis, Δρ, Δτ, Δhubbard_n)
         history_Etot = vcat(info.history_Etot, energies.total)

--- a/src/terms/hubbard.jl
+++ b/src/terms/hubbard.jl
@@ -255,3 +255,34 @@ function reshape_hubbard_proj(projectors::Vector{Matrix{Complex{T}}},
 
     p_I
 end
+
+"""
+Guess an initial hubbard_n if the basis has a Hubbard term, otherwise nothing.
+For now, uses a naive 1/2 occupancy initial guess (i.e. zero Hubbard potential).
+Better guesses could be implemented based on the pseudopotential.
+However, generally speaking there can be many metastable solutions.
+"""
+function guess_hubbard_n(basis::PlaneWaveBasis{T}) where {T}
+    ihubbard = findfirst(t -> t isa TermHubbard, basis.terms)
+    isnothing(ihubbard) && return nothing
+
+    term = basis.terms[ihubbard]
+    map(term.manifolds) do manifold
+        n_spin = basis.model.n_spin_components
+
+        manifold_atoms = manifold.iatoms
+        natoms = length(manifold_atoms)
+        l = manifold.l
+        hubbard_n = Array{Matrix{Complex{T}}}(undef, n_spin, natoms, natoms)
+        for σ in 1:n_spin
+            for idx in 1:natoms, jdx in 1:natoms
+                if idx == jdx
+                    hubbard_n[σ, idx, jdx] = I(2l+1) / 2
+                else
+                    hubbard_n[σ, idx, jdx] = zeros(Complex{T}, 2l+1, 2l+1)
+                end
+            end
+        end
+        hubbard_n
+    end
+end

--- a/test/gdensities.jl
+++ b/test/gdensities.jl
@@ -3,7 +3,7 @@
     using PseudoPotentialData
     using Logging
     using DFTK
-    using DFTK: TauVwScaled, to_representation!, from_representation!
+    using DFTK: TauVwScaled, to_representation, from_representation
     system = load_system("structures/AlVac_4.extxyz")
     pseudopotentials = Dict(:Al => "pseudos/Al_m.upf")
     τW = DFTK.von_weizsaecker_kinetic_energy_density
@@ -22,18 +22,18 @@
     @test all(τW(basis, ρ) .≤ τ)  # Hoffman-Ostenhof
 
     # Check that pack/split are identities
-    D = DFTK.pack_gdensity(basis, ρ, τ)
+    D = DFTK.pack_gdensity(basis, ρ, τ, nothing)
     let
-        ρs, τs = DFTK.split_gdensity(basis, D)
+        ρs, τs, hubbard_ns = DFTK.split_gdensity(basis, D)
         @test ρs ≈ ρ atol=1e-12
         @test τs ≈ τ atol=1e-12
+        @test isnothing(hubbard_ns)
     end
 
     let
         repr = TauVwScaled()
-        Dnew = to_representation!(repr, basis, copy(D))
-        Dnew = from_representation!(repr, basis,  Dnew)
-        ρs, τs = DFTK.split_gdensity(basis, Dnew)
+        ρτ = to_representation(repr, basis, ρ, τ)
+        ρs, τs = from_representation(repr, basis, ρτ)
         @test ρs ≈ ρ atol=1e-12
         @test τs ≈ τ atol=1e-12
     end
@@ -50,17 +50,18 @@
     @test all(τW(basis, scfres.ρ) .≤ scfres.τ)  # Hoffman-Ostenhof
 
     # Check that pack/split are identities
-    Dout = DFTK.pack_gdensity(basis, scfres.ρ, scfres.τ)
-    let 
-        ρs, τs = DFTK.split_gdensity(basis, Dout)
+    Dout = DFTK.pack_gdensity(basis, scfres.ρ, scfres.τ, nothing)
+    let
+        ρs, τs, hubbard_ns = DFTK.split_gdensity(basis, Dout)
         @test ρs ≈ scfres.ρ atol=1e-12
         @test τs ≈ scfres.τ atol=1e-12
+        @test isnothing(hubbard_ns)
     end
 
-    # Take a few random, convex linear combinations
+    # Take a few random, convex linear combinations (of the physical (ρ, τ) content)
     for α in (rand(), rand(), rand())
-        Dnew = D + α * (Dout - D)
-        ρnew, τnew = DFTK.split_gdensity(basis, Dnew)
+        ρnew = D.ρ + α * (Dout.ρ - D.ρ)
+        τnew = D.τ + α * (Dout.τ - D.τ)
 
         @test all(0 .≤ τnew)
         @test all(0 .≤ ρnew)


### PR DESCRIPTION
Incremental progress towards the state refactor... :P

The gdensity is now a tuple of the density, KED, and `hubbard_n`. A `ComponentArray` is not pratical because 1) `hubbard_n` is quite deeply nested and 2) `hubbard_n` is Complex. Regarding 2), apparently it should be real as long as time-reversal symmetry is satisfied, but we probably want to keep it complex for max generality.

Maybe we'll want to move towards a custom struct eventually with a vector-like interface. Currently I implemented addition, subtraction and damping by explicitly breaking the gdensity into its 3 components.

The `hubbard_n` is still not Anderson-accelerated, but this would be possible to implement at the level of the scf solver (quite localized which is nice).

(Started as a vibe coding experiment but then I tweaked/rewrote most of it.)