### PR TITLE
Fix NLCC force missing enforce_real!

### DIFF
--- a/src/terms/xc.jl
+++ b/src/terms/xc.jl
@@ -244,6 +244,9 @@ end
 # Function barrier to work around various type instabilities.
 function _forces_xc(basis::PlaneWaveBasis{T}, Vxc_fourier::AbstractArray{U}, 
                     form_factors, iG2ifnorm, groups) where {T, U}
+    # Adjoint of the enforce_real! call in the construction of the NLCC
+    enforce_real!(Vxc_fourier, basis)
+
     # Pre-allocation of large arrays for GPU Efficiency
     TT = promote_type(T, real(U))
     Gs = G_vectors(basis)

--- a/test/forces.jl
+++ b/test/forces.jl
@@ -250,5 +250,8 @@ end
 
     pseudopotentials = Dict(:C => joinpath(@__DIR__, "pseudos", "C_m.upf"))
     test_forces(system; pseudopotentials, functionals=r2SCAN(),
-                temperature=0.01, Ecut=10, kgrid=[2, 2, 2], atol=1e-7)
+                temperature=0.01, Ecut=10, kgrid=[2, 2, 2], atol=1e-7,
+                # use an even FFT size to serve as a regression test
+                # for enforce_real! call in the XC force computation
+                fft_size=[16,16,16], symmetries_respect_rgrid=true)
 end


### PR DESCRIPTION
~~This is one possible fix, but upon closer inspection the entire `enforce_real!` function is very suspicious. Let's discuss in #1369.~~ This is the correct fix, it's just that `enforce_real!` is misnamed (should be renamed: https://github.com/JuliaMolSim/DFTK.jl/issues/1371).