### PR TITLE
Update DFTKAMDGPUExt.jl

### DIFF
--- a/ext/DFTKAMDGPUExt.jl
+++ b/ext/DFTKAMDGPUExt.jl
@@ -11,17 +11,6 @@ function DFTK.memory_usage(::GPU{<:AMDGPU.ROCArray})
     merge(DFTK.memory_usage(CPU()), (; gpu=AMDGPU.memory_stats().live))
 end
 
-# Temporary workaround to not trigger https://github.com/JuliaGPU/AMDGPU.jl/issues/734
-function LinearAlgebra.cholesky(A::Hermitian{T, <:AMDGPU.ROCArray}) where {T}
-    Acopy, info = AMDGPU.rocSOLVER.potrf!(A.uplo, copy(A.data))
-    LinearAlgebra.Cholesky(Acopy, A.uplo, info)
-end
-
-# Temporary workaround for SVD. See https://github.com/JuliaGPU/AMDGPU.jl/issues/837
-function LinearAlgebra.LAPACK.gesdd!(jobz::Char, A::AMDGPU.ROCArray{T}) where {T}
-    AMDGPU.rocSOLVER.gesvd!(jobz, jobz, A)
-end
-
 # Temporary workaround for 5-argumet mul!, where performance is very bad when array
 # element types and scaling factors types differ.
 # See https://github.com/JuliaGPU/AMDGPU.jl/issues/866#issuecomment-3636981853
@@ -37,9 +26,9 @@ function LinearAlgebra.mul!(C::AMDGPU.ROCArray{T}, A::AMDGPU.ROCArray{T}, B::AMD
 end
 
 # Ensure precompilation is only performed if an AMD GPU is available
-# AMDGPU pre-compiliation is currently broken on Julia > 1.10,
+# AMDGPU pre-compiliation is currently broken on Julia 1.11,
 # see https://github.com/JuliaMolSim/DFTK.jl/issues/1278
-if AMDGPU.functional() && VERSION < v"1.11"
+if AMDGPU.functional() && !(v"1.11" <= VERSION < v"1.12")
     # Precompilation block with a basic workflow
     @setup_workload begin
         # very artificial silicon ground state example


### PR DESCRIPTION
Some AMDGPU workaround were fixed upstream, and pre-compilation now works with Julia v1.12 (but not 1.11).