### PR TITLE
Optionally use a denser grid for the XC evaluation

### DIFF
--- a/ext/DFTKJLD2Ext.jl
+++ b/ext/DFTKJLD2Ext.jl
@@ -36,6 +36,7 @@ function DFTK.save_bands(::Val{:jld2}, file::AbstractString, band_data::NamedTup
     save_jld2(DFTK.band_data_to_dict!, file, band_data; kwargs...)
 end
 
+# TODO: how to save and load the extra_kwargs?
 function load_basis(jld; comm=MPI.COMM_WORLD)
     if mpi_master(comm)
         basis_args = (jld["model"],

--- a/src/PlaneWaveBasis.jl
+++ b/src/PlaneWaveBasis.jl
@@ -400,23 +400,29 @@ end
 
 
 @doc raw"""
+    G_vectors(fft_grid::FFTGrid)
     G_vectors(basis::PlaneWaveBasis)
     G_vectors(basis::PlaneWaveBasis, kpt::Kpoint)
 
-The list of wave vectors ``G`` in reduced (integer) coordinates of a `basis`
-or a ``k``-point `kpt`.
+The list of wave vectors ``G`` in reduced (integer) coordinates of an
+FFT grid, a `basis` or a ``k``-point `kpt`.
 """
-G_vectors(basis::PlaneWaveBasis) = basis.fft_grid.G_vectors
+G_vectors(fft_grid::FFTGrid) = fft_grid.G_vectors
+G_vectors(basis::PlaneWaveBasis) = G_vectors(basis.fft_grid)
 G_vectors(::PlaneWaveBasis, kpt::Kpoint) = kpt.G_vectors
 
 @doc raw"""
+    G_vectors_cart(fft_grid::FFTGrid, model::Model)
     G_vectors_cart(basis::PlaneWaveBasis)
     G_vectors_cart(basis::PlaneWaveBasis, kpt::Kpoint)
 
-The list of ``G`` vectors of a given `basis` or `kpt`, in Cartesian coordinates.
+The list of ``G`` vectors of a given FFT grid, `basis` or `kpt`, in Cartesian coordinates.
 """
+function G_vectors_cart(fft_grid::FFTGrid, model::Model)
+    map(recip_vector_red_to_cart(model), G_vectors(fft_grid))
+end
 function G_vectors_cart(basis::PlaneWaveBasis)
-    map(recip_vector_red_to_cart(basis.model), G_vectors(basis))
+    G_vectors_cart(basis.fft_grid, basis.model)
 end
 function G_vectors_cart(basis::PlaneWaveBasis, kpt::Kpoint)
     recip_vector_red_to_cart.(basis.model, G_vectors(basis, kpt))

--- a/src/PlaneWaveBasis.jl
+++ b/src/PlaneWaveBasis.jl
@@ -92,6 +92,10 @@ struct PlaneWaveBasis{T,
     # not yet implement symmetry. See `unfold_bz` as a convenient way to use this.
     use_symmetries_for_kpoint_reduction::Bool
 
+    # Additional kwargs that were passed to the constructor and forwarded at term instantiation.
+    # These are kept here such that the basis can be reconstructed.
+    extra_kwargs::Any
+
     ## Instantiated terms (<: Term). See Hamiltonian for high-level usage
     terms::Vector{Any}
 end
@@ -130,7 +134,7 @@ function PlaneWaveBasis(model::Model{T}, Ecut::Real, fft_size::Tuple{Int, Int, I
                         variational::Bool, kgrid::AbstractKgrid,
                         symmetries_respect_rgrid::Bool,
                         use_symmetries_for_kpoint_reduction::Bool,
-                        comm_kpts, architecture::Arch
+                        comm_kpts, architecture::Arch, extra_kwargs
                        ) where {T <: Real, Arch <: AbstractArchitecture}
     # TODO This needs a refactor. There is too many different things here happening
     #      at once. In particular steps, which can become rather costly for larger
@@ -250,12 +254,12 @@ function PlaneWaveBasis(model::Model{T}, Ecut::Real, fft_size::Tuple{Int, Int, I
         kcoords_global, kweights_global, n_irreducible_kpoints,
         comm_kpts, krange_thisproc, krange_allprocs, krange_thisproc_allspin,
         architecture, symmetries, symmetries_respect_rgrid,
-        use_symmetries_for_kpoint_reduction, terms)
+        use_symmetries_for_kpoint_reduction, extra_kwargs, terms)
 
     # Instantiate the terms with the basis
     for (it, t) in enumerate(model.term_types)
         term_name = string(nameof(typeof(t)))
-        @timing "Instantiation $term_name" basis.terms[it] = t(basis)
+        @timing "Instantiation $term_name" basis.terms[it] = t(basis; extra_kwargs...)
     end
     basis
 end
@@ -328,7 +332,8 @@ basis = PlaneWaveBasis(model; Ecut=12, fft_size=(48,48,48))
                                 variational=true, fft_size=nothing,
                                 symmetries_respect_rgrid=isnothing(fft_size),
                                 use_symmetries_for_kpoint_reduction=true,
-                                comm_kpts=MPI.COMM_WORLD, architecture=CPU()) where {T <: Real}
+                                comm_kpts=MPI.COMM_WORLD, architecture=CPU(),
+                                extra_kwargs...) where {T <: Real}
     if isnothing(kshift)
         kgrid_inner = build_kgrid(model.lattice, kgrid)
     else
@@ -365,7 +370,7 @@ basis = PlaneWaveBasis(model; Ecut=12, fft_size=(48,48,48))
 
     PlaneWaveBasis(model, austrip(Ecut), fft_size, variational, kgrid_inner,
                    symmetries_respect_rgrid, use_symmetries_for_kpoint_reduction,
-                   comm_kpts, architecture)
+                   comm_kpts, architecture, extra_kwargs)
 end
 
 """
@@ -380,7 +385,8 @@ e.g. a [`MonkhorstPack`](@ref) or a [`ExplicitKpoints`](@ref) grid.
                    basis.fft_size, basis.variational,
                    kgrid_inner, basis.symmetries_respect_rgrid,
                    basis.use_symmetries_for_kpoint_reduction,
-                   basis.comm_kpts, basis.architecture)
+                   basis.comm_kpts, basis.architecture,
+                   basis.extra_kwargs)
 end
 
 """
@@ -395,19 +401,18 @@ Creates a new basis identical to `basis`, but with a different [`Model`](@ref)
                    basis.fft_size, basis.variational,
                    basis.kgrid, basis.symmetries_respect_rgrid,
                    basis.use_symmetries_for_kpoint_reduction,
-                   basis.comm_kpts, basis.architecture)
+                   basis.comm_kpts, basis.architecture,
+                   basis.extra_kwargs)
 end
 
 
 @doc raw"""
-    G_vectors(fft_grid::FFTGrid)
     G_vectors(basis::PlaneWaveBasis)
     G_vectors(basis::PlaneWaveBasis, kpt::Kpoint)
 
-The list of wave vectors ``G`` in reduced (integer) coordinates of an
-FFT grid, a `basis` or a ``k``-point `kpt`.
+The list of wave vectors ``G`` in reduced (integer) coordinates of a `basis`
+or a ``k``-point `kpt`.
 """
-G_vectors(fft_grid::FFTGrid) = fft_grid.G_vectors
 G_vectors(basis::PlaneWaveBasis) = G_vectors(basis.fft_grid)
 G_vectors(::PlaneWaveBasis, kpt::Kpoint) = kpt.G_vectors
 

--- a/src/terms/anyonic.jl
+++ b/src/terms/anyonic.jl
@@ -62,7 +62,7 @@ struct Anyonic
     hbar
     β
 end
-function (A::Anyonic)(basis)
+function (A::Anyonic)(basis; kwargs...)
     @assert length(basis.kpoints) == 1
     @assert basis.kpoints[1].coordinate == [0, 0, 0]
     @assert basis.model.n_dim == 2

--- a/src/terms/entropy.jl
+++ b/src/terms/entropy.jl
@@ -5,7 +5,7 @@ This is in particular useful because the free energy,
 not the energy, is minimized at self-consistency.
 """
 struct Entropy end
-(::Entropy)(basis) = TermEntropy()
+(::Entropy)(basis; kwargs...) = TermEntropy()
 struct TermEntropy <: Term end
 
 function ene_ops(term::TermEntropy, basis::PlaneWaveBasis{T}, ψ, occupation;

--- a/src/terms/ewald.jl
+++ b/src/terms/ewald.jl
@@ -9,7 +9,7 @@ Base.@kwdef struct Ewald
     η = nothing  # Parameter used for the splitting 1/r ≡ erf(η·r)/r + erfc(η·r)/r
                  # (or nothing if autoselected)
 end
-(ewald::Ewald)(basis) = TermEwald(basis; η=something(ewald.η, default_η(basis.model.lattice)))
+(ewald::Ewald)(basis; kwargs...) = TermEwald(basis; η=something(ewald.η, default_η(basis.model.lattice)))
 
 struct TermEwald{T} <: TermLinear
     energy::T                # precomputed energy

--- a/src/terms/exact_exchange.jl
+++ b/src/terms/exact_exchange.jl
@@ -20,7 +20,7 @@ where the `kernel` keyword argument is an [`InteractionKernel`](@ref) , typicall
     scaling_factor::Real = 1.0
     kernel = Coulomb()
 end
-(ex::ExactExchange)(basis) = TermExactExchange(basis, ex.scaling_factor, ex.kernel)
+(ex::ExactExchange)(basis; kwargs...) = TermExactExchange(basis, ex.scaling_factor, ex.kernel)
 
 struct TermExactExchange <: Term
     scaling_factor::Real  # scaling factor, absorbed into interaction_kernel

--- a/src/terms/hartree.jl
+++ b/src/terms/hartree.jl
@@ -15,7 +15,7 @@ struct Hartree
     scaling_factor::Real  # to scale by an arbitrary factor (useful for exploration)
 end
 Hartree(; scaling_factor=1) = Hartree(scaling_factor)
-(hartree::Hartree)(basis)   = TermHartree(basis, hartree.scaling_factor)
+(hartree::Hartree)(basis; kwargs...)   = TermHartree(basis, hartree.scaling_factor)
 function Base.show(io::IO, hartree::Hartree)
     fac = isone(hartree.scaling_factor) ? "" : ", scaling_factor=$(hartree.scaling_factor)"
     print(io, "Hartree($fac)")

--- a/src/terms/hubbard.jl
+++ b/src/terms/hubbard.jl
@@ -125,7 +125,7 @@ function Hubbard(manifold_to_U::Vararg{T}) where {T <: Pair}
     Hubbard([m[1] for m in manifold_to_U], [m[2] for m in manifold_to_U])
 end
 
-function (hubbard::Hubbard{T})(basis::AbstractBasis) where {T}
+function (hubbard::Hubbard{T})(basis::AbstractBasis; kwargs...) where {T}
     manifolds = [resolve_hubbard_manifold(manifold, basis.model) for manifold in hubbard.manifolds]
     projs, labels = atomic_orbital_projectors(basis)
     manifold_data = map(manifold -> extract_manifold(manifold, projs, labels), manifolds)

--- a/src/terms/kinetic.jl
+++ b/src/terms/kinetic.jl
@@ -9,7 +9,7 @@ Base.@kwdef struct Kinetic{F}
     blowup::F = BlowupIdentity()  # Blow-up to smooth energy bands.
 end
 
-(kin::Kinetic)(basis) = TermKinetic(basis, kin.scaling_factor, kin.blowup)
+(kin::Kinetic)(basis; kwargs...) = TermKinetic(basis, kin.scaling_factor, kin.blowup)
 function Base.show(io::IO, kin::Kinetic)
     bup = kin.blowup isa BlowupIdentity ? "" : ", blowup=$(kin.blowup)"
     fac = isone(kin.scaling_factor) ? "" : ", scaling_factor=$(kin.scaling_factor)"

--- a/src/terms/local.jl
+++ b/src/terms/local.jl
@@ -33,7 +33,7 @@ External potential given as values.
 struct ExternalFromValues
     potential_values::AbstractArray
 end
-function (external::ExternalFromValues)(basis::PlaneWaveBasis{T}) where {T}
+function (external::ExternalFromValues)(basis::PlaneWaveBasis{T}; kwargs...) where {T}
     # TODO Could do interpolation here
     @assert size(external.potential_values) == basis.fft_size
     TermExternal(convert_dual.(T, external.potential_values))
@@ -47,7 +47,7 @@ struct ExternalFromReal
     potential::Function
 end
 
-function (external::ExternalFromReal)(basis::PlaneWaveBasis{T}) where {T}
+function (external::ExternalFromReal)(basis::PlaneWaveBasis{T}; kwargs...) where {T}
     pot_real = external.potential.(r_vectors_cart(basis))
     TermExternal(convert_dual.(T, pot_real))
 end
@@ -59,7 +59,7 @@ G is passed in Cartesian coordinates
 struct ExternalFromFourier
     potential::Function
 end
-function (external::ExternalFromFourier)(basis::PlaneWaveBasis{T}) where {T}
+function (external::ExternalFromFourier)(basis::PlaneWaveBasis{T}; kwargs...) where {T}
     unit_cell_volume = basis.model.unit_cell_volume
     pot_fourier = map(G_vectors_cart(basis)) do G
         convert_dual(complex(T), external.potential(G) / sqrt(unit_cell_volume))
@@ -136,7 +136,7 @@ function compute_local_potential(basis::PlaneWaveBasis{T}; positions=basis.model
         return ifft(basis, pot_fourier)
     end
 end
-(::AtomicLocal)(basis::PlaneWaveBasis{T}) where {T} =
+(::AtomicLocal)(basis::PlaneWaveBasis{T}; kwargs...) where {T} =
     TermAtomicLocal(compute_local_potential(basis))
 
 function compute_forces(::TermAtomicLocal, basis::PlaneWaveBasis{T}, ψ, occupation;

--- a/src/terms/local_nonlinearity.jl
+++ b/src/terms/local_nonlinearity.jl
@@ -7,7 +7,7 @@ end
 struct TermLocalNonlinearity{TF} <: TermNonlinear
     f::TF
 end
-(L::LocalNonlinearity)(::AbstractBasis) = TermLocalNonlinearity(L.f)
+(L::LocalNonlinearity)(::AbstractBasis; kwargs...) = TermLocalNonlinearity(L.f)
 
 function ene_ops(term::TermLocalNonlinearity, basis::PlaneWaveBasis{T}, ψ, occupation;
                  ρ, kwargs...) where {T}

--- a/src/terms/magnetic.jl
+++ b/src/terms/magnetic.jl
@@ -8,12 +8,13 @@ struct Magnetic
     Afunction::Function  # A(x,y,z) returns [Ax,Ay,Az]
                          # both [x,y,z] and [Ax,Ay,Az] are in *Cartesian* coordinates
 end
-(M::Magnetic)(basis) = TermMagnetic(basis, M.Afunction)
+(M::Magnetic)(basis; kwargs...) = TermMagnetic(basis, M.Afunction)
 
 struct MagneticFromValues
     # Apotential[α] is an array of size fft_size for α=1:3
     Apotential::Vector{<:AbstractArray}
 end
+# TODO: this looks broken, it should take the basis
 function (M::MagneticFromValues)(Apotential)
     @assert length(Apotential) == 3
     @assert size(Apotential[1]) == basis.fft_size

--- a/src/terms/nonlocal.jl
+++ b/src/terms/nonlocal.jl
@@ -6,7 +6,7 @@ Nonlocal term coming from norm-conserving pseudopotentials in Kleinmann-Bylander
 ```
 """
 struct AtomicNonlocal end
-function (::AtomicNonlocal)(basis::PlaneWaveBasis{T}) where {T}
+function (::AtomicNonlocal)(basis::PlaneWaveBasis{T}; kwargs...) where {T}
     model = basis.model
 
     # keep only pseudopotential atoms and positions

--- a/src/terms/pairwise.jl
+++ b/src/terms/pairwise.jl
@@ -18,7 +18,7 @@ function PairwisePotential(V, params; max_radius=100)
     params = Dict(minmax(key[1], key[2]) => value for (key, value) in params)
     PairwisePotential(V, params, max_radius)
 end
-@timing "precomp: Pairwise" function (P::PairwisePotential)(basis::PlaneWaveBasis{T}) where {T}
+@timing "precomp: Pairwise" function (P::PairwisePotential)(basis::PlaneWaveBasis{T}; kwargs...) where {T}
     model = basis.model
     symbols = element_symbol.(model.atoms)
     (; energy, forces) = energy_forces_pairwise(model.lattice, symbols, model.positions,

--- a/src/terms/psp_correction.jl
+++ b/src/terms/psp_correction.jl
@@ -2,7 +2,7 @@
 Pseudopotential correction energy. TODO discuss the need for this.
 """
 struct PspCorrection end
-(::PspCorrection)(basis) = TermPspCorrection(basis)
+(::PspCorrection)(basis; kwargs...) = TermPspCorrection(basis)
 
 struct TermPspCorrection{T} <: TermLinear
     energy::T  # precomputed energy

--- a/src/terms/xc.jl
+++ b/src/terms/xc.jl
@@ -1,5 +1,11 @@
 """
 Exchange-correlation term, defined by a list of functionals and usually evaluated through libxc.
+
+The grid used for the evaluation of the exchange-correlation energy integral can
+be customized at `PlaneWaveBasis` construction time with the
+`supersampling_xc`, `Ecut_density_xc` or `fft_size_xc` keyword arguments.
+Using a denser grid can help reduce grid position dependence of the XC energy/potential
+(also known as "egg-box effect"). See also Durham et al. [Electron. Struct. 2025].
 """
 struct Xc
     functionals::Vector{Functional}
@@ -10,17 +16,10 @@ struct Xc
 
     use_nlcc::Bool      # Use non-linear core correction or not
     nlcc_from_vw::Bool  # Use van Weizsäcker kinetic energy density for τcore
-
-    # FFT grid on which to evaluate the XC term, or nothing to use the one of the basis.
-    # TODO: This is a discretization parameter, it should not live in Xc
-    #       but rather be passed through the PlaneWaveBasis constructor.
-    fft_size::Union{Nothing,Tuple{Int,Int,Int}}
 end
 function Xc(functionals::AbstractVector{<:Functional}; scaling_factor=1,
-            potential_threshold=0, use_nlcc=true,
-            nlcc_from_vw=false, fft_size=nothing)
-    Xc(functionals, scaling_factor, potential_threshold, use_nlcc,
-       nlcc_from_vw, fft_size)
+            potential_threshold=0, use_nlcc=true, nlcc_from_vw=false)
+    Xc(functionals, scaling_factor, potential_threshold, use_nlcc, nlcc_from_vw)
 end
 function Xc(functionals::AbstractVector; kwargs...)
     fun = map(functionals) do f
@@ -36,11 +35,11 @@ function Base.show(io::IO, xc::Xc)
     print(io, "Xc($fun$fac)")
 end
 
-function (xc::Xc)(basis::PlaneWaveBasis{T}) where {T}
+function (xc::Xc)(basis::PlaneWaveBasis{T};
+                  supersampling_xc=nothing,
+                  Ecut_density_xc=nothing,
+                  fft_size_xc=nothing) where {T}
     isempty(xc.functionals) && return TermNoop()
-
-    fft_grid = xc_fft_grid(xc, basis)
-    dvol = basis.model.unit_cell_volume / prod(fft_grid.fft_size)
 
     # Charge density for non-linear core correction
     ρcore = nothing
@@ -63,6 +62,9 @@ function (xc::Xc)(basis::PlaneWaveBasis{T}) where {T}
         end
     end
 
+    fft_grid = xc_fft_grid(basis, supersampling_xc, Ecut_density_xc, fft_size_xc)
+    dvol = basis.model.unit_cell_volume / prod(fft_grid.fft_size)
+
     functionals = map(xc.functionals) do fun
         # Strip duals from functional parameters if needed
         params = parameters(fun)
@@ -77,21 +79,43 @@ function (xc::Xc)(basis::PlaneWaveBasis{T}) where {T}
            T(xc.potential_threshold), ρcore, τcore, fft_grid, dvol)
 end
 
-function xc_fft_grid(xc::Xc, basis::PlaneWaveBasis)
-    isnothing(xc.fft_size) && return basis.fft_grid
+function xc_fft_grid(basis::PlaneWaveBasis, supersampling_xc, Ecut_density_xc, fft_size_xc)
+    if isnothing(supersampling_xc) && isnothing(Ecut_density_xc) && isnothing(fft_size_xc)
+        return basis.fft_grid
+    end
+    if !isnothing(supersampling_xc)
+        isnothing(Ecut_density_xc) || error("Cannot specify both supersampling_xc and Ecut_density_xc")
+        isnothing(fft_size_xc) || error("Cannot specify both supersampling_xc and fft_size_xc")
+        Ecut_density_xc = supersampling_xc^2 * basis.Ecut
+    end
+    if !isnothing(Ecut_density_xc)
+        isnothing(fft_size_xc) || error("Cannot specify both Ecut_density_xc and fft_size_xc")
+        # TODO: this is duplicated with PlaneWaveBasis
+        if basis.symmetries_respect_rgrid
+            # ensure that the FFT grid is compatible with the "reasonable" symmetries
+            # (those with fractional translations with denominators 2, 3, 4, 6,
+            #  this set being more or less arbitrary) by forcing the FFT size to be
+            # a multiple of the denominators.
+            # See https://github.com/JuliaMolSim/DFTK.jl/pull/642 for discussion
+            denominators = [denominator(rationalize(sym.w[i]; tol=SYMMETRY_TOLERANCE))
+                            for sym in basis.model.symmetries for i = 1:3]
+            factors = intersect((2, 3, 4, 6), denominators)
+        else
+            factors = (1, )
+        end
+        fft_size_xc = compute_fft_size(basis.model, Ecut_density_xc, nothing; supersampling=1, factors)
+    end
 
-    if !all(xc.fft_size .≥ basis.fft_size)
-        throw(ArgumentError("The Xc fft_size $(xc.fft_size) must be at least as large as " *
+    if !all(fft_size_xc .≥ basis.fft_size)
+        throw(ArgumentError("The fft_size_xc $(fft_size_xc) must be at least as large as " *
                             "the fft_size $(basis.fft_size) of the basis in each direction."))
     end
-    # TODO: this is inconvenient/nonsense; can we maybe just symmetrize the density with low-pass on?
-    symmetries = symmetries_preserving_rgrid(basis.symmetries, xc.fft_size)
+    symmetries = symmetries_preserving_rgrid(basis.symmetries, fft_size_xc)
     if length(symmetries) != length(basis.symmetries)
-        throw(ArgumentError("The Xc fft_size $(xc.fft_size) does not respect the symmetries " *
-                            "of the basis. Pass the `factors` used for the basis grid to " *
-                            "`compute_fft_size` to obtain a compatible size."))
+        throw(ArgumentError("The fft_size_xc $(fft_size_xc) does not respect " *
+                            "the symmetries of the basis."))
     end
-    FFTGrid(xc.fft_size, basis.model.unit_cell_volume, basis.architecture)
+    FFTGrid(fft_size_xc, basis.model.unit_cell_volume, basis.architecture)
 end
 
 function hybrid_parameters(xc::Xc)
@@ -119,7 +143,8 @@ function xc_potential_real(term::TermXc, basis::PlaneWaveBasis{T};
         throw(ArgumentError("TermXc needs the kinetic energy density τ. Please pass a `τ` " *
                             "keyword argument to your `Hamiltonian` or `energy_hamiltonian` call."))
     end
-    # TODO: build core densities on the XC FFT grid
+
+    # Add the model core charge density (non-linear core correction)
     if !isnothing(term.ρcore)
         ρ = ρ + term.ρcore
     end
@@ -127,7 +152,9 @@ function xc_potential_real(term::TermXc, basis::PlaneWaveBasis{T};
         τ = τ + term.τcore
     end
 
-    # TODO: if the FFT grids are equal this should be made a no-op
+    # The denser XC FFT grid is treated only as a fix for the XC energy/potential evaluation,
+    # hence the core densities are computed on the coarse grid and transferred along
+    # with the valence densities.
     ρ = transfer_density(ρ, basis.fft_grid, term.fft_grid)
     if !isnothing(τ)
         τ = transfer_density(τ, basis.fft_grid, term.fft_grid)
@@ -135,7 +162,7 @@ function xc_potential_real(term::TermXc, basis::PlaneWaveBasis{T};
 
     E, potential, Vτ = _xc_potential_real(term, basis.model, basis.comm_kpts, ρ, τ)
 
-    # the adjoint of Fourier interpolation is Fourier truncation
+    # The adjoint of Fourier zero-padding is Fourier truncation
     potential = transfer_density(potential, term.fft_grid, basis.fft_grid)
     if !isnothing(Vτ)
         Vτ = transfer_density(Vτ, term.fft_grid, basis.fft_grid)
@@ -466,8 +493,8 @@ function LibxcDensities(model::Model{T}, fft_grid::FFTtype, max_derivative::Inte
                             σ_real, Δρ_real, τ_Libxc)
 end
 
-function _check_negative_bonding_indicator_α(densities::LibxcDensities{T}, comm_kpts;
-                                             density_threshold=100eps(T)) where {T}
+function _check_negative_bonding_indicator_α(densities::LibxcDensities, comm_kpts;
+                                             density_threshold=100eps(eltype(densities.ρ_real)))
     # TODO: The idea here is that libxc cuts components of the XC evaluation anyway if
     #       the density (or contracted density gradient) is below a certain threshold,
     #       so we do the same here for the check to make sure this is not too noisy.
@@ -488,6 +515,7 @@ function _check_negative_bonding_indicator_α(densities::LibxcDensities{T}, comm
         minimum(failure_indicator)
     end
     if mpi_master(comm_kpts)
+        T = eltype(densities.ρ_real)
         if failure_indicator < -eps(T)
             @debug "xc: α failure indicator: $failure_indicator"
         end

--- a/src/terms/xc.jl
+++ b/src/terms/xc.jl
@@ -10,10 +10,17 @@ struct Xc
 
     use_nlcc::Bool      # Use non-linear core correction or not
     nlcc_from_vw::Bool  # Use van Weizsäcker kinetic energy density for τcore
+
+    # FFT grid on which to evaluate the XC term, or nothing to use the one of the basis.
+    # TODO: This is a discretization parameter, it should not live in Xc
+    #       but rather be passed through the PlaneWaveBasis constructor.
+    fft_size::Union{Nothing,Tuple{Int,Int,Int}}
 end
 function Xc(functionals::AbstractVector{<:Functional}; scaling_factor=1,
-            potential_threshold=0, use_nlcc=true, nlcc_from_vw=false)
-    Xc(functionals, scaling_factor, potential_threshold, use_nlcc, nlcc_from_vw)
+            potential_threshold=0, use_nlcc=true,
+            nlcc_from_vw=false, fft_size=nothing)
+    Xc(functionals, scaling_factor, potential_threshold, use_nlcc,
+       nlcc_from_vw, fft_size)
 end
 function Xc(functionals::AbstractVector; kwargs...)
     fun = map(functionals) do f
@@ -31,6 +38,9 @@ end
 
 function (xc::Xc)(basis::PlaneWaveBasis{T}) where {T}
     isempty(xc.functionals) && return TermNoop()
+
+    fft_grid = xc_fft_grid(xc, basis)
+    dvol = basis.model.unit_cell_volume / prod(fft_grid.fft_size)
 
     # Charge density for non-linear core correction
     ρcore = nothing
@@ -64,7 +74,24 @@ function (xc::Xc)(basis::PlaneWaveBasis{T}) where {T}
     end
     TermXc(convert(Vector{Functional}, functionals),
            convert_dual(T, xc.scaling_factor),
-           T(xc.potential_threshold), ρcore, τcore)
+           T(xc.potential_threshold), ρcore, τcore, fft_grid, dvol)
+end
+
+function xc_fft_grid(xc::Xc, basis::PlaneWaveBasis)
+    isnothing(xc.fft_size) && return basis.fft_grid
+
+    if !all(xc.fft_size .≥ basis.fft_size)
+        throw(ArgumentError("The Xc fft_size $(xc.fft_size) must be at least as large as " *
+                            "the fft_size $(basis.fft_size) of the basis in each direction."))
+    end
+    # TODO: this is inconvenient/nonsense; can we maybe just symmetrize the density with low-pass on?
+    symmetries = symmetries_preserving_rgrid(basis.symmetries, xc.fft_size)
+    if length(symmetries) != length(basis.symmetries)
+        throw(ArgumentError("The Xc fft_size $(xc.fft_size) does not respect the symmetries " *
+                            "of the basis. Pass the `factors` used for the basis grid to " *
+                            "`compute_fft_size` to obtain a compatible size."))
+    end
+    FFTGrid(xc.fft_size, basis.model.unit_cell_volume, basis.architecture)
 end
 
 function hybrid_parameters(xc::Xc)
@@ -72,16 +99,18 @@ function hybrid_parameters(xc::Xc)
     isempty(res) ? nothing : only(res)
 end
 
-struct TermXc{T,CT,TCT} <: TermNonlinear where {T,CT,TCT}
+struct TermXc{T,CT,TCT,FT} <: TermNonlinear where {T,CT,TCT,FT}
     functionals::Vector{Functional}
     scaling_factor::T
     potential_threshold::T
     ρcore::CT
     τcore::TCT
+    fft_grid::FT
+    dvol::T
 end
 DftFunctionals.needs_τ(term::TermXc) = any(needs_τ, term.functionals)
 
-function xc_potential_real(term::TermXc, basis::PlaneWaveBasis{T}, ψ, occupation;
+function xc_potential_real(term::TermXc, basis::PlaneWaveBasis{T};
                            ρ, τ=nothing) where {T}
     @assert !isempty(term.functionals)
     @assert all(family(xc) in (:lda, :gga, :mgga, :mggal) for xc in term.functionals)
@@ -90,8 +119,7 @@ function xc_potential_real(term::TermXc, basis::PlaneWaveBasis{T}, ψ, occupatio
         throw(ArgumentError("TermXc needs the kinetic energy density τ. Please pass a `τ` " *
                             "keyword argument to your `Hamiltonian` or `energy_hamiltonian` call."))
     end
-
-    # Add the model core charge density (non-linear core correction)
+    # TODO: build core densities on the XC FFT grid
     if !isnothing(term.ρcore)
         ρ = ρ + term.ρcore
     end
@@ -99,18 +127,40 @@ function xc_potential_real(term::TermXc, basis::PlaneWaveBasis{T}, ψ, occupatio
         τ = τ + term.τcore
     end
 
-    max_ρ_derivs = maximum(max_required_derivative, term.functionals)
-    density = LibxcDensities(basis, max_ρ_derivs, ρ, τ)
-    _check_negative_bonding_indicator_α(density)
+    # TODO: if the FFT grids are equal this should be made a no-op
+    ρ = transfer_density(ρ, basis.fft_grid, term.fft_grid)
+    if !isnothing(τ)
+        τ = transfer_density(τ, basis.fft_grid, term.fft_grid)
+    end
 
-    n_spin = basis.model.n_spin_components
+    E, potential, Vτ = _xc_potential_real(term, basis.model, basis.comm_kpts, ρ, τ)
+
+    # the adjoint of Fourier interpolation is Fourier truncation
+    potential = transfer_density(potential, term.fft_grid, basis.fft_grid)
+    if !isnothing(Vτ)
+        Vτ = transfer_density(Vτ, term.fft_grid, basis.fft_grid)
+    end
+
+    (; E, potential, Vτ)
+end
+
+# Internal evaluation on TermXc's own FFT grid.
+function _xc_potential_real(term::TermXc, model::Model{T}, comm_kpts, ρ, τ) where {T}
+    max_ρ_derivs = maximum(max_required_derivative, term.functionals)
+    density = LibxcDensities(model, term.fft_grid, max_ρ_derivs, ρ, τ)
+    _check_negative_bonding_indicator_α(density, comm_kpts)
+
+    n_spin = model.n_spin_components
     potential_threshold = term.potential_threshold
+    fft_grid     = term.fft_grid
+    fft_size     = fft_grid.fft_size
+    architecture = fft_grid.architecture
 
     # Evaluate terms and energy contribution
     # If the XC functional is not supported for an architecture, terms is on the CPU
     terms = potential_terms(term.functionals, density)
     @assert haskey(terms, :Vρ) && haskey(terms, :e)
-    E = term.scaling_factor * sum(terms.e) * basis.dvol
+    E = term.scaling_factor * sum(terms.e) * term.dvol
 
     # Map from the tuple of spin indices for the contracted density gradient
     # (s, t) to the index convention used in DftFunctionals (i.e. packed symmetry-adapted
@@ -120,14 +170,14 @@ function xc_potential_real(term::TermXc, basis::PlaneWaveBasis{T}, ψ, occupatio
     # Potential contributions Vρ -2 ∇⋅(Vσ ∇ρ) + ΔVl
     potential = zero(ρ)
     @views for s = 1:n_spin
-        Vρ = to_device(basis.architecture, reshape(terms.Vρ, n_spin, basis.fft_size...))
+        Vρ = to_device(architecture, reshape(terms.Vρ, n_spin, fft_size...))
 
         potential[:, :, :, s] .+= Vρ[s, :, :, :]
         if haskey(terms, :Vσ) && any(x -> abs(x) > potential_threshold, terms.Vσ)
             # Need gradient correction
             # TODO Drop do-block syntax here?
-            potential[:, :, :, s] .+= -2divergence_real(basis) do α
-                Vσ = to_device(basis.architecture, reshape(terms.Vσ, :, basis.fft_size...))
+            potential[:, :, :, s] .+= -2divergence_real(fft_grid, model) do α
+                Vσ = to_device(architecture, reshape(terms.Vσ, :, fft_size...))
 
                 # Extra factor (1/2) for s != t is needed because libxc only keeps σ_{αβ}
                 # in the energy expression. See comment block below on spin-polarised XC.
@@ -138,10 +188,10 @@ function xc_potential_real(term::TermXc, basis::PlaneWaveBasis{T}, ψ, occupatio
         end
         if haskey(terms, :Vl) && any(x -> abs(x) > potential_threshold, terms.Vl)
             @warn "Meta-GGAs with a Δρ term have not yet been thoroughly tested." maxlog=1
-            mG² = .-norm2.(G_vectors_cart(basis))
-            Vl  = to_device(basis.architecture, reshape(terms.Vl, n_spin, basis.fft_size...))
-            Vl_fourier = fft(basis, Vl[s, :, :, :])
-            potential[:, :, :, s] .+= irfft(basis, mG² .* Vl_fourier)  # ΔVl
+            mG² = .-norm2.(G_vectors_cart(fft_grid, model))
+            Vl  = to_device(architecture, reshape(terms.Vl, n_spin, fft_size...))
+            Vl_fourier = fft(fft_grid, Vl[s, :, :, :])
+            potential[:, :, :, s] .+= irfft(fft_grid, mG² .* Vl_fourier)  # ΔVl
         end
     end
 
@@ -149,7 +199,7 @@ function xc_potential_real(term::TermXc, basis::PlaneWaveBasis{T}, ψ, occupatio
     Vτ = nothing
     if haskey(terms, :Vτ) && any(x -> abs(x) > potential_threshold, terms.Vτ)
         # Need meta-GGA non-local operator (Note: -½ part of the definition of DivAgrid)
-        Vτ = to_device(basis.architecture, reshape(terms.Vτ, n_spin, basis.fft_size...))
+        Vτ = to_device(architecture, reshape(terms.Vτ, n_spin, fft_size...))
         Vτ = term.scaling_factor * permutedims(Vτ, (2, 3, 4, 1))
     end
 
@@ -161,7 +211,7 @@ end
 
 @views @timing "ene_ops: xc" function ene_ops(term::TermXc, basis::PlaneWaveBasis,
                                               ψ, occupation; ρ, τ=nothing, kwargs...)
-    E, Vxc, Vτ = xc_potential_real(term, basis, ψ, occupation; ρ, τ)
+    E, Vxc, Vτ = xc_potential_real(term, basis; ρ, τ)
 
     ops = map(basis.kpoints) do kpt
         if !isnothing(Vτ)
@@ -189,12 +239,17 @@ end
         τ = τ + term.τcore
     end
 
+    ρ = transfer_density(ρ, basis.fft_grid, term.fft_grid)
+    if !isnothing(τ)
+        τ = transfer_density(τ, basis.fft_grid, term.fft_grid)
+    end
+
     max_ρ_derivs = maximum(max_required_derivative, term.functionals)
-    densities = LibxcDensities(basis, max_ρ_derivs, ρ, τ)
-    _check_negative_bonding_indicator_α(densities)
+    densities = LibxcDensities(basis.model, term.fft_grid, max_ρ_derivs, ρ, τ)
+    _check_negative_bonding_indicator_α(densities, basis.comm_kpts)
 
     edensity = energy_density(term.functionals, densities)
-    term.scaling_factor * sum(edensity) * basis.dvol
+    term.scaling_factor * sum(edensity) * term.dvol
 end
 
 @timing "forces: xc" function compute_forces(term::TermXc, basis::PlaneWaveBasis{T},
@@ -205,7 +260,7 @@ end
     isnothing(term.ρcore) && isnothing(term.τcore) && return nothing
 
     model = basis.model
-    _, Vρ_real, Vτ_real = xc_potential_real(term, basis, ψ, occupation; ρ, τ)
+    _, Vρ_real, Vτ_real = xc_potential_real(term, basis; ρ, τ)
     Vτ_fourier = nothing
     if model.spin_polarization in (:none, :spinless)
         Vρ_fourier = fft(basis, Vρ_real[:,:,:,1])
@@ -340,8 +395,9 @@ end
 
 
 # stores the input to libxc in a format it likes
-struct LibxcDensities{T}
-    basis::PlaneWaveBasis{T}
+struct LibxcDensities{FFTtype}
+    fft_grid::FFTtype
+    n_spin::Int
     max_derivative::Int
     ρ_real    # density ρ[iσ, ix, iy, iz]
     ∇ρ_real   # for GGA, density gradient ∇ρ[iσ, ix, iy, iz, iα]
@@ -353,9 +409,10 @@ end
 """
 Compute density in real space and its derivatives starting from ρ
 """
-function LibxcDensities(basis::PlaneWaveBasis{T}, max_derivative::Integer, ρ, τ) where {T}
-    model = basis.model
+function LibxcDensities(model::Model{T}, fft_grid::FFTtype, max_derivative::Integer,
+                        ρ, τ) where {T, FFTtype<:FFTGrid}
     @assert max_derivative in (0, 1, 2)
+    fft_size = fft_grid.fft_size
 
     n_spin    = model.n_spin_components
     σ_real    = nothing
@@ -365,20 +422,20 @@ function LibxcDensities(basis::PlaneWaveBasis{T}, max_derivative::Integer, ρ, �
     # compute ρ_real and possibly ρ_fourier
     ρ_real = permutedims(ρ, (4, 1, 2, 3))  # ρ[x, y, z, σ] -> ρ_real[σ, x, y, z]
     if max_derivative > 0
-        ρf = fft(basis, ρ)
+        ρf = fft(fft_grid, ρ)
         ρ_fourier = permutedims(ρf, (4, 1, 2, 3))  # ρ_fourier[σ, x, y, z]
     end
 
     # compute ∇ρ and σ
     if max_derivative > 0
         n_spin_σ = div((n_spin + 1) * n_spin, 2)
-        ∇ρ_real = similar(ρ_real,   n_spin, basis.fft_size..., 3)
-        σ_real  = similar(ρ_real, n_spin_σ, basis.fft_size...)
+        ∇ρ_real = similar(ρ_real,   n_spin, fft_size..., 3)
+        σ_real  = similar(ρ_real, n_spin_σ, fft_size...)
 
         for α = 1:3
-            iGα = map(G -> im * G[α], G_vectors_cart(basis))
+            iGα = map(G -> im * G[α], G_vectors_cart(fft_grid, model))
             for σ = 1:n_spin
-                ∇ρ_real[σ, :, :, :, α] .= irfft(basis, iGα .* @view ρ_fourier[σ, :, :, :])
+                ∇ρ_real[σ, :, :, :, α] .= irfft(fft_grid, iGα .* @view ρ_fourier[σ, :, :, :])
             end
         end
 
@@ -396,19 +453,20 @@ function LibxcDensities(basis::PlaneWaveBasis{T}, max_derivative::Integer, ρ, �
 
     # Compute Δρ
     if max_derivative > 1
-        Δρ_real = similar(ρ_real, n_spin, basis.fft_size...)
-        mG² = .-norm2.(G_vectors_cart(basis))
+        Δρ_real = similar(ρ_real, n_spin, fft_size...)
+        mG² = .-norm2.(G_vectors_cart(fft_grid, model))
         for σ = 1:n_spin
-            Δρ_real[σ, :, :, :] .= irfft(basis, mG² .* @view ρ_fourier[σ, :, :, :])
+            Δρ_real[σ, :, :, :] .= irfft(fft_grid, mG² .* @view ρ_fourier[σ, :, :, :])
         end
     end
 
     # τ[x, y, z, σ] -> τ_Libxc[σ, x, y, z]
     τ_Libxc = isnothing(τ) ? nothing : permutedims(τ, (4, 1, 2, 3))
-    LibxcDensities{T}(basis, max_derivative, ρ_real, ∇ρ_real, σ_real, Δρ_real, τ_Libxc)
+    LibxcDensities{FFTtype}(fft_grid, n_spin, max_derivative, ρ_real, ∇ρ_real,
+                            σ_real, Δρ_real, τ_Libxc)
 end
 
-function _check_negative_bonding_indicator_α(densities::LibxcDensities{T};
+function _check_negative_bonding_indicator_α(densities::LibxcDensities{T}, comm_kpts;
                                              density_threshold=100eps(T)) where {T}
     # TODO: The idea here is that libxc cuts components of the XC evaluation anyway if
     #       the density (or contracted density gradient) is below a certain threshold,
@@ -417,8 +475,7 @@ function _check_negative_bonding_indicator_α(densities::LibxcDensities{T};
         return
     end
 
-    n_spin = densities.basis.model.n_spin_components
-    failure_indicator = @views minimum(1:n_spin) do iσ
+    failure_indicator = @views minimum(1:densities.n_spin) do iσ
         # α = (τ - τ_W) / τ_unif should be positive with τ_W = |∇ρ|² / 8ρ
         # equivalently, check 8ρτ - |∇ρ|² ≥ 0
         ρ = densities.ρ_real[iσ, :, :, :]
@@ -430,7 +487,7 @@ function _check_negative_bonding_indicator_α(densities::LibxcDensities{T};
                                 * (abs(τ) ≥ density_threshold))
         minimum(failure_indicator)
     end
-    if mpi_master(densities.basis.comm_kpts)
+    if mpi_master(comm_kpts)
         if failure_indicator < -eps(T)
             @debug "xc: α failure indicator: $failure_indicator"
         end
@@ -451,11 +508,15 @@ function compute_kernel(term::TermXc, basis::PlaneWaveBasis{T}; ρ, kwargs...) w
     if !all(family(xc) == :lda for xc in term.functionals)
         error("compute_kernel only implemented for LDA")
     end
+    if term.fft_grid.fft_size != basis.fft_size
+        # On a denser XC grid the Fourier interpolation makes the kernel non-diagonal
+        error("compute_kernel not implemented for an Xc term with its own fft_size")
+    end
 
     # For LDA the Kernel is known to be diagonal, so we can get away
     # with a single push-forward (two for spin-polarized case)
     if n_spin == 1
-        f_spinless(ε) = xc_potential_real(term, basis, nothing, nothing; ρ=ρ.+ε).potential
+        f_spinless(ε) = xc_potential_real(term, basis; ρ=ρ.+ε).potential
         δpotential = ForwardDiff.derivative(f_spinless, zero(T))
         Diagonal(vec(δpotential))
     else
@@ -463,8 +524,8 @@ function compute_kernel(term::TermXc, basis::PlaneWaveBasis{T}; ρ, kwargs...) w
         function f_collinear(ε)
             dρ1 = reshape([ε, 0], 1, 1, 1, 2)
             dρ2 = reshape([0, ε], 1, 1, 1, 2)
-            stack([xc_potential_real(term, basis, nothing, nothing; ρ=ρ.+dρ1).potential,
-                   xc_potential_real(term, basis, nothing, nothing; ρ=ρ.+dρ2).potential])
+            stack([xc_potential_real(term, basis; ρ=ρ.+dρ1).potential,
+                   xc_potential_real(term, basis; ρ=ρ.+dρ2).potential])
         end
         δpotential = ForwardDiff.derivative(f_collinear, zero(T))
 
@@ -491,7 +552,7 @@ function apply_kernel(term::TermXc, basis::PlaneWaveBasis{T}, δρ::AbstractArra
 
     # Key insight: kernel application is just a Hessian-vector product,
     # which is computed with a push-forward of the gradient.
-    f(ρ_eval) = xc_potential_real(term, basis, nothing, nothing; ρ=ρ_eval).potential
+    f(ρ_eval) = xc_potential_real(term, basis; ρ=ρ_eval).potential
     Tag = typeof(ForwardDiff.Tag(f, T))
     if Tδρ <: T
         # Usually δρ has the same type, so we do a standard push-forward
@@ -573,12 +634,12 @@ Compute divergence of an operand function, which returns the Cartesian x,y,z
 components in real space when called with the arguments 1 to 3.
 The divergence is also returned as a real-space array.
 """
-function divergence_real(operand, basis)
+function divergence_real(operand, fft_grid::FFTGrid, model::Model)
     gradsum = sum(1:3) do α
-        operand_α = fft(basis, operand(α))
-        map(G_vectors_cart(basis), operand_α) do G, operand_αG
+        operand_α = fft(fft_grid, operand(α))
+        map(G_vectors_cart(fft_grid, model), operand_α) do G, operand_αG
             im * G[α] * operand_αG  # ∇_α * operand_α
         end
     end
-    irfft(basis, gradsum)
+    irfft(fft_grid, gradsum)
 end

--- a/src/transfer.jl
+++ b/src/transfer.jl
@@ -1,17 +1,15 @@
 using SparseArrays
 
 """
-Compute the index mapping between the global grids of two bases.
+Compute the index mapping between two FFT grids or two bases' global grids.
 Returns an iterator of 8 pairs `(block_in, block_out)`. Iterated over these pairs
 `x_out_fourier[block_out, :] = x_in_fourier[block_in, :]` does the transfer from
-the Fourier coefficients `x_in_fourier` (defined on `basis_in`) to
-`x_out_fourier` (defined on `basis_out`, equally provided as Fourier coefficients).
+the Fourier coefficients `x_in_fourier` (defined on `fft_size_in`) to
+`x_out_fourier` (defined on `fft_size_out`, equally provided as Fourier coefficients).
 """
-function transfer_mapping(basis_in::PlaneWaveBasis, basis_out::PlaneWaveBasis)
-    @assert basis_in.model.lattice == basis_out.model.lattice
-
+function transfer_mapping(fft_size_in::Tuple{Int,Int,Int}, fft_size_out::Tuple{Int,Int,Int})
     # TODO This logic feels rather convoluted ... think if there are ways to simplify
-    idcs = map(basis_in.fft_size, basis_out.fft_size) do fft_in, fft_out
+    idcs = map(fft_size_in, fft_size_out) do fft_in, fft_out
         if fft_in <= fft_out
             a = cld(fft_in, 2)
             b = fld(fft_in, 2)
@@ -28,6 +26,10 @@ function transfer_mapping(basis_in::PlaneWaveBasis, basis_out::PlaneWaveBasis)
     idcs_in  = CartesianIndices.(Iterators.product(idcs[1].in,  idcs[2].in,  idcs[3].in))
     idcs_out = CartesianIndices.(Iterators.product(idcs[1].out, idcs[2].out, idcs[3].out))
     zip(idcs_in, idcs_out)
+end
+function transfer_mapping(basis_in::PlaneWaveBasis, basis_out::PlaneWaveBasis)
+    @assert basis_in.model.lattice == basis_out.model.lattice
+    transfer_mapping(basis_in.fft_size, basis_out.fft_size)
 end
 
 """
@@ -150,7 +152,7 @@ function transfer_blochwave(ψ_in, basis_in::PlaneWaveBasis, basis_out::PlaneWav
 end
 
 @doc raw"""
-Transfer density (in real space) between two basis sets.
+Transfer density (in real space) between two basis sets, or directly between two FFT grids.
 
 This function is fast by transferring only the Fourier coefficients from the small basis
 to the big basis.
@@ -162,19 +164,22 @@ Fourier component and the identity ``c_G = c_{-G}^\ast`` does not fully hold).
 Note further that for the direction big -> small employing this function does not give
 the same answer as using first `transfer_blochwave` and then `compute_density`.
 """
-function transfer_density(ρ_in, basis_in::PlaneWaveBasis{T},
-                          basis_out::PlaneWaveBasis{T}) where {T}
-    @assert basis_in.model.lattice == basis_out.model.lattice
+function transfer_density(ρ_in, grid_in::FFTGrid, grid_out::FFTGrid)
     @assert length(size(ρ_in)) ∈ (3, 4)
 
-    ρ_freq_in  = fft(basis_in, ρ_in)
-    ρ_freq_out = zeros_like(ρ_freq_in, basis_out.fft_size..., size(ρ_in, 4))
+    ρ_freq_in  = fft(grid_in, ρ_in)
+    ρ_freq_out = zeros_like(ρ_freq_in, grid_out.fft_size..., size(ρ_in, 4))
 
-    for (block_in, block_out) in transfer_mapping(basis_in, basis_out)
+    for (block_in, block_out) in transfer_mapping(grid_in.fft_size, grid_out.fft_size)
         ρ_freq_out[block_out, :] .= ρ_freq_in[block_in, :]
     end
 
-    irfft(basis_out, ρ_freq_out)
+    irfft(grid_out, ρ_freq_out)
+end
+function transfer_density(ρ_in, basis_in::PlaneWaveBasis{T},
+                          basis_out::PlaneWaveBasis{T}) where {T}
+    @assert basis_in.model.lattice == basis_out.model.lattice
+    transfer_density(ρ_in, basis_in.fft_grid, basis_out.fft_grid)
 end
 
 """

--- a/src/transfer.jl
+++ b/src/transfer.jl
@@ -156,6 +156,7 @@ Transfer density (in real space) between two basis sets, or directly between two
 
 This function is fast by transferring only the Fourier coefficients from the small basis
 to the big basis.
+If the two grids are the same, the input density is returned directly **without copying**.
 
 Note that this implies that for even-sized small FFT grids doing the
 transfer small -> big -> small is not an identity (as the small basis has an unmatched
@@ -166,6 +167,7 @@ the same answer as using first `transfer_blochwave` and then `compute_density`.
 """
 function transfer_density(ρ_in, grid_in::FFTGrid, grid_out::FFTGrid)
     @assert length(size(ρ_in)) ∈ (3, 4)
+    grid_in.fft_size == grid_out.fft_size && return ρ_in
 
     ρ_freq_in  = fft(grid_in, ρ_in)
     ρ_freq_out = zeros_like(ρ_freq_in, grid_out.fft_size..., size(ρ_in, 4))

--- a/src/workarounds/forwarddiff_rules.jl
+++ b/src/workarounds/forwarddiff_rules.jl
@@ -230,7 +230,8 @@ function construct_value(basis::PlaneWaveBasis{T}) where {T <: Dual}
                    basis.symmetries_respect_rgrid,
                    basis.use_symmetries_for_kpoint_reduction,
                    basis.comm_kpts,
-                   basis.architecture)
+                   basis.architecture,
+                   basis.extra_kwargs)
 end
 
 

--- a/test/hamiltonian_consistency.jl
+++ b/test/hamiltonian_consistency.jl
@@ -12,7 +12,7 @@ function test_consistency_term(term; rtol=1e-4, atol=1e-8, ε=1e-6,
                                test_for_constant=false, test_energy_ad=true,
                                n_empty=3, kgrid=[1, 2, 3], kshift=[0, 1, 0]/2, Ecut=10,
                                lattice=silicon.lattice, atom=nothing, spin_polarization=:none,
-                               exxalg=AceExx())
+                               exxalg=AceExx(), basis_kwargs=(;))
     sspol = spin_polarization != :none ? " ($spin_polarization)" : ""
     xc    = term isa Xc ? "($(first(term.functionals)))" : ""
     @testset "$(typeof(term))$xc $sspol" begin
@@ -23,7 +23,7 @@ function test_consistency_term(term; rtol=1e-4, atol=1e-8, ε=1e-6,
         atoms = [atom, atom]
         model = Model(lattice, atoms, silicon.positions; terms=[term], spin_polarization,
                       symmetries=true)
-        basis = PlaneWaveBasis(model; Ecut, kgrid=MonkhorstPack(kgrid; kshift))
+        basis = PlaneWaveBasis(model; Ecut, kgrid=MonkhorstPack(kgrid; kshift), basis_kwargs...)
         @assert length(basis.terms) == 1
 
         n_electrons = silicon.n_electrons
@@ -61,7 +61,7 @@ function test_consistency_term(term; rtol=1e-4, atol=1e-8, ε=1e-6,
         δψ = [randn(ComplexF64, size(ψ[ik])) for ik = 1:length(basis.kpoints)]
         function compute_E(ε::T) where {T}
             modelE = Model(model; lattice=Matrix{T}(model.lattice))
-            basisE = PlaneWaveBasis(modelE; Ecut, kgrid=MonkhorstPack(kgrid; kshift))
+            basisE = PlaneWaveBasis(modelE; Ecut, kgrid=MonkhorstPack(kgrid; kshift), basis_kwargs...)
 
             ψ_trial = ψ .+ ε .* δψ
             ρ_trial = with_logger(NullLogger()) do
@@ -148,22 +148,32 @@ end
         Si = ElementPsp(14, load_psp(psp))
         test_consistency_term(AtomicLocal(); atom=Si)
         test_consistency_term(AtomicNonlocal(); atom=Si)
-        test_consistency_term(Xc([:lda_xc_teter93]); atom=Si)
-        test_consistency_term(Xc([:lda_xc_teter93]); atom=Si, spin_polarization=:collinear)
-        test_consistency_term(Xc([:gga_x_pbe]); atom=Si, spin_polarization=:collinear)
 
-        # TODO: for use_nlcc=true need to fix consistency for meta-GGA with NLCC
-        #       (see JuliaMolSim/DFTK.jl#1180)
-        test_consistency_term(Xc([:mgga_x_tpss]; use_nlcc=false); atom=Si, tauad...)
-        test_consistency_term(Xc([:mgga_x_scan]; use_nlcc=false); atom=Si, tauad...)
-        test_consistency_term(Xc([:mgga_c_scan]; use_nlcc=false); atom=Si, tauad...,
-                              spin_polarization=:collinear)
-        test_consistency_term(Xc([:mgga_x_b00]; use_nlcc=false); atom=Si, tauad...)
-        test_consistency_term(Xc([:mgga_c_b94]; use_nlcc=false); atom=Si, tauad...,
-                              spin_polarization=:collinear)
-        test_consistency_term(Xc([:mgga_x_scanl]); atom=Si)
-        test_consistency_term(Xc([:mgga_x_r2scanl, :mgga_c_scan]); atom=Si, tauad...,
-                              spin_polarization=:collinear)
+        for supersample_xc in [false, true]
+            basis_kwargs = supersample_xc ? (; supersampling_xc=4) : (;)
+
+            test_consistency_term(Xc([:lda_xc_teter93]); atom=Si, basis_kwargs)
+            test_consistency_term(Xc([:lda_xc_teter93]); atom=Si,
+                                  spin_polarization=:collinear, basis_kwargs)
+            test_consistency_term(Xc([:gga_x_pbe]); atom=Si,
+                                  spin_polarization=:collinear, basis_kwargs)
+
+            # TODO: for use_nlcc=true need to fix consistency for meta-GGA with NLCC
+            #       (see JuliaMolSim/DFTK.jl#1180)
+            test_consistency_term(Xc([:mgga_x_tpss]; use_nlcc=false); atom=Si,
+                                  tauad..., basis_kwargs)
+            test_consistency_term(Xc([:mgga_x_scan]; use_nlcc=false); atom=Si,
+                                  tauad..., basis_kwargs)
+            test_consistency_term(Xc([:mgga_c_scan]; use_nlcc=false); atom=Si,
+                                  tauad..., spin_polarization=:collinear, basis_kwargs)
+            test_consistency_term(Xc([:mgga_x_b00]; use_nlcc=false); atom=Si,
+                                  tauad..., basis_kwargs)
+            test_consistency_term(Xc([:mgga_c_b94]; use_nlcc=false); atom=Si,
+                                  tauad..., spin_polarization=:collinear, basis_kwargs)
+            test_consistency_term(Xc([:mgga_x_scanl]); atom=Si, basis_kwargs)
+            test_consistency_term(Xc([:mgga_x_r2scanl, :mgga_c_scan]); atom=Si,
+                                  tauad..., spin_polarization=:collinear, basis_kwargs)
+        end
     end
 
     @testset "Exact exchange" begin


### PR DESCRIPTION
The main idea here is to beat the egg-box effect that typically occurs for meta-GGA functionals. Related work: https://doi.org/10.1088/2516-1075/adc056
Related: #1334.

- We already had the density transfer infrastructure so it was not too bad.
- I added the infrastructure for extra `PlaneWaveBasis` kwargs to be passed to the terms at instantiation time. E.g. `PlaneWaveBasis(model; Ecut, kgrid, supersampling_xc=4)`.

First version written by Claude Opus 5.