### PR TITLE
Fix profiling and type stability of DftHamiltonian multiplication

### DIFF
--- a/src/terms/Hamiltonian.jl
+++ b/src/terms/Hamiltonian.jl
@@ -19,18 +19,22 @@ struct GenericHamiltonianBlock <: HamiltonianBlock
 end
 
 """A more optimized HamiltonianBlock for the important case of a DFT Hamiltonian."""
-struct DftHamiltonianBlock <: HamiltonianBlock
-    basis::PlaneWaveBasis
-    kpoint::Kpoint
+struct DftHamiltonianBlock{Tbasis<:PlaneWaveBasis,
+                           Tkpoint<:Kpoint,
+                           Tlocal<:RealSpaceMultiplication,
+                           TdivAgrad<:Union{Nothing,DivAgradOperator},
+                           Tscratch} <: HamiltonianBlock
+    basis::Tbasis
+    kpoint::Tkpoint
     operators::Vector
 
     # Individual operators for easy access
     fourier_op::FourierMultiplication
-    local_op::RealSpaceMultiplication
+    local_op::Tlocal
     nonlocal_op::Union{Nothing,NonlocalOperator}
-    divAgrad_op::Union{Nothing,DivAgradOperator}
+    divAgrad_op::TdivAgrad
 
-    scratch  # Pre-allocated scratch arrays for fast application
+    scratch::Tscratch  # Pre-allocated scratch arrays for fast application
 end
 
 function HamiltonianBlock(basis, kpoint, operators; scratch=nothing)

--- a/src/terms/Hamiltonian.jl
+++ b/src/terms/Hamiltonian.jl
@@ -104,18 +104,17 @@ end
         T = eltype(H.basis)
         (; Hψ_fourier = similar(Hψ, size(Hψ, 1)),
            ψ_real  = similar(ψ, complex(T), H.basis.fft_size...),
-           Hψ_real = similar(Hψ, complex(T), H.basis.fft_size...))
+           Hψ_real = similar(Hψ, complex(T), H.basis.fft_size...),
+           to = TimerOutput())
     end
-    parallel_loop_over_range(1:size(ψ, 2); allocate_local_storage) do iband, storage
-        to = TimerOutput()  # Thread-local timer output
-
+    storages = parallel_loop_over_range(1:size(ψ, 2); allocate_local_storage) do iband, storage
         # Take ψi, IFFT it to ψ_real, apply each term to Hψ_fourier and Hψ_real, and add it
         # to Hψ.
         storage.Hψ_real .= 0
         storage.Hψ_fourier .= 0
         ifft!(storage.ψ_real, H.basis, H.kpoint, ψ[:, iband])
         for op in H.optimized_operators
-            @timeit to "$(nameof(typeof(op)))" begin
+            @timeit storage.to "$(nameof(typeof(op)))" begin
                 apply!((; fourier=storage.Hψ_fourier, real=storage.Hψ_real),
                        op,
                        (; fourier=ψ[:, iband], real=storage.ψ_real))
@@ -124,11 +123,8 @@ end
         Hψ[:, iband] .= storage.Hψ_fourier
         fft!(storage.Hψ_fourier, H.basis, H.kpoint, storage.Hψ_real)
         Hψ[:, iband] .+= storage.Hψ_fourier
-
-        if Threads.threadid() == 1
-            merge!(DFTK.timer, to; tree_point=[t.name for t in DFTK.timer.timer_stack])
-        end
     end
+    merge!(DFTK.timer, first(storages).to; tree_point=[t.name for t in DFTK.timer.timer_stack])
 
     Hψ
 end
@@ -152,9 +148,13 @@ end
     potential = H.local_op.potential .* H.basis.fft_grid.fft_normalization .*
                 H.basis.fft_grid.ifft_normalization
 
-    parallel_loop_over_range(1:n_bands, H.scratch) do iband, storage
-        to = TimerOutput()  # Thread-local timer output
-        ψ_real = storage.ψ_reals
+    # Give main timer to first thread and a dummy to the others
+    storages = map(enumerate(H.scratch)) do (i, scratch)
+        (scratch, i == 1 ? DFTK.timer : TimerOutput())
+    end
+
+    parallel_loop_over_range(1:n_bands, storages) do iband, (scratch, to)
+        ψ_real = scratch.ψ_reals
 
         @timeit to "local" begin
             ifft!(ψ_real, H.basis, H.kpoint, ψ[:, iband]; normalize=false)
@@ -169,10 +169,6 @@ end
                        (; fourier=ψ[:, iband], real=nothing);
                        ψ_real, G_plus_k) # overwrites ψ_real
             end
-        end
-
-        if Threads.threadid() == 1
-            merge!(DFTK.timer, to; tree_point=[t.name for t in DFTK.timer.timer_stack])
         end
     end
 


### PR DESCRIPTION
Two fixes:
1. Properly record the `local` timer output. In my runs it was simply missing, which I attribute to `threadid()` being generally unreliable. Additionally, we now only allocate one `TimerOutput` per thread rather than per band.
2. Fix type instability **inside the hot per-band loop** by adding type parameters to `DftHamiltonianBlock`.

With extra profiling sections, before the 2nd commit:
```
    DftHamiltonian multiplication      839    42.4s   62.3%  50.5ms   1.28GiB   20.5%  1.56MiB
      parallel for                     839    38.4s   56.4%  45.7ms    563MiB    8.8%   687KiB
        local                        9.39k    25.9s   38.0%  2.76ms    259MiB    4.1%  28.2KiB
      nonlocal                         839    3.15s    4.6%  3.76ms    124MiB    1.9%   151KiB
      normalized potential             839    679ms    1.0%   809μs    618MiB    9.7%   754KiB
      kinetic                          839    149ms    0.2%   177μs   3.64MiB    0.1%  4.45KiB
      allocate storages                839   14.6ms    0.0%  17.5μs    675KiB    0.0%     824B
```
Notice all the lost time between `parallel for` and `local` in the first. Additionally, `local` is allocating a lot even though it shouldn't (because of dynamic dispatch).

After the 2nd commit:
```
    DftHamiltonian multiplication      849    27.3s   53.6%  32.2ms    690MiB   12.8%   832KiB
      parallel for                     849    23.8s   46.7%  28.0ms   4.73MiB    0.1%  5.71KiB
        local                        9.43k    23.2s   45.6%  2.46ms   2.16MiB    0.0%     240B
      nonlocal                         849    3.17s    6.2%  3.73ms   62.3MiB    1.2%  75.2KiB
      normalized potential             849    228ms    0.4%   268μs    622MiB   11.6%   750KiB
      kinetic                          849    139ms    0.3%   164μs    328KiB    0.0%     396B
      allocate storages                849   1.85ms    0.0%  2.18μs    332KiB    0.0%     400B
```
Almost all the time of `parallel for` is in `local` and the allocations got drastically reduced. Overall a ~1.5x speedup in this case! On the GPU this could also make a large difference @abussy.