### PR TITLE
Delete lowpass_for_symmetry!

### DIFF
--- a/src/PlaneWaveBasis.jl
+++ b/src/PlaneWaveBasis.jl
@@ -291,6 +291,7 @@ If parameters are not given explicitly as a kwarg, the constructor chooses sensi
 - `supersampling::Real` (default: `recommended_cutoff(model).supersampling`): Factor
     determining the density/potential cutoff relative to `Ecut`. The density cutoff is
     `supersampling^2 * Ecut` (default supersampling = 2.0, i.e. density cutoff = 4 * Ecut).
+    Values below 2 alias the density and are not recommended.
 - `fft_size::Union{Nothing,Tuple{Int,Int,Int}}` (default: `nothing`): Explicit FFT grid
     size. If `nothing` (recommended), an automatic FFT grid compatible with `Ecut` and `supersampling`
     is computed.

--- a/src/densities.jl
+++ b/src/densities.jl
@@ -44,7 +44,7 @@ using an optional `occupation_threshold`. By default all occupation numbers are 
     ρ = sum(storage -> storage.ρ, storages)
 
     mpi_sum!(ρ, basis.comm_kpts)
-    ρ = symmetrize_ρ(basis, ρ; do_lowpass=false)
+    ρ = symmetrize_ρ(basis, ρ)
 
     # There can always be small negative densities, e.g. due to numerical fluctuations
     # in a vacuum region, so put some tolerance even if occupation_threshold == 0
@@ -104,7 +104,7 @@ end
     δρ = sum(getfield.(storages, :δρ))
 
     mpi_sum!(δρ, basis.comm_kpts)
-    symmetrize_ρ(basis, δρ; do_lowpass=false)
+    symmetrize_ρ(basis, δρ)
 end
 
 @views @timing function compute_kinetic_energy_density(basis::PlaneWaveBasis, ψ, occupation)
@@ -121,7 +121,7 @@ end
         end
     end
     mpi_sum!(τ, basis.comm_kpts)
-    symmetrize_ρ(basis, τ; do_lowpass=false)
+    symmetrize_ρ(basis, τ)
 end
 
 """

--- a/src/density_methods.jl
+++ b/src/density_methods.jl
@@ -176,7 +176,7 @@ function atomic_density_superposition(basis::PlaneWaveBasis{T},
         end
     end
 
-    drop_nyquist_frequency!(ρ, basis)
+    drop_nyquist_components!(ρ, basis)
     irfft(basis, reshape(ρ, basis.fft_size))
 end
 

--- a/src/density_methods.jl
+++ b/src/density_methods.jl
@@ -176,7 +176,7 @@ function atomic_density_superposition(basis::PlaneWaveBasis{T},
         end
     end
 
-    enforce_real!(ρ, basis)  # Symmetrize Fourier coeffs to have real iFFT
+    drop_nyquist_frequency!(ρ, basis)
     irfft(basis, reshape(ρ, basis.fft_size))
 end
 

--- a/src/density_methods.jl
+++ b/src/density_methods.jl
@@ -176,7 +176,6 @@ function atomic_density_superposition(basis::PlaneWaveBasis{T},
         end
     end
 
-    drop_nyquist_components!(ρ, basis)
     irfft(basis, reshape(ρ, basis.fft_size))
 end
 

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -22,21 +22,10 @@ import AbstractFFTs: fft, fft!, ifft, ifft!
 of given sizes.
 """
 function G_vectors(fft_size::Union{Tuple,AbstractVector})
-    # Note that a collect(G_vectors_generator(fft_size)) is 100-fold slower
-    # than this implementation, hence the code duplication.
     start = .- cld.(fft_size .- 1, 2)
     stop  = fld.(fft_size .- 1, 2)
     axes  = [[collect(0:stop[i]); collect(start[i]:-1)] for i = 1:3]
     [Vec3{Int}(i, j, k) for i in axes[1], j in axes[2], k in axes[3]]
-end
-
-function G_vectors_generator(fft_size::Union{Tuple,AbstractVector})
-    # The generator version is used mainly in symmetry.jl for lowpass_for_symmetry! and
-    # accumulate_over_symmetries!, which are 100-fold slower with G_vector(fft_size).
-    start = .- cld.(fft_size .- 1, 2)
-    stop  = fld.(fft_size .- 1, 2)
-    axes = [[collect(0:stop[i]); collect(start[i]:-1)] for i = 1:3]
-    (Vec3{Int}(i, j, k) for i in axes[1], j in axes[2], k in axes[3])
 end
 
 """

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -130,22 +130,11 @@ function ifft(fft_grid::FFTGrid, Gvec_mapping::AbstractVector{Int}, f_fourier::A
     ifft!(similar(f_fourier, fft_grid.fft_size...), fft_grid, Gvec_mapping, f_fourier; kwargs...)
 end
 """
-Zero out the Nyquist components of `f_fourier`, ie the wavevectors `G` that don't have a `-G`
-counterpart in the grid (`G = -N/2` along an even direction of size `N`).
-"""
-function drop_nyquist_components!(f_fourier::AbstractArray, fft_size)
-    for (idim, N) in enumerate(fft_size)
-        iseven(N) && (selectdim(f_fourier, idim, N ÷ 2 + 1) .= 0)
-    end
-    f_fourier
-end
-
-"""
-Perform a real valued iFFT; see [`ifft`](@ref). The Nyquist components are dropped
-*from the input array*, so this method is technically mutating.
+Perform a real valued iFFT; see [`ifft`](@ref). Note that this function
+silently drops the imaginary part.
 """
 function irfft(fft_grid::FFTGrid{T}, f_fourier::AbstractArray) where {T}
-    real(ifft(fft_grid, drop_nyquist_components!(copy(f_fourier), fft_grid.fft_size)))
+    real(ifft(fft_grid, f_fourier))
 end
 
 @doc raw"""

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -130,11 +130,22 @@ function ifft(fft_grid::FFTGrid, Gvec_mapping::AbstractVector{Int}, f_fourier::A
     ifft!(similar(f_fourier, fft_grid.fft_size...), fft_grid, Gvec_mapping, f_fourier; kwargs...)
 end
 """
-Perform a real valued iFFT; see [`ifft`](@ref). Note that this function
-silently drops the imaginary part.
+Zero out the Nyquist components of `f_fourier`, ie the wavevectors `G` that don't have a `-G`
+counterpart in the grid (`G = -N/2` along an even direction of size `N`).
+"""
+function drop_nyquist_components!(f_fourier::AbstractArray, fft_size)
+    for (idim, N) in enumerate(fft_size)
+        iseven(N) && (selectdim(f_fourier, idim, N ÷ 2 + 1) .= 0)
+    end
+    f_fourier
+end
+
+"""
+Perform a real valued iFFT; see [`ifft`](@ref). The Nyquist components are dropped
+*from the input array*, so this method is technically mutating.
 """
 function irfft(fft_grid::FFTGrid{T}, f_fourier::AbstractArray) where {T}
-    real(ifft(fft_grid, f_fourier))
+    real(ifft(fft_grid, drop_nyquist_components!(copy(f_fourier), fft_grid.fft_size)))
 end
 
 @doc raw"""

--- a/src/response/chi0.jl
+++ b/src/response/chi0.jl
@@ -66,19 +66,19 @@ function compute_χ0(ham;
         V = Vs[ik]
         Vr = cat(ifft.(Ref(basis), Ref(kpt), eachcol(V))..., dims=4)
         Vr = reshape(Vr, n_fft, N)
-        for m = 1:N, n = 1:N
+        # The (n,m) and (m,n) terms are complex conjugates of each other, so we only run
+        # over the lower triangle and take the real part.
+        for m = 1:N, n = 1:m
             enred = (E[n] - εF) / temperature
             @assert occupation[ik][n] ≈ filled_occ * Smearing.occupation(smearing, enred)
             ddiff = Smearing.occupation_divided_difference
             ratio = filled_occ * ddiff(smearing, E[m], E[n], εF, temperature)
             # dvol because inner products have a dvol in them
             # so that the dual gets one : |f> -> <dvol f|
-            # can take the real part here because the nm term is complex conjugate of mn
-            # TODO optimize this a bit... use symmetry nm, reduce allocs, etc.
-            factor = basis.kweights[ik] * ratio * basis.dvol
+            factor = basis.kweights[ik] * ratio * basis.dvol * (m == n ? 1 : 2)
 
-            @views χ0σσ .+= factor .* real(conj((Vr[:, m] .* Vr[:, m]'))
-                                           .*   (Vr[:, n] .* Vr[:, n]'))
+            ρmn = @views conj(Vr[:, m]) .* Vr[:, n]
+            χ0σσ .+= factor .* real.(ρmn .* ρmn')
         end
     end
     mpi_sum!(χ0, basis.comm_kpts)

--- a/src/scf/mixing.jl
+++ b/src/scf/mixing.jl
@@ -83,7 +83,6 @@ end
     δF_fourier    = fft(basis, δF)
     δFtot_fourier = total_density(δF_fourier)
     δρtot_fourier = δFtot_fourier .* G² ./ (kTF.^2 .+ G²)
-    drop_nyquist_components!(δρtot_fourier, basis)
     δρtot = irfft(basis, δρtot_fourier)
 
     # Copy DC component, otherwise it never gets updated
@@ -96,7 +95,6 @@ end
     else
         δFspin_fourier = spin_density(δF_fourier)
         δρspin_fourier = @. δFspin_fourier - δFtot_fourier * (4π * ΔDOS_Ω) / (kTF^2 + G²)
-        drop_nyquist_components!(δρspin_fourier, basis)
         δρspin = irfft(basis, δρspin_fourier)
         ρ_from_total_and_spin(δρtot, δρspin)
     end

--- a/src/scf/mixing.jl
+++ b/src/scf/mixing.jl
@@ -83,7 +83,7 @@ end
     δF_fourier    = fft(basis, δF)
     δFtot_fourier = total_density(δF_fourier)
     δρtot_fourier = δFtot_fourier .* G² ./ (kTF.^2 .+ G²)
-    drop_nyquist_frequency!(δρtot_fourier, basis)
+    drop_nyquist_components!(δρtot_fourier, basis)
     δρtot = irfft(basis, δρtot_fourier)
 
     # Copy DC component, otherwise it never gets updated
@@ -96,7 +96,7 @@ end
     else
         δFspin_fourier = spin_density(δF_fourier)
         δρspin_fourier = @. δFspin_fourier - δFtot_fourier * (4π * ΔDOS_Ω) / (kTF^2 + G²)
-        drop_nyquist_frequency!(δρspin_fourier, basis)
+        drop_nyquist_components!(δρspin_fourier, basis)
         δρspin = irfft(basis, δρspin_fourier)
         ρ_from_total_and_spin(δρtot, δρspin)
     end

--- a/src/scf/mixing.jl
+++ b/src/scf/mixing.jl
@@ -83,7 +83,7 @@ end
     δF_fourier    = fft(basis, δF)
     δFtot_fourier = total_density(δF_fourier)
     δρtot_fourier = δFtot_fourier .* G² ./ (kTF.^2 .+ G²)
-    enforce_real!(δρtot_fourier, basis)
+    drop_nyquist_frequency!(δρtot_fourier, basis)
     δρtot = irfft(basis, δρtot_fourier)
 
     # Copy DC component, otherwise it never gets updated
@@ -96,7 +96,7 @@ end
     else
         δFspin_fourier = spin_density(δF_fourier)
         δρspin_fourier = @. δFspin_fourier - δFtot_fourier * (4π * ΔDOS_Ω) / (kTF^2 + G²)
-        enforce_real!(δρspin_fourier, basis)
+        drop_nyquist_frequency!(δρspin_fourier, basis)
         δρspin = irfft(basis, δρspin_fourier)
         ρ_from_total_and_spin(δρtot, δρspin)
     end

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -318,39 +318,16 @@ function accumulate_over_symmetries!(ρaccu, ρin, basis::PlaneWaveBasis{T}, sym
     ρaccu
 end
 
-# Low-pass filters ρ (in Fourier) so that symmetry operations acting on it stay in the grid
-# This function is optimized for CPU and GPU.
-function lowpass_for_symmetry!(ρ::AbstractArray, basis; symmetries=basis.symmetries)
-    all(isone, symmetries) && return ρ
-
-    Gs = reshape(G_vectors(basis), size(ρ))
-    fft_size = basis.fft_size
-
-    symm_S = to_device(basis.architecture, [symop.S for symop in symmetries])
-
-    # Loop structure optimized for both CPU and GPU
-    map!(ρ, ρ, Gs) do ρ_i, G
-        acc = ρ_i
-        for S in symm_S
-            idx = index_G_vectors(fft_size, S * G)
-            acc *= isnothing(idx) ? 0 : 1
-        end
-        acc
-    end
-    ρ
-end
-
 """
 Symmetrize a density by applying all the basis (by default) symmetries and forming the average.
 """
 @views @timing function symmetrize_ρ(basis, ρ::AbstractArray{T};
-                                     symmetries=basis.symmetries, do_lowpass=true) where {T}
+                                     symmetries=basis.symmetries) where {T}
     ρin_fourier  = fft(basis, ρ)
     ρout_fourier = zero(ρin_fourier)
     for σ = 1:size(ρ, 4)
         accumulate_over_symmetries!(ρout_fourier[:, :, :, σ],
                                     ρin_fourier[:, :, :, σ], basis, symmetries)
-        do_lowpass && lowpass_for_symmetry!(ρout_fourier[:, :, :, σ], basis; symmetries)
     end
     inv_fft = T <: Real ? irfft : ifft
     inv_fft(basis, ρout_fourier ./ length(symmetries))
@@ -548,5 +525,9 @@ Ensure its real-space equivalent of passed Fourier-space representation is entir
 removing wavevectors `G` that don't have a `-G` counterpart in the basis.
 """
 @timing function enforce_real!(fourier_coeffs, basis::PlaneWaveBasis)
-    lowpass_for_symmetry!(fourier_coeffs, basis; symmetries=[SymOp(-Mat3(I), Vec3(0, 0, 0))])
+    Gs = reshape(G_vectors(basis), size(fourier_coeffs))
+    fft_size = basis.fft_size
+    map!(fourier_coeffs, fourier_coeffs, Gs) do coeff, G
+        isnothing(index_G_vectors(fft_size, -G)) ? zero(coeff) : coeff
+    end
 end

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -521,10 +521,10 @@ function unfold_kcoords(kcoords, symmetries)
 end
 
 """
-Zero out the Nyquist frequencies of a Fourier-space representation, ie the wavevectors `G`
+Zero out the Nyquist components of a Fourier-space representation, ie the wavevectors `G`
 that don't have a `-G` counterpart in the basis (only present for even `fft_size`).
 """
-@timing function drop_nyquist_frequency!(fourier_coeffs, basis::PlaneWaveBasis)
+@timing function drop_nyquist_components!(fourier_coeffs, basis::PlaneWaveBasis)
     Gs = reshape(G_vectors(basis), size(fourier_coeffs))
     fft_size = basis.fft_size
     map!(fourier_coeffs, fourier_coeffs, Gs) do coeff, G

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -519,15 +519,3 @@ function unfold_kcoords(kcoords, symmetries)
         normalize_kpoint_coordinate(round.(k; digits) .+ 0.0)
     end
 end
-
-"""
-Zero out the Nyquist components of a Fourier-space representation, ie the wavevectors `G`
-that don't have a `-G` counterpart in the basis (only present for even `fft_size`).
-"""
-@timing function drop_nyquist_components!(fourier_coeffs, basis::PlaneWaveBasis)
-    Gs = reshape(G_vectors(basis), size(fourier_coeffs))
-    fft_size = basis.fft_size
-    map!(fourier_coeffs, fourier_coeffs, Gs) do coeff, G
-        isnothing(index_G_vectors(fft_size, -G)) ? zero(coeff) : coeff
-    end
-end

--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -521,10 +521,10 @@ function unfold_kcoords(kcoords, symmetries)
 end
 
 """
-Ensure its real-space equivalent of passed Fourier-space representation is entirely real by
-removing wavevectors `G` that don't have a `-G` counterpart in the basis.
+Zero out the Nyquist frequencies of a Fourier-space representation, ie the wavevectors `G`
+that don't have a `-G` counterpart in the basis (only present for even `fft_size`).
 """
-@timing function enforce_real!(fourier_coeffs, basis::PlaneWaveBasis)
+@timing function drop_nyquist_frequency!(fourier_coeffs, basis::PlaneWaveBasis)
     Gs = reshape(G_vectors(basis), size(fourier_coeffs))
     fft_size = basis.fft_size
     map!(fourier_coeffs, fourier_coeffs, Gs) do coeff, G

--- a/src/terms/hartree.jl
+++ b/src/terms/hartree.jl
@@ -38,7 +38,7 @@ function compute_poisson_green_coeffs(basis::PlaneWaveBasis{T}, scaling_factor;
         # Compensating charge background => Zero DC.
         GPUArraysCore.@allowscalar poisson_green_coeffs[1] = 0
         # Symmetrize Fourier coeffs to have real iFFT.
-        drop_nyquist_frequency!(poisson_green_coeffs, basis)
+        drop_nyquist_components!(poisson_green_coeffs, basis)
     end
     scaling_factor .* poisson_green_coeffs
 end

--- a/src/terms/hartree.jl
+++ b/src/terms/hartree.jl
@@ -37,9 +37,6 @@ function compute_poisson_green_coeffs(basis::PlaneWaveBasis{T}, scaling_factor;
     if iszero(q)
         # Compensating charge background => Zero DC.
         GPUArraysCore.@allowscalar poisson_green_coeffs[1] = 0
-        # Dropped on the coefficients rather than left to `irfft`, so that the matrix form
-        # of the kernel (`compute_kernel`) describes the same operator.
-        drop_nyquist_components!(poisson_green_coeffs, basis.fft_size)
     end
     scaling_factor .* poisson_green_coeffs
 end

--- a/src/terms/hartree.jl
+++ b/src/terms/hartree.jl
@@ -37,8 +37,9 @@ function compute_poisson_green_coeffs(basis::PlaneWaveBasis{T}, scaling_factor;
     if iszero(q)
         # Compensating charge background => Zero DC.
         GPUArraysCore.@allowscalar poisson_green_coeffs[1] = 0
-        # Symmetrize Fourier coeffs to have real iFFT.
-        drop_nyquist_components!(poisson_green_coeffs, basis)
+        # Dropped on the coefficients rather than left to `irfft`, so that the matrix form
+        # of the kernel (`compute_kernel`) describes the same operator.
+        drop_nyquist_components!(poisson_green_coeffs, basis.fft_size)
     end
     scaling_factor .* poisson_green_coeffs
 end

--- a/src/terms/hartree.jl
+++ b/src/terms/hartree.jl
@@ -38,7 +38,7 @@ function compute_poisson_green_coeffs(basis::PlaneWaveBasis{T}, scaling_factor;
         # Compensating charge background => Zero DC.
         GPUArraysCore.@allowscalar poisson_green_coeffs[1] = 0
         # Symmetrize Fourier coeffs to have real iFFT.
-        enforce_real!(poisson_green_coeffs, basis)
+        drop_nyquist_frequency!(poisson_green_coeffs, basis)
     end
     scaling_factor .* poisson_green_coeffs
 end

--- a/src/terms/local.jl
+++ b/src/terms/local.jl
@@ -64,7 +64,6 @@ function (external::ExternalFromFourier)(basis::PlaneWaveBasis{T}) where {T}
     pot_fourier = map(G_vectors_cart(basis)) do G
         convert_dual(complex(T), external.potential(G) / sqrt(unit_cell_volume))
     end
-    drop_nyquist_components!(pot_fourier, basis)
     TermExternal(irfft(basis, pot_fourier))
 end
 
@@ -130,7 +129,6 @@ function compute_local_potential(basis::PlaneWaveBasis{T}; positions=basis.model
 
     pot_fourier = reshape(pot, basis.fft_size)
     if iszero(q)
-        drop_nyquist_components!(pot, basis)
         return irfft(basis, pot_fourier)
     else
         return ifft(basis, pot_fourier)

--- a/src/terms/local.jl
+++ b/src/terms/local.jl
@@ -64,7 +64,7 @@ function (external::ExternalFromFourier)(basis::PlaneWaveBasis{T}) where {T}
     pot_fourier = map(G_vectors_cart(basis)) do G
         convert_dual(complex(T), external.potential(G) / sqrt(unit_cell_volume))
     end
-    drop_nyquist_frequency!(pot_fourier, basis)
+    drop_nyquist_components!(pot_fourier, basis)
     TermExternal(irfft(basis, pot_fourier))
 end
 
@@ -130,7 +130,7 @@ function compute_local_potential(basis::PlaneWaveBasis{T}; positions=basis.model
 
     pot_fourier = reshape(pot, basis.fft_size)
     if iszero(q)
-        drop_nyquist_frequency!(pot, basis)
+        drop_nyquist_components!(pot, basis)
         return irfft(basis, pot_fourier)
     else
         return ifft(basis, pot_fourier)

--- a/src/terms/local.jl
+++ b/src/terms/local.jl
@@ -64,7 +64,7 @@ function (external::ExternalFromFourier)(basis::PlaneWaveBasis{T}) where {T}
     pot_fourier = map(G_vectors_cart(basis)) do G
         convert_dual(complex(T), external.potential(G) / sqrt(unit_cell_volume))
     end
-    enforce_real!(pot_fourier, basis)  # Symmetrize Fourier coeffs to have real iFFT
+    drop_nyquist_frequency!(pot_fourier, basis)
     TermExternal(irfft(basis, pot_fourier))
 end
 
@@ -130,7 +130,7 @@ function compute_local_potential(basis::PlaneWaveBasis{T}; positions=basis.model
 
     pot_fourier = reshape(pot, basis.fft_size)
     if iszero(q)
-        enforce_real!(pot, basis)  # Symmetrize coeffs to have real iFFT
+        drop_nyquist_frequency!(pot, basis)
         return irfft(basis, pot_fourier)
     else
         return ifft(basis, pot_fourier)

--- a/src/terms/local.jl
+++ b/src/terms/local.jl
@@ -35,7 +35,7 @@ struct ExternalFromValues
 end
 function (external::ExternalFromValues)(basis::PlaneWaveBasis{T}) where {T}
     # TODO Could do interpolation here
-    @assert size(external.potential_values) == basis.fft_size
+    @assert size(external.potential_values)[1:3] == basis.fft_size
     TermExternal(convert_dual.(T, external.potential_values))
 end
 

--- a/src/terms/terms.jl
+++ b/src/terms/terms.jl
@@ -59,6 +59,7 @@ breaks_time_reversal_symmetry(::Any) = false
 include("kinetic.jl")
 
 include("local.jl")
+breaks_symmetries(::ExternalFromValues) = true
 breaks_symmetries(::ExternalFromReal) = true
 breaks_symmetries(::ExternalFromFourier) = true
 

--- a/src/terms/xc.jl
+++ b/src/terms/xc.jl
@@ -244,9 +244,6 @@ end
 # Function barrier to work around various type instabilities.
 function _forces_xc(basis::PlaneWaveBasis{T}, Vxc_fourier::AbstractArray{U}, 
                     form_factors, iG2ifnorm, groups) where {T, U}
-    # Adjoint of the enforce_real! call in the construction of the NLCC
-    enforce_real!(Vxc_fourier, basis)
-
     # Pre-allocation of large arrays for GPU Efficiency
     TT = promote_type(T, real(U))
     Gs = G_vectors(basis)

--- a/test/anderson.jl
+++ b/test/anderson.jl
@@ -11,13 +11,13 @@ function test_addiis(testcase; temperature=0, Ecut=10, kgrid=[3, 3, 3], n_bands=
     ψ = DFTK.random_orbitals(basis, n_bands)
 
     solver = scf_anderson_solver(; errorfactor=Inf, maxcond=Inf, m=100)
-    scfres_simple = self_consistent_field(basis; ρ, ψ, tol=1e-10, mixing=SimpleMixing(), solver)
+    scfres_simple = self_consistent_field(basis; ρ, ψ, tol=1e-11, mixing=SimpleMixing(), solver)
 
     solver = scf_anderson_solver(; errorfactor=Inf, maxcond=1e6, m=100)
-    scfres_rdiis = self_consistent_field(basis; ρ, ψ, tol=1e-10, mixing=SimpleMixing(), solver)
+    scfres_rdiis = self_consistent_field(basis; ρ, ψ, tol=1e-11, mixing=SimpleMixing(), solver)
 
     solver = scf_anderson_solver(; errorfactor=1e5, maxcond=Inf, m=100)
-    scfres_addiis = self_consistent_field(basis; ρ, ψ, tol=1e-10, mixing=SimpleMixing(), solver)
+    scfres_addiis = self_consistent_field(basis; ρ, ψ, tol=1e-11, mixing=SimpleMixing(), solver)
 
     @test norm(scfres_addiis.ρ - scfres_rdiis.ρ) * sqrt(basis.dvol) < 5e-9
     @test norm(scfres_simple.ρ - scfres_rdiis.ρ) * sqrt(basis.dvol) < 5e-9

--- a/test/chi0.jl
+++ b/test/chi0.jl
@@ -32,9 +32,10 @@ function test_chi0(testcase; symmetries=false, temperature=0, spin_polarization=
         basis = PlaneWaveBasis(model; basis_kwargs...)
         ρ0    = guess_density(basis, magnetic_moments)
         ham0  = energy_hamiltonian(basis, nothing, nothing; ρ=ρ0).ham
-        # Fixed rather than adaptive bands, so that the bands of low occupation are
-        # converged as well: the finite differences below are sensitive to them.
-        nbandsalg = is_εF_fixed ? FixedBands(; n_bands_converge=6) : FixedBands(model)
+        # The finite differences below are sensitive to the bands of low occupation, so
+        # converge more of them than the default would.
+        nbandsalg = is_εF_fixed ? FixedBands(; n_bands_converge=6) :
+                                  FixedBands(model; temperature_factor_converge=2)
         res = DFTK.next_density(ham0, nbandsalg; tol, eigensolver)
         scfres = (; ham=ham0, res...)
 

--- a/test/chi0.jl
+++ b/test/chi0.jl
@@ -6,9 +6,9 @@ using LinearAlgebra
 
 function test_chi0(testcase; symmetries=false, temperature=0, spin_polarization=:none,
                    eigensolver=lobpcg_hyper, Ecut=10, kgrid=[3, 1, 1],
-                   fft_size=nothing, ε=3e-4,
-                   compute_full_χ0=false, εF=nothing, functionals=LDA(), tol=1e-11,
-                   atol=1e-7)
+                   fft_size=nothing, ε=2e-4,
+                   compute_full_χ0=false, εF=nothing, functionals=LDA(), tol=1e-12,
+                   atol=2e-7)
 
     collinear   = spin_polarization == :collinear
     is_εF_fixed = !isnothing(εF)
@@ -120,10 +120,11 @@ end
         end
     end
 
-    # Additional test for compute_χ0
+    # Additional test for compute_χ0. It builds a dense n_fft × n_fft matrix, so we take
+    # the smallest Ecut that still holds the requested number of bands at every k-point.
     for spin_polarization in (:none, :collinear)
         test_chi0(silicon; symmetries=false, spin_polarization, eigensolver=diag_full,
-                  Ecut=3, fft_size=[10, 1, 10], compute_full_χ0=true)
+                  Ecut=0.8, compute_full_χ0=true)
         test_chi0(magnesium; spin_polarization, temperature=0.01, εF=0.3)
     end
 end

--- a/test/chi0.jl
+++ b/test/chi0.jl
@@ -5,9 +5,10 @@ using DFTK: mpi_mean!
 using LinearAlgebra
 
 function test_chi0(testcase; symmetries=false, temperature=0, spin_polarization=:none,
-                   eigensolver=lobpcg_hyper, Ecut=10, kgrid=[3, 1, 1], fft_size=[15, 1, 15],
+                   eigensolver=lobpcg_hyper, Ecut=10, kgrid=[3, 1, 1],
+                   fft_size=nothing, ε=3e-4,
                    compute_full_χ0=false, εF=nothing, functionals=LDA(), tol=1e-11,
-                   ε=1e-6, atol=2e-6)
+                   atol=1e-7)
 
     collinear   = spin_polarization == :collinear
     is_εF_fixed = !isnothing(εF)
@@ -31,27 +32,30 @@ function test_chi0(testcase; symmetries=false, temperature=0, spin_polarization=
         basis = PlaneWaveBasis(model; basis_kwargs...)
         ρ0    = guess_density(basis, magnetic_moments)
         ham0  = energy_hamiltonian(basis, nothing, nothing; ρ=ρ0).ham
-        nbandsalg = is_εF_fixed ? FixedBands(; n_bands_converge=6) : AdaptiveBands(model)
+        default_bands = is_εF_fixed ? FixedBands(; n_bands_converge=6) : AdaptiveBands(model)
+        nbandsalg = FixedBands(; n_bands_converge=default_bands.n_bands_compute,
+                               n_bands_compute=default_bands.n_bands_compute + 3,
+                               default_bands.occupation_threshold)
         res = DFTK.next_density(ham0, nbandsalg; tol, eigensolver)
         scfres = (; ham=ham0, res...)
 
-        # create external small perturbation εδV
+        # create external small perturbation εδV. apply_χ0 (being grounded on a symmetric basis)
+        # only resolves perturbations respecting the symmetries, so we make δV symmetric.
         n_spin = model.n_spin_components
         δV = randn(eltype(basis), basis.fft_size..., n_spin)
         mpi_mean!(δV, basis.comm_kpts)
-        δV_sym = DFTK.symmetrize_ρ(basis, δV; model.symmetries)
-        if symmetries
-            δV = δV_sym
-        else
-            @test δV_sym ≈ δV
-        end
+        δV_sym = DFTK.symmetrize_ρ(basis, δV)
+        symmetries || @test δV_sym ≈ δV
+        δV = δV_sym
 
+        fd_basis_kwargs = merge(basis_kwargs, (; basis.fft_size))
         function compute_ρ_FD(ε)
-            term_builder = basis -> DFTK.TermExternal(ε * δV)
             model = model_DFT(testcase.lattice, testcase.atoms, testcase.positions;
-                              functionals, model_kwargs..., extra_terms=[term_builder])
-            basis = PlaneWaveBasis(model; basis_kwargs...)
-            ham = energy_hamiltonian(basis, nothing, nothing; ρ=ρ0).ham
+                              functionals, model_kwargs...,
+                              extra_terms=[DFTK.ExternalFromValues(ε * δV)])
+            basis_fd = PlaneWaveBasis(model; fd_basis_kwargs...)
+            @test length(basis_fd.symmetries) == 1  # δV breaks all symmetries
+            ham = energy_hamiltonian(basis_fd, nothing, nothing; ρ=ρ0).ham
             res = DFTK.next_density(ham, nbandsalg; tol, eigensolver)
             res.ρ
         end
@@ -138,5 +142,5 @@ end
     sodium_chloride = (; lattice, positions, atoms, is_metal=false)
     test_chi0(sodium_chloride;
               symmetries=true, temperature=1e-4, Ecut=20,
-              kgrid=[2, 2, 2], fft_size=[36, 36, 36], atol=5e-6)
+              kgrid=[2, 2, 2], fft_size=[36, 36, 36])
 end

--- a/test/chi0.jl
+++ b/test/chi0.jl
@@ -32,10 +32,9 @@ function test_chi0(testcase; symmetries=false, temperature=0, spin_polarization=
         basis = PlaneWaveBasis(model; basis_kwargs...)
         ρ0    = guess_density(basis, magnetic_moments)
         ham0  = energy_hamiltonian(basis, nothing, nothing; ρ=ρ0).ham
-        default_bands = is_εF_fixed ? FixedBands(; n_bands_converge=6) : AdaptiveBands(model)
-        nbandsalg = FixedBands(; n_bands_converge=default_bands.n_bands_compute,
-                               n_bands_compute=default_bands.n_bands_compute + 3,
-                               default_bands.occupation_threshold)
+        # Fixed rather than adaptive bands, so that the bands of low occupation are
+        # converged as well: the finite differences below are sensitive to them.
+        nbandsalg = is_εF_fixed ? FixedBands(; n_bands_converge=6) : FixedBands(model)
         res = DFTK.next_density(ham0, nbandsalg; tol, eigensolver)
         scfres = (; ham=ham0, res...)
 

--- a/test/forces.jl
+++ b/test/forces.jl
@@ -251,7 +251,7 @@ end
     pseudopotentials = Dict(:C => joinpath(@__DIR__, "pseudos", "C_m.upf"))
     test_forces(system; pseudopotentials, functionals=r2SCAN(),
                 temperature=0.01, Ecut=10, kgrid=[2, 2, 2], atol=1e-7,
-                # use an even FFT size to serve as a regression test
-                # for enforce_real! call in the XC force computation
-                fft_size=[16,16,16], symmetries_respect_rgrid=true)
+                # Even FFT size, so that the NLCC form factors have a Nyquist component:
+                # the XC force is only right if it is treated consistently there (#1370).
+                fft_size=[16, 16, 16], symmetries_respect_rgrid=true)
 end

--- a/test/hubbard.jl
+++ b/test/hubbard.jl
@@ -110,11 +110,13 @@ end
    
    @testset "Test Energy results" begin
         # The reference values are obtained with first released version
-        # of the Hubbard code in DFTK and are in good agreement with Quantum Espresso
-        ref = -354.907446880021
+        # of the Hubbard code in DFTK and are in good reasonable agreement with Quantum Espresso
+        # but at this supersampling the nlcc core density is badly aliased (~10mHa on the total energy),
+        # and the comparison should not be trusted too much
+        ref = -354.91625589331755
         e_total = scfres.energies.total
         @test e_total ≈ ref
-        ref_hub = 0.17629078433258719
+        ref_hub = 0.17631957087331435
         @test scfres.energies.Hubbard ≈ ref_hub
    end
    # The unfolding of the kpoints is not supported with MPI

--- a/test/kernel.jl
+++ b/test/kernel.jl
@@ -181,10 +181,9 @@ end
             δΔρ = reshape(δΔρ_real, size(Δρ)...)
             δτ  = mpi_bcast!(randn(size(τ)) / model.unit_cell_volume, basis.comm_kpts)
 
-            # The tolerance is limited not by the finite differences themselves, but by the
-            # handful of points where ∇ρ vanishes by symmetry. A true σ = |∇ρ|² never goes
-            # negative, but the linearised σ + εδσ used here does, and Libxc clamps it back
-            # to 0: the stencil then straddles a kink that the functional does not have.
+            # Loose tolerance because of a few points of small σ, where the meta-GGAs have
+            # very large ∂Vσ/∂σ: they dominate both the finite-difference error and the
+            # norm it is measured against.
             rtol = 1e-5
 
             @testset "LDA" begin

--- a/test/kernel.jl
+++ b/test/kernel.jl
@@ -181,9 +181,15 @@ end
             δΔρ = reshape(δΔρ_real, size(Δρ)...)
             δτ  = mpi_bcast!(randn(size(τ)) / model.unit_cell_volume, basis.comm_kpts)
 
-            # Loose tolerance: at a few grid points the functionals are not smooth (Libxc
-            # clamps σ to 0, r2scanl has a kink of its own), and there the finite-difference
-            # error does not shrink with ε_fd.
+            # Where ∇ρ vanishes by symmetry σ is ~1e-18, far below the reach of the stencil,
+            # which would then straddle the σ ≥ 0 clamp in Libxc at any ε_fd. Lift it clear;
+            # the αβ channel is ∇ρα⋅∇ρβ and may legitimately be negative, so leave it alone.
+            same_spin = size(σ, 1) == 1 ? [1] : [1, 3]
+            σ = copy(σ)
+            σ[same_spin, :] .= max.(σ[same_spin, :], 4ε_fd .* abs.(δσ[same_spin, :]))
+
+            # Loose tolerance: at a few points of small σ the meta-GGAs are stiff enough
+            # that the ε_fd⁴ truncation error still reaches ~2e-6.
             rtol = 1e-5
 
             @testset "LDA" begin

--- a/test/kernel.jl
+++ b/test/kernel.jl
@@ -181,9 +181,9 @@ end
             δΔρ = reshape(δΔρ_real, size(Δρ)...)
             δτ  = mpi_bcast!(randn(size(τ)) / model.unit_cell_volume, basis.comm_kpts)
 
-            # Loose tolerance because of a few points of small σ, where the meta-GGAs have
-            # very large ∂Vσ/∂σ: they dominate both the finite-difference error and the
-            # norm it is measured against.
+            # Loose tolerance: at a few grid points the functionals are not smooth (Libxc
+            # clamps σ to 0, r2scanl has a kink of its own), and there the finite-difference
+            # error does not shrink with ε_fd.
             rtol = 1e-5
 
             @testset "LDA" begin

--- a/test/kernel.jl
+++ b/test/kernel.jl
@@ -181,9 +181,10 @@ end
             δΔρ = reshape(δΔρ_real, size(Δρ)...)
             δτ  = mpi_bcast!(randn(size(τ)) / model.unit_cell_volume, basis.comm_kpts)
 
-            # The tolerance is not limited by the finite differences themselves, but by the
-            # handful of points where ∇ρ vanishes by symmetry: there σ(ε) is quadratic, so
-            # the stencil straddles the kink Libxc has at σ = 0.
+            # The tolerance is limited not by the finite differences themselves, but by the
+            # handful of points where ∇ρ vanishes by symmetry. A true σ = |∇ρ|² never goes
+            # negative, but the linearised σ + εδσ used here does, and Libxc clamps it back
+            # to 0: the stencil then straddles a kink that the functional does not have.
             rtol = 1e-5
 
             @testset "LDA" begin

--- a/test/kernel.jl
+++ b/test/kernel.jl
@@ -162,9 +162,10 @@ end
             Δρ = reshape(density.Δρ_real, size(density.Δρ_real, 1), :)
             τ  = reshape(density.τ_real,  size(density.τ_real, 1),  :)
 
+            ε_fd = 1e-4
             ε_ad = Dual{typeof(ForwardDiff.Tag(nothing, Float64))}(0.0, 1.0)
             do_ad(f) = map(y -> partials.(y, 1), f(ε_ad))
-            function do_fd(f; ε_fd=1e-4)
+            function do_fd(f)
                 map(f(-2ε_fd), f(-1ε_fd), f(+1ε_fd), f(+2ε_fd)) do y_m2ε, y_m1ε, y_p1ε, y_p2ε
                     (-y_p2ε + 8y_p1ε - 8y_m1ε + y_m2ε) / 12ε_fd
                 end
@@ -179,6 +180,15 @@ end
             δσ  = reshape(δσ_real, size(σ)...)
             δΔρ = reshape(δΔρ_real, size(Δρ)...)
             δτ  = mpi_bcast!(randn(size(τ)) / model.unit_cell_volume, basis.comm_kpts)
+
+            # Finite differences walk along the linearised σ + εδσ, while the true σ(ε) is
+            # quadratic where ∇ρ vanishes by symmetry: at those points the stencil leaves
+            # σ ≥ 0, gets clamped by Libxc and straddles a kink. Drop them. (Only the
+            # same-spin channels are constrained; the αβ one is ∇ρα⋅∇ρβ and may be negative.)
+            same_spin = size(σ, 1) == 1 ? [1] : [1, 3]
+            keep = vec(all(σ[same_spin, :] .> 2ε_fd .* abs.(δσ[same_spin, :]); dims=1))
+            ρ, σ, Δρ, τ = ρ[:, keep], σ[:, keep], Δρ[:, keep], τ[:, keep]
+            δρ, δσ, δΔρ, δτ = δρ[:, keep], δσ[:, keep], δΔρ[:, keep], δτ[:, keep]
 
             @testset "LDA" begin
                 func = DFTK.LibxcFunctional(:lda_xc_teter93)

--- a/test/kernel.jl
+++ b/test/kernel.jl
@@ -182,8 +182,7 @@ end
             δτ  = mpi_bcast!(randn(size(τ)) / model.unit_cell_volume, basis.comm_kpts)
 
             # Where ∇ρ vanishes by symmetry σ is ~1e-18, far below the reach of the stencil,
-            # which would then straddle the σ ≥ 0 clamp in Libxc at any ε_fd. Lift it clear;
-            # the αβ channel is ∇ρα⋅∇ρβ and may legitimately be negative, so leave it alone.
+            # which would then straddle the diag(σ) ≥ 0 clamp in Libxc at any ε_fd, so we raise it
             same_spin = size(σ, 1) == 1 ? [1] : [1, 3]
             σ = copy(σ)
             σ[same_spin, :] .= max.(σ[same_spin, :], 4ε_fd .* abs.(δσ[same_spin, :]))

--- a/test/kernel.jl
+++ b/test/kernel.jl
@@ -181,14 +181,10 @@ end
             δΔρ = reshape(δΔρ_real, size(Δρ)...)
             δτ  = mpi_bcast!(randn(size(τ)) / model.unit_cell_volume, basis.comm_kpts)
 
-            # Finite differences walk along the linearised σ + εδσ, while the true σ(ε) is
-            # quadratic where ∇ρ vanishes by symmetry: at those points the stencil leaves
-            # σ ≥ 0, gets clamped by Libxc and straddles a kink. Drop them. (Only the
-            # same-spin channels are constrained; the αβ one is ∇ρα⋅∇ρβ and may be negative.)
-            same_spin = size(σ, 1) == 1 ? [1] : [1, 3]
-            keep = vec(all(σ[same_spin, :] .> 2ε_fd .* abs.(δσ[same_spin, :]); dims=1))
-            ρ, σ, Δρ, τ = ρ[:, keep], σ[:, keep], Δρ[:, keep], τ[:, keep]
-            δρ, δσ, δΔρ, δτ = δρ[:, keep], δσ[:, keep], δΔρ[:, keep], δτ[:, keep]
+            # The tolerance is not limited by the finite differences themselves, but by the
+            # handful of points where ∇ρ vanishes by symmetry: there σ(ε) is quadratic, so
+            # the stencil straddles the kink Libxc has at σ = 0.
+            rtol = 1e-5
 
             @testset "LDA" begin
                 func = DFTK.LibxcFunctional(:lda_xc_teter93)
@@ -198,8 +194,8 @@ end
                 δe_ad, δVρ_ad = do_ad(f)
                 δe_fd, δVρ_fd = do_fd(f)
 
-                @test δe_ad  ≈ δe_fd  rtol=1e-6
-                @test δVρ_ad ≈ δVρ_fd rtol=1e-6
+                @test δe_ad  ≈ δe_fd  rtol=rtol
+                @test δVρ_ad ≈ δVρ_fd rtol=rtol
             end
 
             @testset "GGA" begin
@@ -210,9 +206,9 @@ end
                 δe_ad, δVρ_ad, δVσ_ad = do_ad(f)
                 δe_fd, δVρ_fd, δVσ_fd = do_fd(f)
 
-                @test δe_ad  ≈ δe_fd  rtol=1e-6
-                @test δVρ_ad ≈ δVρ_fd rtol=1e-6
-                @test δVσ_ad ≈ δVσ_fd rtol=1e-6
+                @test δe_ad  ≈ δe_fd  rtol=rtol
+                @test δVρ_ad ≈ δVρ_fd rtol=rtol
+                @test δVσ_ad ≈ δVσ_fd rtol=rtol
             end
 
             @testset "MGGA" begin
@@ -223,11 +219,10 @@ end
                 δe_ad, δVρ_ad, δVσ_ad, δVτ_ad = do_ad(f)
                 δe_fd, δVρ_fd, δVσ_fd, δVτ_fd = do_fd(f)
 
-                @test δe_ad  ≈ δe_fd  rtol=1e-6
-                # Seems more sensitive to noise, use a slightly looser tolerance:
-                @test δVρ_ad ≈ δVρ_fd rtol=2e-6
-                @test δVσ_ad ≈ δVσ_fd rtol=4e-6
-                @test δVτ_ad ≈ δVτ_fd rtol=1e-6
+                @test δe_ad  ≈ δe_fd  rtol=rtol
+                @test δVρ_ad ≈ δVρ_fd rtol=rtol
+                @test δVσ_ad ≈ δVσ_fd rtol=rtol
+                @test δVτ_ad ≈ δVτ_fd rtol=rtol
             end
 
             @testset "MGGAL without τ" begin
@@ -241,11 +236,10 @@ end
                 δe_ad, δVρ_ad, δVσ_ad, δVl_ad = do_ad(f)
                 δe_fd, δVρ_fd, δVσ_fd, δVl_fd = do_fd(f)
 
-                @test δe_ad  ≈ δe_fd  rtol=1e-6
-                # Seems more sensitive to noise, use a slightly looser tolerance:
-                @test δVρ_ad ≈ δVρ_fd rtol=2e-6
-                @test δVσ_ad ≈ δVσ_fd rtol=5e-6
-                @test δVl_ad ≈ δVl_fd rtol=3e-6
+                @test δe_ad  ≈ δe_fd  rtol=rtol
+                @test δVρ_ad ≈ δVρ_fd rtol=rtol
+                @test δVσ_ad ≈ δVσ_fd rtol=rtol
+                @test δVl_ad ≈ δVl_fd rtol=rtol
             end
 
             @testset "MGGAL with τ" begin
@@ -259,11 +253,11 @@ end
                 δe_ad, δVρ_ad, δVσ_ad, δVτ_ad, δVl_ad = do_ad(f)
                 δe_fd, δVρ_fd, δVσ_fd, δVτ_fd, δVl_fd = do_fd(f)
 
-                @test δe_ad  ≈ δe_fd  rtol=1e-6
-                @test δVρ_ad ≈ δVρ_fd rtol=1e-6
-                @test δVσ_ad ≈ δVσ_fd rtol=1e-6
-                @test δVτ_ad ≈ δVτ_fd rtol=1e-6
-                @test δVl_ad ≈ δVl_fd rtol=1e-6
+                @test δe_ad  ≈ δe_fd  rtol=rtol
+                @test δVρ_ad ≈ δVρ_fd rtol=rtol
+                @test δVσ_ad ≈ δVσ_fd rtol=rtol
+                @test δVτ_ad ≈ δVτ_fd rtol=rtol
+                @test δVl_ad ≈ δVl_fd rtol=rtol
             end
         end
     end

--- a/test/symmetry_issues.jl
+++ b/test/symmetry_issues.jl
@@ -36,7 +36,7 @@
         function G_vectors_calls(basis)
             for symop in basis.symmetries
                 invS = Mat3{Int}(inv(symop.S))
-                for (ig, G) in enumerate(DFTK.G_vectors_generator(basis.fft_size))
+                for (ig, G) in enumerate(DFTK.G_vectors(basis.fft_size))
                     igired = DFTK.index_G_vectors(basis, invS * G)
                 end
             end

--- a/test/transfer.jl
+++ b/test/transfer.jl
@@ -58,11 +58,8 @@ end
 
         # A random density on an even-sized grid has a Fourier component G, where its
         # counterpart -G is *not* part of the FFT grid, therefore ifft(fft(ρ)) would
-        # not be an identity. To prevent this we use drop_nyquist_components! to explicitly
-        # set the non-matched Fourier component to zero.
-        ρ = random_density(basis, 1)
-        ρ_fourier_purified = DFTK.drop_nyquist_components!(fft(basis, ρ), basis)
-        ρ = irfft(basis, ρ_fourier_purified)
+        # not be an identity. Round-tripping through irfft drops those components.
+        ρ = irfft(basis, fft(basis, random_density(basis, 1)))
 
         ρ_b  = transfer_density(ρ,   basis,     basis_big)
         ρ_bb = transfer_density(ρ_b, basis_big, basis    )

--- a/test/transfer.jl
+++ b/test/transfer.jl
@@ -53,13 +53,13 @@ end
 
     # Test grids that have both even and odd sizes.
     @testset "Small -> big -> small is identity" begin
-        basis      = PlaneWaveBasis(model; Ecut, kgrid, fft_size=(15, 30,  1))
+        basis      = PlaneWaveBasis(model; Ecut, kgrid, fft_size=(15, 31,  1))
         basis_big  = PlaneWaveBasis(model; Ecut, kgrid, fft_size=(20, 33, 11))
 
-        # A random density on an even-sized grid has a Fourier component G, where its
-        # counterpart -G is *not* part of the FFT grid, therefore ifft(fft(ρ)) would
-        # not be an identity. Round-tripping through irfft drops those components.
-        ρ = irfft(basis, fft(basis, random_density(basis, 1)))
+        # The small grid is odd on purpose: on an even grid a random density has a Fourier
+        # component G whose counterpart -G is not on the grid, and that one is not recovered
+        # by the round trip (which is what the next testset checks).
+        ρ = random_density(basis, 1)
 
         ρ_b  = transfer_density(ρ,   basis,     basis_big)
         ρ_bb = transfer_density(ρ_b, basis_big, basis    )

--- a/test/transfer.jl
+++ b/test/transfer.jl
@@ -58,10 +58,10 @@ end
 
         # A random density on an even-sized grid has a Fourier component G, where its
         # counterpart -G is *not* part of the FFT grid, therefore ifft(fft(ρ)) would
-        # not be an identity. To prevent this we use enforce_real! to explicitly set
-        # the non-matched Fourier component to zero.
+        # not be an identity. To prevent this we use drop_nyquist_frequency! to explicitly
+        # set the non-matched Fourier component to zero.
         ρ = random_density(basis, 1)
-        ρ_fourier_purified = DFTK.enforce_real!(fft(basis, ρ), basis)
+        ρ_fourier_purified = DFTK.drop_nyquist_frequency!(fft(basis, ρ), basis)
         ρ = irfft(basis, ρ_fourier_purified)
 
         ρ_b  = transfer_density(ρ,   basis,     basis_big)

--- a/test/transfer.jl
+++ b/test/transfer.jl
@@ -58,10 +58,10 @@ end
 
         # A random density on an even-sized grid has a Fourier component G, where its
         # counterpart -G is *not* part of the FFT grid, therefore ifft(fft(ρ)) would
-        # not be an identity. To prevent this we use drop_nyquist_frequency! to explicitly
+        # not be an identity. To prevent this we use drop_nyquist_components! to explicitly
         # set the non-matched Fourier component to zero.
         ρ = random_density(basis, 1)
-        ρ_fourier_purified = DFTK.drop_nyquist_frequency!(fft(basis, ρ), basis)
+        ρ_fourier_purified = DFTK.drop_nyquist_components!(fft(basis, ρ), basis)
         ρ = irfft(basis, ρ_fourier_purified)
 
         ρ_b  = transfer_density(ρ,   basis,     basis_big)


### PR DESCRIPTION
Fix https://github.com/JuliaMolSim/DFTK.jl/issues/1366. Along the way, fix flaky tests. The test now uses fft_size=nothing instead of the hardcoded one (all sorts of things go bad with supersampling < 2 anyway)